### PR TITLE
BridgeStudyCreator to add Bridge Admin and Staff teams to Synapse projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeServerLogic</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>

--- a/src/main/resources/bridge-server.conf
+++ b/src/main/resources/bridge-server.conf
@@ -71,6 +71,12 @@ prod.webservices.url = https://ws.sagebridge.org
 
 route53.zone = ZP0HNVK1V670D
 
+# Synapse Team IDs, used by the BridgeStudyCreator when creating Synapse projects.
+team.bridge.admin = 3388390
+team.bridge.staff = 3388389
+prod.team.bridge.admin = 3388392
+prod.team.bridge.staff = 3388391
+
 # AWS credentials for doing pre-signed upload
 aws.key.upload = dummy-value
 aws.secret.key.upload = dummy-value


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2396

Testing done:
* mvn verify (unit tests, jacoco test coverage)
* modified integ test StudyTest.createSynapseProjectTeam() to verify the Synapse project is created with the right permissions. (Note that this integ test is currently disabled because it interferes with the Exporter.)