### PR TITLE
add MD5 to uploads; build directly from develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: java
 jdk: oraclejdk8
 sudo: false
-script: mvn clean verify
-deploy:
-  provider: script
-  script: mvn deploy
-  on:
-    branch: release
+script: mvn clean deploy

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeServerLogic</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
             <version>8.8.4</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/src/main/java/org/sagebionetworks/bridge/upload/UploadRawZipHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/upload/UploadRawZipHandler.java
@@ -1,38 +1,36 @@
 package org.sagebionetworks.bridge.upload;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
-import org.sagebionetworks.bridge.s3.S3Helper;
 
 /** Uploads decrypted zip file to attachments and sets the record's raw data attachment ID appropriately. */
 @Component
 public class UploadRawZipHandler implements UploadValidationHandler {
     // Package-scoped for unit tests.
-    static final String ATTACHMENT_BUCKET = BridgeConfigFactory.getConfig().getProperty("attachment.bucket");
     static final String RAW_ATTACHMENT_SUFFIX = "-raw.zip";
 
-    private S3Helper s3Helper;
+    private UploadFileHelper uploadFileHelper;
 
-    /** S3 Helper, used to submit raw zip file as an attachment. */
+    /** Upload File Helper, used to submit raw zip file as an attachment. */
     @Autowired
-    public void setS3Helper(S3Helper s3Helper) {
-        this.s3Helper = s3Helper;
+    public final void setUploadFileHelper(UploadFileHelper uploadFileHelper) {
+        this.uploadFileHelper = uploadFileHelper;
     }
 
     /** {@inheritDoc} */
     @Override
-    public void handle(UploadValidationContext context) {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
-
+    public void handle(UploadValidationContext context) throws UploadValidationException {
         // Upload raw data as an attachment. Attachment ID is "[uploadId]-raw.zip".
         String rawDataAttachmentId = context.getUploadId() + RAW_ATTACHMENT_SUFFIX;
-        s3Helper.writeFileToS3(ATTACHMENT_BUCKET, rawDataAttachmentId, context.getDecryptedDataFile(), metadata);
+        try {
+            uploadFileHelper.uploadFileAsAttachment(rawDataAttachmentId, context.getDecryptedDataFile());
+        } catch (IOException ex) {
+            throw new UploadValidationException("Error upload raw data zip for upload " + context.getUploadId());
+        }
 
         HealthDataRecord record = context.getHealthDataRecord();
         record.setRawDataAttachmentId(rawDataAttachmentId);

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -27,6 +27,9 @@ public class TestConstants {
     
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
 
+    public static final byte[] MOCK_MD5 = { 29, -23, 101, -93, -27, -88, -82, 87, 126 };
+    public static final String MOCK_MD5_BASE64_ENCODED = "Hello+World+";
+
     public static final String TEST_STUDY_IDENTIFIER = "api";
     public static final StudyIdentifier TEST_STUDY = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);
     public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
@@ -2,11 +2,13 @@ package org.sagebionetworks.bridge.upload;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.io.File;
@@ -17,10 +19,12 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
@@ -38,13 +42,17 @@ public class UploadFileHelperFindValueTest {
     private ArgumentCaptor<ObjectMetadata> metadataCaptor;
 
     @Before
-    public void before() {
+    public void before() throws Exception {
         // Spy file helper, so we can check to see how many times we read the disk later. Also make a dummy temp dir,
         // as an in-memory place we can put files into.
         inMemoryFileHelper = spy(new InMemoryFileHelper());
         tmpDir = inMemoryFileHelper.createTempDir();
 
         // Mock dependencies.
+        DigestUtils mockMd5DigestUtils = mock(DigestUtils.class);
+        when(mockMd5DigestUtils.digest(any(File.class))).thenReturn(TestConstants.MOCK_MD5);
+        when(mockMd5DigestUtils.digest(any(byte[].class))).thenReturn(TestConstants.MOCK_MD5);
+
         mockS3Helper = mock(S3Helper.class);
 
         metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
@@ -52,6 +60,7 @@ public class UploadFileHelperFindValueTest {
         // Create UploadFileHelper.
         uploadFileHelper = new UploadFileHelper();
         uploadFileHelper.setFileHelper(inMemoryFileHelper);
+        uploadFileHelper.setMd5DigestUtils(mockMd5DigestUtils);
         uploadFileHelper.setS3Helper(mockS3Helper);
     }
 
@@ -73,8 +82,11 @@ public class UploadFileHelperFindValueTest {
         // Verify uploaded file
         verify(mockS3Helper).writeFileToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(expectedAttachmentFilename),
                 eq(recordJsonFile), metadataCaptor.capture());
-        
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+
+        ObjectMetadata metadata = metadataCaptor.getValue();
+        assertEquals(TestConstants.MOCK_MD5_BASE64_ENCODED, metadata.getUserMetaDataOf(
+                UploadFileHelper.KEY_CUSTOM_CONTENT_MD5));
+        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadata.getSSEAlgorithm());
     }
 
     @Test
@@ -175,8 +187,11 @@ public class UploadFileHelperFindValueTest {
         // Verify uploaded file
         verify(mockS3Helper).writeBytesToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(expectedAttachmentFilename),
                 eq("\"record-value\"".getBytes(Charsets.UTF_8)), metadataCaptor.capture());
-        
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+
+        ObjectMetadata metadata = metadataCaptor.getValue();
+        assertEquals(TestConstants.MOCK_MD5_BASE64_ENCODED, metadata.getUserMetaDataOf(
+                UploadFileHelper.KEY_CUSTOM_CONTENT_MD5));
+        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadata.getSSEAlgorithm());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadRawZipHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadRawZipHandlerTest.java
@@ -1,54 +1,66 @@
 package org.sagebionetworks.bridge.upload;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
+import java.io.IOException;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
-
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.upload.Upload;
-import org.sagebionetworks.bridge.s3.S3Helper;
 
 public class UploadRawZipHandlerTest {
     private static final String UPLOAD_ID = "my-upload";
+    private static final String EXPECTED_RAW_DATA_ATTACHMENT_ID = UPLOAD_ID +
+            UploadRawZipHandler.RAW_ATTACHMENT_SUFFIX;
 
-    @Test
-    public void test() {
+    private UploadValidationContext context;
+    private UploadRawZipHandler handler;
+    private File mockDecryptedFile;
+    private UploadFileHelper mockUploadFileHelper;
+    private HealthDataRecord record;
+
+    @Before
+    public void before() {
         // Set up mocks and handler.
-        S3Helper mockS3Helper = mock(S3Helper.class);
-        UploadRawZipHandler handler = new UploadRawZipHandler();
-        handler.setS3Helper(mockS3Helper);
-        
-        ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);;
+        mockUploadFileHelper = mock(UploadFileHelper.class);
+        handler = new UploadRawZipHandler();
+        handler.setUploadFileHelper(mockUploadFileHelper);
 
         // Set up context. We only read the upload ID, decrypted data file (mock), and the record.
-        UploadValidationContext context = new UploadValidationContext();
+        context = new UploadValidationContext();
 
         Upload upload = Upload.create();
         upload.setUploadId(UPLOAD_ID);
         context.setUpload(upload);
 
-        File mockDecryptedFile = mock(File.class);
+        mockDecryptedFile = mock(File.class);
         context.setDecryptedDataFile(mockDecryptedFile);
 
-        HealthDataRecord record = HealthDataRecord.create();
+        record = HealthDataRecord.create();
         context.setHealthDataRecord(record);
+    }
 
+    @Test
+    public void test() throws Exception {
         // Execute and validate.
         handler.handle(context);
+        verify(mockUploadFileHelper).uploadFileAsAttachment(EXPECTED_RAW_DATA_ATTACHMENT_ID, mockDecryptedFile);
+        assertEquals(EXPECTED_RAW_DATA_ATTACHMENT_ID, record.getRawDataAttachmentId());
+    }
 
-        String expectedRawDataAttachmentId = UPLOAD_ID + UploadRawZipHandler.RAW_ATTACHMENT_SUFFIX;
-        verify(mockS3Helper).writeFileToS3(eq(UploadRawZipHandler.ATTACHMENT_BUCKET), eq(expectedRawDataAttachmentId),
-                eq(mockDecryptedFile), metadataCaptor.capture());
+    @Test(expected = UploadValidationException.class)
+    public void errorCase() throws Exception {
+        // Mock uploadFileHelper to throw.
+        doThrow(IOException.class).when(mockUploadFileHelper).uploadFileAsAttachment(EXPECTED_RAW_DATA_ATTACHMENT_ID,
+                mockDecryptedFile);
 
-        assertEquals(expectedRawDataAttachmentId, record.getRawDataAttachmentId());
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        // Execute (throws exception).
+        handler.handle(context);
     }
 }


### PR DESCRIPTION
This change is needed to use External S3 Buckets in Synapse. See also https://sagebionetworks.jira.com/browse/BRIDGE-2414