### PR TITLE
Align test libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,9 +181,9 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/AppVersionHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/AppVersionHelper.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -38,7 +38,7 @@ public class AppVersionHelper {
         // validate result
         Method getOsKeysMethod = objClass.getMethod("getAppVersionOperatingSystems");
         Set<String> osKeySet = (Set<String>) getOsKeysMethod.invoke(obj);
-        assertEquals(7, osKeySet.size());
+        assertEquals(osKeySet.size(), 7);
         assertTrue(osKeySet.contains("foo"));
         assertTrue(osKeySet.contains("bar"));
         assertTrue(osKeySet.contains("baz"));
@@ -69,33 +69,33 @@ public class AppVersionHelper {
 
         // Get the map back. Verify that the null value is not there.
         Map<String, Integer> gettedMap1 = (Map<String, Integer>) getMapMethod.invoke(obj);
-        assertEquals(2, gettedMap1.size());
-        assertEquals(2, gettedMap1.get("fooOs").intValue());
-        assertEquals(3, gettedMap1.get("barOs").intValue());
+        assertEquals(gettedMap1.size(), 2);
+        assertEquals(gettedMap1.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap1.get("barOs").intValue(), 3);
 
         // Write to the originalMap. Get the map again and verify it's unchanged.
         originalMap.put("qwertyOs", 4);
         Map<String, Integer> gettedMap2 = (Map<String, Integer>) getMapMethod.invoke(obj);
-        assertEquals(2, gettedMap2.size());
-        assertEquals(2, gettedMap2.get("fooOs").intValue());
-        assertEquals(3, gettedMap2.get("barOs").intValue());
+        assertEquals(gettedMap2.size(), 2);
+        assertEquals(gettedMap2.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap2.get("barOs").intValue(), 3);
 
         // Put a value that modifies the object's map. Verify that it appears in the new getted map, but not in the old
         // ones.
         setByOsNameMethod.invoke(obj, "asdfOs", 5);
         Map<String, Integer> gettedMap3 = (Map<String, Integer>) getMapMethod.invoke(obj);
-        assertEquals(3, gettedMap3.size());
-        assertEquals(2, gettedMap3.get("fooOs").intValue());
-        assertEquals(3, gettedMap3.get("barOs").intValue());
-        assertEquals(5, gettedMap3.get("asdfOs").intValue());
+        assertEquals(gettedMap3.size(), 3);
+        assertEquals(gettedMap3.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap3.get("barOs").intValue(), 3);
+        assertEquals(gettedMap3.get("asdfOs").intValue(), 5);
 
-        assertEquals(2, gettedMap2.size());
-        assertEquals(2, gettedMap2.get("fooOs").intValue());
-        assertEquals(3, gettedMap2.get("barOs").intValue());
+        assertEquals(gettedMap2.size(), 2);
+        assertEquals(gettedMap2.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap2.get("barOs").intValue(), 3);
 
-        assertEquals(2, gettedMap1.size());
-        assertEquals(2, gettedMap1.get("fooOs").intValue());
-        assertEquals(3, gettedMap1.get("barOs").intValue());
+        assertEquals(gettedMap1.size(), 2);
+        assertEquals(gettedMap1.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap1.get("barOs").intValue(), 3);
 
         // Test getted maps are immutable.
         try {
@@ -120,17 +120,17 @@ public class AppVersionHelper {
         }
 
         // Test getting by OS name
-        assertEquals(2, getByOsNameMethod.invoke(obj, "fooOs"));
-        assertEquals(3, getByOsNameMethod.invoke(obj, "barOs"));
-        assertEquals(5, getByOsNameMethod.invoke(obj, "asdfOs"));
+        assertEquals(getByOsNameMethod.invoke(obj, "fooOs"), 2);
+        assertEquals(getByOsNameMethod.invoke(obj, "barOs"), 3);
+        assertEquals(getByOsNameMethod.invoke(obj, "asdfOs"), 5);
 
         // We can remove by OS name
         setByOsNameMethod.invoke(obj, "asdfOs", null);
         assertNull(getByOsNameMethod.invoke(obj, "asdfOs"));
         Map<String, Integer> gettedMap4 = (Map<String, Integer>) getMapMethod.invoke(obj);
-        assertEquals(2, gettedMap4.size());
-        assertEquals(2, gettedMap4.get("fooOs").intValue());
-        assertEquals(3, gettedMap4.get("barOs").intValue());
+        assertEquals(gettedMap4.size(), 2);
+        assertEquals(gettedMap4.get("fooOs").intValue(), 2);
+        assertEquals(gettedMap4.get("barOs").intValue(), 3);
 
         // Setting the map to null converts it to an empty map. (For the setMapMethod, we need to wrap it in an array
         // because varargs with null is weird.)

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -22,8 +22,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
-import org.junit.After;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.hibernate.HibernateAccount;
@@ -46,7 +47,7 @@ public class BridgeUtilsTest {
     
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.parse("2010-10-10T10:10:10.111");
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
     }
@@ -63,11 +64,11 @@ public class BridgeUtilsTest {
         account.setAccountSubstudies(ImmutableSet.of(substudy1, substudy2, substudy3, substudy4));
         
         Map<String, String> results = BridgeUtils.mapSubstudyMemberships(account);
-        assertEquals(4, results.size());
-        assertEquals("<none>", results.get("subA"));
-        assertEquals("extB", results.get("subB"));
-        assertEquals("extC", results.get("subC"));
-        assertEquals("<none>", results.get("subD"));
+        assertEquals(results.size(), 4);
+        assertEquals(results.get("subA"), "<none>");
+        assertEquals(results.get("subB"), "extB");
+        assertEquals(results.get("subC"), "extC");
+        assertEquals(results.get("subD"), "<none>");
     }
     
     @Test
@@ -78,8 +79,8 @@ public class BridgeUtilsTest {
         account.setAccountSubstudies(ImmutableSet.of(substudy2));
         
         Map<String, String> results = BridgeUtils.mapSubstudyMemberships(account);
-        assertEquals(1, results.size());
-        assertEquals("extB", results.get("subB"));
+        assertEquals(results.size(), 1);
+        assertEquals(results.get("subB"), "extB");
     }
     
     @Test
@@ -113,7 +114,7 @@ public class BridgeUtilsTest {
         Set<String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(accountSubstudies)
                 .getSubstudyIdsVisibleToCaller();
         
-        assertEquals(ImmutableSet.of("substudyA", "substudyB"), visibles);
+        assertEquals(visibles, ImmutableSet.of("substudyA", "substudyB"));
     }
     
     @Test
@@ -126,7 +127,7 @@ public class BridgeUtilsTest {
         Set<String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(accountSubstudies)
                 .getSubstudyIdsVisibleToCaller();
         
-        assertEquals(ImmutableSet.of("substudyA", "substudyB", "substudyC"), visibles);
+        assertEquals(visibles, ImmutableSet.of("substudyA", "substudyB", "substudyC"));
     }
     
     @Test
@@ -137,7 +138,7 @@ public class BridgeUtilsTest {
         Set<String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(ImmutableSet.of())
                 .getSubstudyIdsVisibleToCaller();
         
-        assertEquals(ImmutableSet.of(), visibles);
+        assertEquals(visibles, ImmutableSet.of());
     }    
     
     @Test
@@ -148,7 +149,7 @@ public class BridgeUtilsTest {
         Set<String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(null)
                 .getSubstudyIdsVisibleToCaller();
         
-        assertEquals(ImmutableSet.of(), visibles);
+        assertEquals(visibles, ImmutableSet.of());
     }
     
     @Test
@@ -167,7 +168,7 @@ public class BridgeUtilsTest {
         Map<String, String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(accountSubstudies)
                 .getExternalIdsVisibleToCaller();
         
-        assertEquals(ImmutableMap.of("substudyA", "extA", "substudyB", "extB"), visibles);
+        assertEquals(visibles, ImmutableMap.of("substudyA", "extA", "substudyB", "extB"));
     }
     
     @Test
@@ -183,7 +184,7 @@ public class BridgeUtilsTest {
         Map<String, String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(accountSubstudies)
                 .getExternalIdsVisibleToCaller();
         
-        assertEquals(ImmutableMap.of("substudyA", "extA", "substudyB", "extB", "substudyC", "extC"), visibles);
+        assertEquals(visibles, ImmutableMap.of("substudyA", "extA", "substudyB", "extB", "substudyC", "extC"));
     }    
 
     @Test
@@ -194,7 +195,7 @@ public class BridgeUtilsTest {
         Map<String, String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(ImmutableSet.of())
                 .getExternalIdsVisibleToCaller();
         
-        assertEquals(ImmutableMap.of(), visibles);
+        assertEquals(visibles, ImmutableMap.of());
     }      
     
     @Test
@@ -205,7 +206,7 @@ public class BridgeUtilsTest {
         Map<String, String> visibles = BridgeUtils.substudyAssociationsVisibleToCaller(null)
                 .getExternalIdsVisibleToCaller();
         
-        assertEquals(ImmutableMap.of(), visibles);
+        assertEquals(visibles, ImmutableMap.of());
     }
     
     @Test
@@ -220,13 +221,13 @@ public class BridgeUtilsTest {
         account.setExternalId("subDextId");
         
         Set<String> externalIds = BridgeUtils.collectExternalIds(account);
-        assertEquals(ImmutableSet.of("subAextId","subBextId","subDextId"), externalIds);
+        assertEquals(externalIds, ImmutableSet.of("subAextId","subBextId","subDextId"));
     }
     
     @Test
     public void collectExternalIdsNullsAreIgnored() {
         Set<String> externalIds = BridgeUtils.collectExternalIds(Account.create());
-        assertEquals(ImmutableSet.of(), externalIds);
+        assertEquals(externalIds, ImmutableSet.of());
     }    
     
     @Test
@@ -236,8 +237,8 @@ public class BridgeUtilsTest {
                 .withCallerSubstudies(substudies).build());
         
         Account account = BridgeUtils.filterForSubstudy(getAccountWithSubstudy("substudyB", "substudyA"));
-        assertEquals(1, account.getAccountSubstudies().size());
-        assertEquals("substudyA", Iterables.getFirst(account.getAccountSubstudies(), null).getSubstudyId());
+        assertEquals(account.getAccountSubstudies().size(), 1);
+        assertEquals(Iterables.getFirst(account.getAccountSubstudies(), null).getSubstudyId(), "substudyA");
         
         BridgeUtils.setRequestContext(null);
     }
@@ -245,7 +246,7 @@ public class BridgeUtilsTest {
     @Test
     public void filterForSubstudyAccountReturnsAllUnsharedSubstudyIdsForNonSubstudyCaller() {
         Account account = BridgeUtils.filterForSubstudy(getAccountWithSubstudy("substudyB", "substudyA"));
-        assertEquals(2, account.getAccountSubstudies().size());
+        assertEquals(account.getAccountSubstudies().size(), 2);
     }
     
     @Test
@@ -346,69 +347,69 @@ public class BridgeUtilsTest {
         RequestContext otherContext = new RequestContext.Builder().withRequestId("other request ID").build();
         
         BridgeUtils.setRequestContext(context);
-        assertEquals("main request ID", BridgeUtils.getRequestContext().getId());
+        assertEquals(BridgeUtils.getRequestContext().getId(), "main request ID");
 
         // Request ID is thread local, so a separate thread should see a different request ID.
         Runnable runnable = () -> {
-            assertEquals(RequestContext.NULL_INSTANCE, BridgeUtils.getRequestContext());
+            assertEquals(BridgeUtils.getRequestContext(), RequestContext.NULL_INSTANCE);
             BridgeUtils.setRequestContext(otherContext);
-            assertEquals("other request ID", BridgeUtils.getRequestContext().getId());
+            assertEquals(BridgeUtils.getRequestContext().getId(), "other request ID");
         };
         Thread otherThread = new Thread(runnable);
         otherThread.start();
         otherThread.join();
 
         // Other thread doesn't affect this thread.
-        assertEquals("main request ID", BridgeUtils.getRequestContext().getId());
+        assertEquals(BridgeUtils.getRequestContext().getId(), "main request ID");
 
         // Setting request ID to null is fine.
         BridgeUtils.setRequestContext(null);
-        assertEquals(RequestContext.NULL_INSTANCE, BridgeUtils.getRequestContext());
+        assertEquals(BridgeUtils.getRequestContext(), RequestContext.NULL_INSTANCE);
     }
 
     @Test
     public void secondsToPeriodString() {
-        assertEquals("30 seconds", BridgeUtils.secondsToPeriodString(30));
-        assertEquals("1 minute", BridgeUtils.secondsToPeriodString(60));
-        assertEquals("90 seconds", BridgeUtils.secondsToPeriodString(90));
-        assertEquals("5 minutes", BridgeUtils.secondsToPeriodString(60*5));
-        assertEquals("25 minutes", BridgeUtils.secondsToPeriodString(60*25));
-        assertEquals("90 minutes", BridgeUtils.secondsToPeriodString(60*90));
-        assertEquals("1 hour", BridgeUtils.secondsToPeriodString(60*60));
-        assertEquals("2 hours", BridgeUtils.secondsToPeriodString(60*60*2));
-        assertEquals("36 hours", BridgeUtils.secondsToPeriodString(60*60*36));
-        assertEquals("1 day", BridgeUtils.secondsToPeriodString(60*60*24));
-        assertEquals("2 days", BridgeUtils.secondsToPeriodString(60*60*24*2));
-        assertEquals("7 days", BridgeUtils.secondsToPeriodString(60*60*24*7));
+        assertEquals(BridgeUtils.secondsToPeriodString(30), "30 seconds");
+        assertEquals(BridgeUtils.secondsToPeriodString(60), "1 minute");
+        assertEquals(BridgeUtils.secondsToPeriodString(90), "90 seconds");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*5), "5 minutes");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*25), "25 minutes");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*90), "90 minutes");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60), "1 hour");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60*2), "2 hours");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60*36), "36 hours");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60*24), "1 day");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60*24*2), "2 days");
+        assertEquals(BridgeUtils.secondsToPeriodString(60*60*24*7), "7 days");
     }
     
     @Test
     public void parseAccountId() {
         // Identifier has upper-case letter to ensure we don't downcase or otherwise change it.
         AccountId accountId = BridgeUtils.parseAccountId("test", "IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("IdentifierA9", accountId.getId());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getId(), "IdentifierA9");
         
         accountId = BridgeUtils.parseAccountId("test", "externalid:IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("IdentifierA9", accountId.getExternalId());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getExternalId(), "IdentifierA9");
         
         accountId = BridgeUtils.parseAccountId("test", "externalId:IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("IdentifierA9", accountId.getExternalId());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getExternalId(), "IdentifierA9");
         
         accountId = BridgeUtils.parseAccountId("test", "healthcode:IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("IdentifierA9", accountId.getHealthCode());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getHealthCode(), "IdentifierA9");
         
         accountId = BridgeUtils.parseAccountId("test", "healthCode:IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("IdentifierA9", accountId.getHealthCode());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getHealthCode(), "IdentifierA9");
         
         // Unrecognized prefix is just part of the userId
         accountId = BridgeUtils.parseAccountId("test", "unk:IdentifierA9");
-        assertEquals("test", accountId.getStudyId());
-        assertEquals("unk:IdentifierA9", accountId.getId());
+        assertEquals(accountId.getStudyId(), "test");
+        assertEquals(accountId.getId(), "unk:IdentifierA9");
     }
     
     @Test
@@ -429,15 +430,15 @@ public class BridgeUtilsTest {
         });
         map.put("thisMap", "isMutable");
         
-        assertEquals("name2", map.get("studyName"));
-        assertEquals("shortName", map.get("studyShortName"));
-        assertEquals("identifier2", map.get("studyId"));
-        assertEquals("sponsorName2", map.get("sponsorName"));
-        assertEquals("supportEmail2", map.get("supportEmail"));
-        assertEquals("technicalEmail2", map.get("technicalEmail"));
-        assertEquals("consentNotificationEmail2", map.get("consentEmail"));
-        assertEquals("isMutable", map.get("thisMap"));
-        assertEquals(host, map.get("host"));
+        assertEquals(map.get("studyName"), "name2");
+        assertEquals(map.get("studyShortName"), "shortName");
+        assertEquals(map.get("studyId"), "identifier2");
+        assertEquals(map.get("sponsorName"), "sponsorName2");
+        assertEquals(map.get("supportEmail"), "supportEmail2");
+        assertEquals(map.get("technicalEmail"), "technicalEmail2");
+        assertEquals(map.get("consentEmail"), "consentNotificationEmail2");
+        assertEquals(map.get("thisMap"), "isMutable");
+        assertEquals(map.get("host"), host);
     }
     
     @Test
@@ -459,7 +460,7 @@ public class BridgeUtilsTest {
         // In particular, verifying that replacement of multiple identical tokens occurs,
         // unmatched variables are left alone
         String result = BridgeUtils.resolveTemplate("foo ${baz} bar ${baz} ${box} ${unused}", map);
-        assertEquals("foo Belgium bar Belgium Albuquerque ${unused}", result);
+        assertEquals(result, "foo Belgium bar Belgium Albuquerque ${unused}");
     }
     
     @Test
@@ -470,10 +471,10 @@ public class BridgeUtilsTest {
         // In particular, verifying that replacement of multiple identical tokens occurs,
         // unmatched variables are left alone
         String result = BridgeUtils.resolveTemplate("foo ${baz}", map);
-        assertEquals("foo ${baz}", result);
+        assertEquals(result, "foo ${baz}");
         
         result = BridgeUtils.resolveTemplate(" ", map);
-        assertEquals(" ", result);
+        assertEquals(result, " ");
     }
     
     @Test
@@ -482,7 +483,7 @@ public class BridgeUtilsTest {
         map.put("b.z", "bar");
         
         String result = BridgeUtils.resolveTemplate("${baz}", map);
-        assertEquals("${baz}", result);
+        assertEquals(result, "${baz}");
     }
     
     @Test
@@ -514,15 +515,15 @@ public class BridgeUtilsTest {
     public void setToCommaList() {
         Set<String> set = Sets.newHashSet("a", null, "", "b");
         
-        assertEquals("a,b", BridgeUtils.setToCommaList(set));
+        assertEquals(BridgeUtils.setToCommaList(set), "a,b");
         assertNull(BridgeUtils.setToCommaList(null));
         assertNull(BridgeUtils.setToCommaList(Sets.newHashSet()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void nullsafeImmutableSet() {
-        assertEquals(0, BridgeUtils.nullSafeImmutableSet(null).size());
-        assertEquals(Sets.newHashSet("A"), BridgeUtils.nullSafeImmutableSet(Sets.newHashSet("A")));
+        assertEquals(BridgeUtils.nullSafeImmutableSet(null).size(), 0);
+        assertEquals(BridgeUtils.nullSafeImmutableSet(Sets.newHashSet("A")), Sets.newHashSet("A"));
         
         // This should throw an UnsupportedOperationException
         Set<String> set = BridgeUtils.nullSafeImmutableSet(Sets.newHashSet("A"));
@@ -532,14 +533,14 @@ public class BridgeUtilsTest {
     @Test
     public void nullsAreRemovedFromSet() {
         // nulls are removed. They have to be to create ImmutableSet
-        assertEquals(Sets.newHashSet("A"), BridgeUtils.nullSafeImmutableSet(Sets.newHashSet(null, "A")));
+        assertEquals(BridgeUtils.nullSafeImmutableSet(Sets.newHashSet(null, "A")), Sets.newHashSet("A"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void nullsafeImmutableList() {
-        assertEquals(0, BridgeUtils.nullSafeImmutableList(null).size());
+        assertEquals(BridgeUtils.nullSafeImmutableList(null).size(), 0);
         
-        assertEquals(Lists.newArrayList("A","B"), BridgeUtils.nullSafeImmutableList(Lists.newArrayList("A","B")));
+        assertEquals(BridgeUtils.nullSafeImmutableList(Lists.newArrayList("A","B")), Lists.newArrayList("A","B"));
         
         List<String> list = BridgeUtils.nullSafeImmutableList(Lists.newArrayList("A","B"));
         list.add("C");
@@ -548,20 +549,20 @@ public class BridgeUtilsTest {
     @Test
     public void nullsAreRemovedFromList() {
         List<String> list = BridgeUtils.nullSafeImmutableList(Lists.newArrayList(null,"A",null,"B"));
-        assertEquals(Lists.newArrayList("A","B"), list);
+        assertEquals(list, Lists.newArrayList("A","B"));
     }    
     
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void nullsafeImmutableMap() {
-        assertEquals(0, BridgeUtils.nullSafeImmutableMap(null).size());
+        assertEquals(BridgeUtils.nullSafeImmutableMap(null).size(), 0);
         
         Map<String,String> map = Maps.newHashMap();
         map.put("A", "B");
         map.put("C", "D");
         
-        assertEquals("B", map.get("A"));
-        assertEquals("D", map.get("C"));
-        assertEquals(map, BridgeUtils.nullSafeImmutableMap(map));
+        assertEquals(map.get("A"), "B");
+        assertEquals(map.get("C"), "D");
+        assertEquals(BridgeUtils.nullSafeImmutableMap(map), map);
         
         Map<String,String> newMap = BridgeUtils.nullSafeImmutableMap(map);
         newMap.put("E","F");
@@ -576,39 +577,39 @@ public class BridgeUtilsTest {
         Map<String,String> mapWithoutNulls = Maps.newHashMap();
         mapWithoutNulls.put("A", "B");
         
-        assertEquals(mapWithoutNulls, BridgeUtils.nullSafeImmutableMap(map));
+        assertEquals(BridgeUtils.nullSafeImmutableMap(map), mapWithoutNulls);
     }    
     
     @Test
     public void textToErrorKey() {
-        assertEquals("iphone_os", BridgeUtils.textToErrorKey("iPhone OS"));
-        assertEquals("android", BridgeUtils.textToErrorKey("Android"));
-        assertEquals("testers_operating_system_v2", BridgeUtils.textToErrorKey("Tester's Operating System v2"));
+        assertEquals(BridgeUtils.textToErrorKey("iPhone OS"), "iphone_os");
+        assertEquals(BridgeUtils.textToErrorKey("Android"), "android");
+        assertEquals(BridgeUtils.textToErrorKey("Tester's Operating System v2"), "testers_operating_system_v2");
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void textToErrorKeyRejectsNull() {
         BridgeUtils.textToErrorKey(null);
     }
             
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void textToErrorKeyRejectsEmptyString() {
         BridgeUtils.textToErrorKey(" ");
     }
     
     @Test
     public void parseIntegerOrDefault() {
-        assertEquals(3, BridgeUtils.getIntOrDefault(null, 3));
-        assertEquals(3, BridgeUtils.getIntOrDefault("  ", 3));
-        assertEquals(1, BridgeUtils.getIntOrDefault("1", 3));
+        assertEquals(BridgeUtils.getIntOrDefault(null, 3), 3);
+        assertEquals(BridgeUtils.getIntOrDefault("  ", 3), 3);
+        assertEquals(BridgeUtils.getIntOrDefault("1", 3), 1);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void parseIntegerOrDefaultThrowsException() {
         BridgeUtils.getIntOrDefault("asdf", 3);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void withoutNullEntriesNullMap() {
         BridgeUtils.withoutNullEntries(null);
     }
@@ -627,21 +628,21 @@ public class BridgeUtilsTest {
         inputMap.put("CCC", "333");
 
         Map<String, String> outputMap = BridgeUtils.withoutNullEntries(inputMap);
-        assertEquals(2, outputMap.size());
-        assertEquals("111", outputMap.get("AAA"));
-        assertEquals("333", outputMap.get("CCC"));
+        assertEquals(outputMap.size(), 2);
+        assertEquals(outputMap.get("AAA"), "111");
+        assertEquals(outputMap.get("CCC"), "333");
 
         // validate that modifying the input map doesn't affect the output map
         inputMap.put("new key", "new value");
-        assertEquals(2, outputMap.size());
+        assertEquals(outputMap.size(), 2);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void putOrRemoveNullMap() {
         BridgeUtils.putOrRemove(null, "key", "value");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void putOrRemoveNullKey() {
         BridgeUtils.putOrRemove(new HashMap<>(), null, "value");
     }
@@ -654,33 +655,33 @@ public class BridgeUtilsTest {
         BridgeUtils.putOrRemove(map, "AAA", "111");
         BridgeUtils.putOrRemove(map, "BBB", "222");
         BridgeUtils.putOrRemove(map, "CCC", "333");
-        assertEquals(3, map.size());
-        assertEquals("111", map.get("AAA"));
-        assertEquals("222", map.get("BBB"));
-        assertEquals("333", map.get("CCC"));
+        assertEquals(map.size(), 3);
+        assertEquals(map.get("AAA"), "111");
+        assertEquals(map.get("BBB"), "222");
+        assertEquals(map.get("CCC"), "333");
 
         // replace a value and verify
         BridgeUtils.putOrRemove(map, "CCC", "not 333");
-        assertEquals(3, map.size());
-        assertEquals("111", map.get("AAA"));
-        assertEquals("222", map.get("BBB"));
-        assertEquals("not 333", map.get("CCC"));
+        assertEquals(map.size(), 3);
+        assertEquals(map.get("AAA"), "111");
+        assertEquals(map.get("BBB"), "222");
+        assertEquals(map.get("CCC"), "not 333");
 
         // remove a value and verify
         BridgeUtils.putOrRemove(map, "BBB", null);
-        assertEquals(2, map.size());
-        assertEquals("111", map.get("AAA"));
-        assertEquals("not 333", map.get("CCC"));
+        assertEquals(map.size(), 2);
+        assertEquals(map.get("AAA"), "111");
+        assertEquals(map.get("CCC"), "not 333");
     }
 
     @Test
     public void testGetLongOrDefault() {
         assertNull(BridgeUtils.getLongOrDefault(null, null));
-        assertEquals(new Long(10), BridgeUtils.getLongOrDefault(null, 10L));
-        assertEquals(new Long(20), BridgeUtils.getLongOrDefault("20", null));
+        assertEquals(BridgeUtils.getLongOrDefault(null, 10L), new Long(10));
+        assertEquals(BridgeUtils.getLongOrDefault("20", null), new Long(20));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void testGetLongWithNonLongValue() {
         BridgeUtils.getLongOrDefault("asdf20", 10L);
     }
@@ -689,51 +690,51 @@ public class BridgeUtilsTest {
     public void testGetDateTimeOrDefault() {
         DateTime dateTime = DateTime.now();
         assertNull(BridgeUtils.getDateTimeOrDefault(null, null));
-        assertEquals(dateTime, BridgeUtils.getDateTimeOrDefault(null, dateTime));
+        assertEquals(BridgeUtils.getDateTimeOrDefault(null, dateTime), dateTime);
         assertTrue(dateTime.isEqual(BridgeUtils.getDateTimeOrDefault(dateTime.toString(), null)));
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void testGetDateTimeWithInvalidDateTime() {
         BridgeUtils.getDateTimeOrDefault("asdf", null);
     }
     
     @Test
     public void encodeURIComponent() {
-        assertEquals("tester%2B4%40tester.com", BridgeUtils.encodeURIComponent("tester+4@tester.com"));
+        assertEquals(BridgeUtils.encodeURIComponent("tester+4@tester.com"), "tester%2B4%40tester.com");
     }
     
     @Test
     public void encodeURIComponentEmpty() {
-        assertEquals("", BridgeUtils.encodeURIComponent(""));
+        assertEquals(BridgeUtils.encodeURIComponent(""), "");
     }
     
     @Test
     public void encodeURIComponentNull() {
-        assertEquals(null, BridgeUtils.encodeURIComponent(null));
+        assertNull(BridgeUtils.encodeURIComponent(null));
     }
     
     @Test
     public void encodeURIComponentNoEscaping() {
-        assertEquals("foo-bar", BridgeUtils.encodeURIComponent("foo-bar"));
+        assertEquals(BridgeUtils.encodeURIComponent("foo-bar"), "foo-bar");
     }
     
     @Test
     public void passwordPolicyDescription() {
         PasswordPolicy policy = new PasswordPolicy(8, false, true, false, true);
         String description = BridgeUtils.passwordPolicyDescription(policy);
-        assertEquals("Password must be 8 or more characters, and must contain at least one upper-case letter, and one symbolic character (non-alphanumerics like #$%&@).", description);
+        assertEquals(description, "Password must be 8 or more characters, and must contain at least one upper-case letter, and one symbolic character (non-alphanumerics like #$%&@).");
         
         policy = new PasswordPolicy(2, false, false, false, false);
         description = BridgeUtils.passwordPolicyDescription(policy);
-        assertEquals("Password must be 2 or more characters.", description);
+        assertEquals(description, "Password must be 2 or more characters.");
     }
     
     @Test
     public void returnPasswordInURI() throws Exception {
         URI uri = new URI("redis://rediscloud:thisisapassword@pub-redis-555.us-east-1-4.1.ec2.garantiadata.com:555");
         String password = BridgeUtils.extractPasswordFromURI(uri);
-        assertEquals("thisisapassword", password);
+        assertEquals(password, "thisisapassword");
     }
     
     @Test
@@ -748,13 +749,13 @@ public class BridgeUtilsTest {
         Activity activity = TestUtils.getActivity2();
         
         String referent = BridgeUtils.createReferentGuidIndex(activity, LOCAL_DATE_TIME);
-        assertEquals("BBB:survey:2010-10-10T10:10:10.111", referent);
+        assertEquals(referent, "BBB:survey:2010-10-10T10:10:10.111");
     }
     
     @Test
     public void createReferentGuid2() {
         String referent = BridgeUtils.createReferentGuidIndex(ActivityType.TASK, "foo", LOCAL_DATE_TIME.toString());
-        assertEquals("foo:task:2010-10-10T10:10:10.111", referent);
+        assertEquals(referent, "foo:task:2010-10-10T10:10:10.111");
     }
     
     @Test
@@ -762,7 +763,7 @@ public class BridgeUtilsTest {
         LocalDate localDate = LocalDate.parse("2017-05-10");
         LocalDate parsed = BridgeUtils.getLocalDateOrDefault(localDate.toString(), null);
         
-        assertEquals(localDate, parsed);
+        assertEquals(parsed, localDate);
     }
     
     @Test
@@ -770,33 +771,33 @@ public class BridgeUtilsTest {
         LocalDate localDate = LocalDate.parse("2017-05-10");
         LocalDate parsed = BridgeUtils.getLocalDateOrDefault(null, localDate);
         
-        assertEquals(localDate, parsed);
+        assertEquals(parsed, localDate);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getLocalDateWithError() {
         BridgeUtils.getLocalDateOrDefault("2017-05-10T05:05:10.000Z", null);
     }
     
     @Test
     public void toSynapseFriendlyName() {
-        assertEquals("This is a .-_ synapse Friendly Name3",
-                BridgeUtils.toSynapseFriendlyName("This (is a).-_ synapse Friendly Name3 "));
+        assertEquals(BridgeUtils.toSynapseFriendlyName("This (is a).-_ synapse Friendly Name3 "),
+                "This is a .-_ synapse Friendly Name3");
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullToSynapseFriendlyNameThrowsException() {
         BridgeUtils.toSynapseFriendlyName(null);
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void emptyStringToSynapseFriendlyName() {
         BridgeUtils.toSynapseFriendlyName("  #");
     }
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.
     private <T> void orderedSetsEqual(Set<T> first, Set<T> second) {
-        assertEquals(first.size(), second.size());
+        assertEquals(second.size(), first.size());
         
         Iterator<T> firstIterator = first.iterator();
         Iterator<T> secondIterator = second.iterator();

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -1,19 +1,20 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dynamodb.AnnotationBasedTableCreator;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -31,7 +32,7 @@ public class DefaultStudyBootstrapperTest {
 
     private DefaultStudyBootstrapper defaultStudyBootstrapper;
 
-    @Before
+    @BeforeMethod
     public void before() {
         studyService = mock(StudyService.class);
 
@@ -53,31 +54,31 @@ public class DefaultStudyBootstrapperTest {
 
         // Validate api study.
         Study study = createdStudyList.get(0);
-        assertEquals("Test Study", study.getName());
-        assertEquals(BridgeConstants.API_STUDY_ID_STRING, study.getIdentifier());
-        assertEquals("Sage Bionetworks", study.getSponsorName());
-        assertEquals("TestStudy", study.getShortName());
-        assertEquals(18, study.getMinAgeOfConsent());
-        assertEquals("bridge-testing+consent@sagebase.org", study.getConsentNotificationEmail());
-        assertEquals("bridge-testing+technical@sagebase.org", study.getTechnicalEmail());
-        assertEquals("support@sagebridge.org", study.getSupportEmail());
-        assertEquals(Sets.newHashSet("can_be_recontacted"), study.getUserProfileAttributes());
-        assertEquals(new PasswordPolicy(2, false, false, false, false), study.getPasswordPolicy());
+        assertEquals(study.getName(), "Test Study");
+        assertEquals(study.getIdentifier(), BridgeConstants.API_STUDY_ID_STRING);
+        assertEquals(study.getSponsorName(), "Sage Bionetworks");
+        assertEquals(study.getShortName(), "TestStudy");
+        assertEquals(study.getMinAgeOfConsent(), 18);
+        assertEquals(study.getConsentNotificationEmail(), "bridge-testing+consent@sagebase.org");
+        assertEquals(study.getTechnicalEmail(), "bridge-testing+technical@sagebase.org");
+        assertEquals(study.getSupportEmail(), "support@sagebridge.org");
+        assertEquals(study.getUserProfileAttributes(), Sets.newHashSet("can_be_recontacted"));
+        assertEquals(study.getPasswordPolicy(), new PasswordPolicy(2, false, false, false, false));
         assertTrue(study.isEmailVerificationEnabled());
 
         // Validate shared study. No need to test every attribute. Just validate the important attributes.
         Study sharedStudy = createdStudyList.get(1);
-        assertEquals("Shared Module Library", sharedStudy.getName());
-        assertEquals(BridgeConstants.SHARED_STUDY_ID_STRING, sharedStudy.getIdentifier());
+        assertEquals(sharedStudy.getName(), "Shared Module Library");
+        assertEquals(sharedStudy.getIdentifier(), BridgeConstants.SHARED_STUDY_ID_STRING);
 
         // So it doesn't get out of sync, validate the study. However, default templates are set 
         // by the service. so those two errors are expected.
         try {
             Validate.entityThrowingException(new StudyValidator(), study);    
         } catch(InvalidEntityException e) {
-            assertEquals(2, e.getErrors().keySet().size());
-            assertEquals(1, e.getErrors().get("verifyEmailTemplate").size());
-            assertEquals(1, e.getErrors().get("resetPasswordTemplate").size());
+            assertEquals(e.getErrors().keySet().size(), 2);
+            assertEquals(e.getErrors().get("verifyEmailTemplate").size(), 1);
+            assertEquals(e.getErrors().get("resetPasswordTemplate").size(), 1);
         }
         
     }

--- a/src/test/java/org/sagebionetworks/bridge/PasswordGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/PasswordGeneratorTest.java
@@ -1,18 +1,18 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class PasswordGeneratorTest {
 
     @Test
     public void generatesPasswordCorrectLength() {
-        assertEquals(16,PasswordGenerator.INSTANCE.nextPassword(16).length());
-        assertEquals(101,PasswordGenerator.INSTANCE.nextPassword(101).length());
+        assertEquals(PasswordGenerator.INSTANCE.nextPassword(16).length(), 16);
+        assertEquals(PasswordGenerator.INSTANCE.nextPassword(101).length(), 101);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.Metrics;
 
@@ -62,11 +62,11 @@ public class RequestContextTest {
                 .withCallerStudyId(TestConstants.TEST_STUDY).withCallerSubstudies(SUBSTUDIES)
                 .withMetrics(metrics).withCallerRoles(ROLES).build();
 
-        assertEquals("requestId", context.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, context.getCallerStudyId());
-        assertEquals(TestConstants.TEST_STUDY, context.getCallerStudyIdentifier());
-        assertEquals(SUBSTUDIES, context.getCallerSubstudies());
-        assertEquals(ROLES, context.getCallerRoles());
-        assertEquals(metrics, context.getMetrics());
+        assertEquals(context.getId(), "requestId");
+        assertEquals(context.getCallerStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(context.getCallerStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(context.getCallerSubstudies(), SUBSTUDIES);
+        assertEquals(context.getCallerRoles(), ROLES);
+        assertEquals(context.getMetrics(), metrics);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/SecureTokenGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/SecureTokenGeneratorTest.java
@@ -1,21 +1,18 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SecureTokenGeneratorTest {
-
+    
     @Test
     public void testNoArgConstructor() {
         String value = SecureTokenGenerator.INSTANCE.nextToken();
         
-        assertEquals(21, value.length());
+        assertEquals(value.length(), 21);
         assertNotEquals(value, SecureTokenGenerator.INSTANCE.nextToken());
     }
     
@@ -27,7 +24,7 @@ public class SecureTokenGeneratorTest {
     @Test
     public void phoneCodeString() {
         String token = SecureTokenGenerator.PHONE_CODE_INSTANCE.nextToken();
-        assertEquals(6, token.length());
+        assertEquals(token.length(), 6);
         assertTrue(token.matches("^\\d+$")); // composed only of digits
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -112,7 +112,7 @@ public class TestUtils {
         // I don't know of a one line test for this... maybe just comparing ISO string formats of the date.
         assertTrue(date1.isEqual(date2));
         // This ensures that zones such as "America/Los_Angeles" and "-07:00" are equal 
-        assertEquals( date1.getZone().getOffset(date1), date2.getZone().getOffset(date2) );
+        assertEquals(date2.getZone().getOffset(date2), date1.getZone().getOffset(date1));
     }
 
     public static <E> void assertListIsImmutable(List<E> list, E sampleElement) {

--- a/src/test/java/org/sagebionetworks/bridge/TestUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtilsTest.java
@@ -1,16 +1,17 @@
 package org.sagebionetworks.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 
 import java.util.HashSet;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoCriteria;
 import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
@@ -30,13 +31,13 @@ public class TestUtilsTest {
             throw new EntityNotFoundException(Account.class);});
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void testAssertExceptionThrowsTheExceptionWithWrongMessage() {
         TestUtils.assertException(EntityNotFoundException.class, "Account not found", () -> {
             throw new EntityNotFoundException(AppConfig.class);});
     }
     
-    @Test(expected = ConstraintViolationException.class)
+    @Test(expectedExceptions = ConstraintViolationException.class)
     public void testAssertThrowsExceptionUnrelatedException() {
         TestUtils.assertException(EntityNotFoundException.class, "Account not found", () -> {
             throw new ConstraintViolationException.Builder().build();});
@@ -48,7 +49,7 @@ public class TestUtilsTest {
             TestUtils.assertException(Exception.class, "Any message at all", () -> {});
             fail("Should have thrown exception");
         } catch(Throwable e) {
-            assertEquals("Should have thrown exception: java.lang.Exception, message: 'Any message at all'", e.getMessage());
+            assertEquals(e.getMessage(), "Should have thrown exception: java.lang.Exception, message: 'Any message at all'");
         }
     }
     
@@ -56,10 +57,10 @@ public class TestUtilsTest {
     public void createCriteriaWithArguments() {
         Criteria criteria = TestUtils.createCriteria(5, 15, ALL_OF_GROUPS, NONE_OF_GROUPS);
 
-        assertEquals(new Integer(5), criteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(15), criteria.getMaxAppVersion(IOS));
-        assertEquals(ALL_OF_GROUPS, criteria.getAllOfGroups());
-        assertEquals(NONE_OF_GROUPS, criteria.getNoneOfGroups());
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(5));
+        assertEquals(criteria.getMaxAppVersion(IOS), new Integer(15));
+        assertEquals(criteria.getAllOfGroups(), ALL_OF_GROUPS);
+        assertEquals(criteria.getNoneOfGroups(), NONE_OF_GROUPS);
     }
     
     @Test
@@ -73,13 +74,13 @@ public class TestUtilsTest {
         Criteria criteria = newCriteria();
         
         Criteria newCriteria = TestUtils.copyCriteria(criteria);
-        assertEquals(new Integer(5), newCriteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(15), newCriteria.getMaxAppVersion(IOS));
-        assertEquals(new Integer(12), newCriteria.getMaxAppVersion(ANDROID));
-        assertEquals(ALL_OF_GROUPS, newCriteria.getAllOfGroups());
-        assertEquals(NONE_OF_GROUPS, newCriteria.getNoneOfGroups());
-        assertEquals(Sets.newHashSet(IOS, ANDROID), newCriteria.getAppVersionOperatingSystems());
-        assertFalse( criteria == newCriteria);
+        assertEquals(newCriteria.getMinAppVersion(IOS), new Integer(5));
+        assertEquals(newCriteria.getMaxAppVersion(IOS), new Integer(15));
+        assertEquals(newCriteria.getMaxAppVersion(ANDROID), new Integer(12));
+        assertEquals(newCriteria.getAllOfGroups(), ALL_OF_GROUPS);
+        assertEquals(newCriteria.getNoneOfGroups(), NONE_OF_GROUPS);
+        assertEquals(newCriteria.getAppVersionOperatingSystems(), Sets.newHashSet(IOS, ANDROID));
+        assertFalse(criteria == newCriteria);
     }
     
     private Criteria newCriteria() {

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheKeyTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -20,69 +21,69 @@ public class CacheKeyTest {
         EqualsVerifier.forClass(CacheKey.class).allFieldsShouldBeUsed().verify();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullsRejected() {
         CacheKey.appConfigList(null);
     }
     
     @Test
     public void reauthTokenLookupKey() {
-        assertEquals("ABC:api:ReauthToken", CacheKey.reauthTokenLookupKey("ABC", TestConstants.TEST_STUDY).toString());
+        assertEquals(CacheKey.reauthTokenLookupKey("ABC", TestConstants.TEST_STUDY).toString(), "ABC:api:ReauthToken");
     }
     
     @Test
     public void shortenUrl() {
-        assertEquals("ABC:ShortenedUrl", CacheKey.shortenUrl("ABC").toString());
+        assertEquals(CacheKey.shortenUrl("ABC").toString(), "ABC:ShortenedUrl");
     }
     
     @Test
     public void appConfigList() {
-        assertEquals("api:AppConfigList", CacheKey.appConfigList(TestConstants.TEST_STUDY).toString());
+        assertEquals(CacheKey.appConfigList(TestConstants.TEST_STUDY).toString(), "api:AppConfigList");
     }
     
     @Test
     public void channelThrottling() {
-        assertEquals("userId:email:channel-throttling", CacheKey.channelThrottling("email", "userId").toString());
+        assertEquals(CacheKey.channelThrottling("email", "userId").toString(), "userId:email:channel-throttling");
     }
     
     @Test
     public void emailSignInRequest() {
         SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
                 .withEmail("email@email.com").build();
-        assertEquals("email@email.com:api:signInRequest", CacheKey.emailSignInRequest(signIn).toString());
+        assertEquals(CacheKey.emailSignInRequest(signIn).toString(), "email@email.com:api:signInRequest");
     }
     
     @Test
     public void emailVerification() {
-        assertEquals("email@email.com:emailVerificationStatus", CacheKey.emailVerification("email@email.com").toString());
+        assertEquals(CacheKey.emailVerification("email@email.com").toString(), "email@email.com:emailVerificationStatus");
     }
     
     @Test
     public void itpWithPhone() {
-        assertEquals("guid:"+TestConstants.PHONE.getNumber()+":api:itp",
-                CacheKey.itp(SUBPOP_GUID, TestConstants.TEST_STUDY, TestConstants.PHONE).toString());
+        assertEquals(CacheKey.itp(SUBPOP_GUID, TestConstants.TEST_STUDY, TestConstants.PHONE).toString(),
+                "guid:" + TestConstants.PHONE.getNumber() + ":api:itp");
     }
     
     @Test
     public void itpWithEmail() {
-        assertEquals("guid:email@email.com:api:itp",
-                CacheKey.itp(SUBPOP_GUID, TestConstants.TEST_STUDY, "email@email.com").toString());
+        assertEquals(CacheKey.itp(SUBPOP_GUID, TestConstants.TEST_STUDY, "email@email.com").toString(),
+                "guid:email@email.com:api:itp");
     }
     
     @Test
     public void lock() {
-        assertEquals("value:java.lang.String:lock", CacheKey.lock("value", String.class).toString());
+        assertEquals(CacheKey.lock("value", String.class).toString(), "value:java.lang.String:lock");
     }
     
     @Test
     public void passwordResetForEmail() {
-        assertEquals("sptoken:api", CacheKey.passwordResetForEmail("sptoken", "api").toString());
+        assertEquals(CacheKey.passwordResetForEmail("sptoken", "api").toString(), "sptoken:api");
     }
     
     @Test
     public void passwordResetForPhone() {
-        assertEquals("sptoken:phone:" + TestConstants.PHONE.getNumber(),
-                CacheKey.passwordResetForPhone("sptoken", TestConstants.PHONE.getNumber()).toString());
+        assertEquals(CacheKey.passwordResetForPhone("sptoken", TestConstants.PHONE.getNumber()).toString(),
+                "sptoken:phone:" + TestConstants.PHONE.getNumber());
     }
     
     @Test
@@ -90,48 +91,48 @@ public class CacheKeyTest {
         SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
                 .withPhone(TestConstants.PHONE).build();
         
-        assertEquals(TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest",
-                CacheKey.phoneSignInRequest(signIn).toString());
+        assertEquals(CacheKey.phoneSignInRequest(signIn).toString(),
+                TestConstants.PHONE.getNumber() + ":api:phoneSignInRequest");
     }
     
     @Test
     public void requestInfo() {
-        assertEquals("userId:request-info", CacheKey.requestInfo("userId").toString());
+        assertEquals(CacheKey.requestInfo("userId").toString(), "userId:request-info");
     }
     
     @Test
     public void study() {
-        assertEquals("api:study", CacheKey.study("api").toString());
+        assertEquals(CacheKey.study("api").toString(), "api:study");
     }    
     
     @Test
     public void subpop() {
-        assertEquals("guid:api:Subpopulation", CacheKey.subpop(SUBPOP_GUID, TestConstants.TEST_STUDY).toString());
+        assertEquals(CacheKey.subpop(SUBPOP_GUID, TestConstants.TEST_STUDY).toString(), "guid:api:Subpopulation");
     }
     
     @Test
     public void subpopList() {
-        assertEquals("api:SubpopulationList", CacheKey.subpopList(TestConstants.TEST_STUDY).toString());
+        assertEquals(CacheKey.subpopList(TestConstants.TEST_STUDY).toString(), "api:SubpopulationList");
     }
     
     @Test
     public void verificationToken() {
-        assertEquals("token", CacheKey.verificationToken("token").toString());
+        assertEquals(CacheKey.verificationToken("token").toString(), "token");
     }
     
     @Test
     public void viewKey() {
-        assertEquals("a:b:StringBuilder:view", CacheKey.viewKey(StringBuilder.class, "a", "b").toString());
+        assertEquals(CacheKey.viewKey(StringBuilder.class, "a", "b").toString(), "a:b:StringBuilder:view");
     }
     
     @Test
     public void userIdToSession() {
-        assertEquals("userId:session2:user", CacheKey.userIdToSession("userId").toString());
+        assertEquals(CacheKey.userIdToSession("userId").toString(), "userId:session2:user");
     }
     
     @Test
     public void tokenToUserId() { 
-        assertEquals("aSessionToken:session2", CacheKey.tokenToUserId("aSessionToken").toString());
+        assertEquals(CacheKey.tokenToUserId("aSessionToken").toString(), "aSessionToken:session2");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -1,10 +1,5 @@
 package org.sagebionetworks.bridge.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -16,17 +11,21 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
@@ -55,7 +54,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CacheProviderMockTest {
 
     private static final CacheKey CACHE_KEY = CacheKey.study("key");
@@ -89,13 +87,13 @@ public class CacheProviderMockTest {
         simpleCacheProvider.setObject(cacheKey, json, BridgeConstants.BRIDGE_VIEW_EXPIRE_IN_SECONDS);
 
         String cachedString = simpleCacheProvider.getObject(cacheKey, String.class);
-        assertEquals(json, cachedString);
+        assertEquals(cachedString, json);
 
         // Remove something that's not the key
         final CacheKey brokenCacheKey = CacheKey.study(study.getIdentifier()+"2");
         simpleCacheProvider.removeObject(brokenCacheKey);
         cachedString = simpleCacheProvider.getObject(cacheKey, String.class);
-        assertEquals(json, cachedString);
+        assertEquals(cachedString, json);
 
         simpleCacheProvider.removeObject(cacheKey);
         cachedString = simpleCacheProvider.getObject(cacheKey, String.class);
@@ -120,36 +118,37 @@ public class CacheProviderMockTest {
         UserSession session = cacheProvider.getUserSession(DECRYPTED_SESSION_TOKEN);
 
         assertTrue(session.isAuthenticated());
-        assertEquals(Environment.LOCAL, session.getEnvironment());
-        assertEquals(DECRYPTED_SESSION_TOKEN, session.getSessionToken());
-        assertEquals("4f0937a5-6ebf-451b-84bc-fbf649b9e93c", session.getInternalSessionToken());
-        assertEquals("6gq4jGXLmAxVbLLmVifKN4", session.getId());
-        assertEquals("api", session.getStudyIdentifier().getIdentifier());
+        assertEquals(session.getEnvironment(), Environment.LOCAL);
+        assertEquals(session.getSessionToken(), DECRYPTED_SESSION_TOKEN);
+        assertEquals(session.getInternalSessionToken(), "4f0937a5-6ebf-451b-84bc-fbf649b9e93c");
+        assertEquals(session.getId(), "6gq4jGXLmAxVbLLmVifKN4");
+        assertEquals(session.getStudyIdentifier().getIdentifier(), "api");
         
         StudyParticipant participant = session.getParticipant();
-        assertEquals("Bridge", participant.getFirstName());
-        assertEquals("IT", participant.getLastName());
-        assertEquals("bridgeit@sagebase.org", participant.getEmail());
-        assertEquals(SharingScope.NO_SHARING, participant.getSharingScope());
-        assertEquals(DateTime.parse("2016-04-21T16:48:22.386Z"), participant.getCreatedOn());
-        assertEquals(Sets.newHashSet(Roles.ADMIN), participant.getRoles());
-        assertEquals(ImmutableList.of("en","fr"), participant.getLanguages());
-        assertEquals("ABC", participant.getExternalId());
+        assertEquals(participant.getFirstName(), "Bridge");
+        assertEquals(participant.getLastName(), "IT");
+        assertEquals(participant.getEmail(), "bridgeit@sagebase.org");
+        assertEquals(participant.getSharingScope(), SharingScope.NO_SHARING);
+        assertEquals(participant.getCreatedOn(), DateTime.parse("2016-04-21T16:48:22.386Z"));
+        assertEquals(participant.getRoles(), Sets.newHashSet(Roles.ADMIN));
+        assertEquals(participant.getLanguages(), ImmutableList.of("en","fr"));
+        assertEquals(participant.getExternalId(), "ABC");
         
-        assertEquals(participant.getHealthCode(), ENCRYPTOR.decrypt(ENCRYPTED_SESSION_TOKEN));
+        assertEquals(ENCRYPTOR.decrypt(ENCRYPTED_SESSION_TOKEN), participant.getHealthCode());
         
         SubpopulationGuid apiGuid = SubpopulationGuid.create("api");
         Map<SubpopulationGuid,ConsentStatus> consentStatuses = session.getConsentStatuses();
         ConsentStatus status = consentStatuses.get(apiGuid);
-        assertEquals("Default Consent Group", status.getName());
-        assertEquals(apiGuid.getGuid(), status.getSubpopulationGuid());
+        assertEquals(status.getName(), "Default Consent Group");
+        assertEquals(status.getSubpopulationGuid(), apiGuid.getGuid());
         assertTrue(status.getSignedMostRecentConsent());
         assertTrue(status.isRequired());
         assertFalse(status.isConsented());
     }
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         mockTransaction(transaction);
         
         when(jedisOps.getTransaction()).thenReturn(transaction);
@@ -217,7 +216,7 @@ public class CacheProviderMockTest {
         when(jedisOps.get(CACHE_KEY.toString())).thenReturn(ser);
         
         OAuthProvider returned = cacheProvider.getObject(CACHE_KEY, OAuthProvider.class);
-        assertEquals(provider, returned);
+        assertEquals(returned, provider);
         verify(jedisOps).get(CACHE_KEY.toString());
     }
     
@@ -227,7 +226,7 @@ public class CacheProviderMockTest {
         when(jedisOps.get(CACHE_KEY.toString())).thenReturn(ser);
         
         String result = cacheProvider.getObject(CACHE_KEY, String.class);
-        assertEquals("Test", result);
+        assertEquals(result, "Test");
         verify(jedisOps).get(CACHE_KEY.toString());
     }
     
@@ -238,7 +237,7 @@ public class CacheProviderMockTest {
         when(jedisOps.get(CACHE_KEY.toString())).thenReturn(ser);
         
         OAuthProvider returned = cacheProvider.getObject(CACHE_KEY, OAuthProvider.class, 100);
-        assertEquals(provider, returned);
+        assertEquals(returned, provider);
         verify(jedisOps).get(CACHE_KEY.toString());
         verify(jedisOps).expire(CACHE_KEY.toString(), 100);
     }
@@ -249,7 +248,7 @@ public class CacheProviderMockTest {
         when(jedisOps.get(CACHE_KEY.toString())).thenReturn(ser);
         
         String result = cacheProvider.getObject(CACHE_KEY, String.class, 100);
-        assertEquals("Test", result);
+        assertEquals(result, "Test");
         verify(jedisOps).expire(CACHE_KEY.toString(), 100);
     }
     
@@ -264,9 +263,9 @@ public class CacheProviderMockTest {
         TypeReference<List<OAuthProvider>> typeRef = new TypeReference<List<OAuthProvider>>() {};
         
         List<OAuthProvider> returned = cacheProvider.getObject(CACHE_KEY, typeRef);
-        assertEquals(provider1, returned.get(0));
-        assertEquals(provider2, returned.get(1));
-        assertEquals(2, returned.size());
+        assertEquals(returned.get(0), provider1);
+        assertEquals(returned.get(1), provider2);
+        assertEquals(returned.size(), 2);
     }
 
     @Test
@@ -284,7 +283,7 @@ public class CacheProviderMockTest {
         when(jedisOps.get(USER_ID_TO_SESSION.toString())).thenReturn(ser);
         
         UserSession retrieved = cacheProvider.getUserSessionByUserId(USER_ID);
-        assertEquals(DECRYPTED_SESSION_TOKEN, retrieved.getSessionToken());
+        assertEquals(retrieved.getSessionToken(), DECRYPTED_SESSION_TOKEN);
     }
 
     @Test
@@ -308,7 +307,7 @@ public class CacheProviderMockTest {
                 .thenReturn(BridgeObjectMapper.get().writeValueAsString(session));
 
         UserSession retrieved = cacheProvider.getUserSession(DECRYPTED_SESSION_TOKEN);
-        assertEquals(session.getSessionToken(), retrieved.getSessionToken());
+        assertEquals(retrieved.getSessionToken(), session.getSessionToken());
     }
     
     @Test
@@ -477,7 +476,7 @@ public class CacheProviderMockTest {
         try {
             cacheProvider.setUserSession(session);
         } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
+            assertTrue(true, "NPE expected.");
         } catch(Throwable e) {
             fail(e.getMessage());
         }
@@ -493,7 +492,7 @@ public class CacheProviderMockTest {
         try {
             cacheProvider.setUserSession(session);
         } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
+            assertTrue(true, "NPE expected.");
         } catch(Throwable e) {
             fail(e.getMessage());
         }
@@ -513,7 +512,7 @@ public class CacheProviderMockTest {
         try {
             cacheProvider.setUserSession(session);
         } catch(NullPointerException e) {
-            assertTrue("NPE expected.", true);
+            assertTrue(true, "NPE expected.");
         } catch(Throwable e) {
             fail(e.getMessage());
         }

--- a/src/test/java/org/sagebionetworks/bridge/cache/ViewCacheTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/ViewCacheTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheKey;
@@ -30,7 +31,7 @@ public class ViewCacheTest {
     private BridgeObjectMapper mapper;
     private Study study;
     
-    @Before
+    @BeforeMethod
     public void before() {
         mapper = BridgeObjectMapper.get();
         
@@ -57,7 +58,7 @@ public class ViewCacheTest {
         });
         
         Study foundStudy = BridgeObjectMapper.get().readValue(json, DynamoStudy.class);
-        assertEquals("Test Study 2", foundStudy.getName());
+        assertEquals(foundStudy.getName(), "Test Study 2");
     }
     
     @Test
@@ -81,7 +82,7 @@ public class ViewCacheTest {
             });
             fail("This should have thrown an exception");
         } catch(BridgeServiceException e) {
-            assertEquals("There has been a problem retrieving the study", e.getMessage());
+            assertEquals(e.getMessage(), "There has been a problem retrieving the study");
         }
     }
     
@@ -106,7 +107,7 @@ public class ViewCacheTest {
         });
         
         Study foundStudy = BridgeObjectMapper.get().readValue(json, DynamoStudy.class);
-        assertEquals("Test Study [ViewCacheTest]", foundStudy.getName());
+        assertEquals(foundStudy.getName(), "Test Study [ViewCacheTest]");
     }
     
     @Test
@@ -130,7 +131,7 @@ public class ViewCacheTest {
             }
         });
         Study foundStudy = BridgeObjectMapper.get().readValue(json, DynamoStudy.class);
-        assertEquals("Test Study 2", foundStudy.getName());
+        assertEquals(foundStudy.getName(), "Test Study 2");
     }
     
     @Test
@@ -138,7 +139,7 @@ public class ViewCacheTest {
         ViewCache cache = new ViewCache();
         
         CacheKey cacheKey = cache.getCacheKey(Study.class, "mostRandom", "leastRandom");
-        assertEquals("mostRandom:leastRandom:Study:view", cacheKey.toString());
+        assertEquals(cacheKey.toString(), "mostRandom:leastRandom:Study:view");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoaderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoaderTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.crypto;
 
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.File;
 import java.nio.file.Files;
 
 import com.google.common.base.Charsets;
-import org.junit.Test;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.Test;
 
 public class CmsEncryptorCacheLoaderTest {
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigElementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigElementTest.java
@@ -1,16 +1,17 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -30,18 +31,18 @@ public class DynamoAppConfigElementTest {
         DynamoAppConfigElement element = new DynamoAppConfigElement();
         element.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         element.setId(ID);
-        assertEquals(KEY, element.getKey());
+        assertEquals(element.getKey(), KEY);
         
         // set key, get through getters
         element = new DynamoAppConfigElement();
         element.setKey(KEY);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, element.getStudyId());
-        assertEquals(ID, element.getId());
+        assertEquals(element.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(element.getId(), ID);
         
         // set key, get through getters
         element = new DynamoAppConfigElement();
         element.setKey(KEY);
-        assertEquals(KEY, element.getKey());
+        assertEquals(element.getKey(), KEY);
         
         // setters nullify key
         element = new DynamoAppConfigElement();
@@ -84,18 +85,18 @@ public class DynamoAppConfigElementTest {
         JsonNode node = BridgeObjectMapper.get().valueToTree(element);
         assertNull(node.get("key"));
         assertNull(node.get("studyId"));
-        assertEquals(1L, node.get("revision").longValue());
-        assertEquals(ID, node.get("id").textValue());
+        assertEquals(node.get("revision").longValue(), 1L);
+        assertEquals(node.get("id").textValue(), ID);
         assertTrue(node.get("deleted").booleanValue());
-        assertEquals(TestUtils.getClientData(), node.get("data"));
-        assertEquals(CREATED_ON.toString(), node.get("createdOn").textValue());
-        assertEquals(MODIFIED_ON.toString(), node.get("modifiedOn").textValue());
-        assertEquals(2L, node.get("version").longValue());
-        assertEquals("AppConfigElement", node.get("type").textValue());
+        assertEquals(node.get("data"), TestUtils.getClientData());
+        assertEquals(node.get("createdOn").textValue(), CREATED_ON.toString());
+        assertEquals(node.get("modifiedOn").textValue(), MODIFIED_ON.toString());
+        assertEquals(node.get("version").longValue(), 2L);
+        assertEquals(node.get("type").textValue(), "AppConfigElement");
         
         AppConfigElement deser = BridgeObjectMapper.get().readValue(node.toString(), AppConfigElement.class);
         deser.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
-        assertEquals(element, deser);
+        assertEquals(deser, element);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -1,17 +1,18 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -100,68 +101,68 @@ public class DynamoAppConfigTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(appConfig);
         
-        assertEquals(12, node.size());
+        assertEquals(node.size(), 12);
         JsonNode critNode = node.get("criteria");
-        assertEquals("fr", critNode.get("language").textValue());
-        assertEquals(2, critNode.get("allOfGroups").size());
-        assertEquals("a", critNode.get("allOfGroups").get(0).textValue());
-        assertEquals("b", critNode.get("allOfGroups").get(1).textValue());
-        assertEquals(2, critNode.get("noneOfGroups").size());
-        assertEquals("d", critNode.get("noneOfGroups").get(0).textValue());
-        assertEquals("c", critNode.get("noneOfGroups").get(1).textValue());
-        assertEquals(2, critNode.get("minAppVersions").get("iPhone OS").intValue());
-        assertEquals(10, critNode.get("minAppVersions").get("Android").intValue());
-        assertEquals(8, critNode.get("maxAppVersions").get("iPhone OS").intValue());
-        assertEquals(15, critNode.get("maxAppVersions").get("Android").intValue());
-        assertEquals("Criteria", critNode.get("type").textValue());
+        assertEquals(critNode.get("language").textValue(), "fr");
+        assertEquals(critNode.get("allOfGroups").size(), 2);
+        assertEquals(critNode.get("allOfGroups").get(0).textValue(), "a");
+        assertEquals(critNode.get("allOfGroups").get(1).textValue(), "b");
+        assertEquals(critNode.get("noneOfGroups").size(), 2);
+        assertEquals(critNode.get("noneOfGroups").get(0).textValue(), "d");
+        assertEquals(critNode.get("noneOfGroups").get(1).textValue(), "c");
+        assertEquals(critNode.get("minAppVersions").get("iPhone OS").intValue(), 2);
+        assertEquals(critNode.get("minAppVersions").get("Android").intValue(), 10);
+        assertEquals(critNode.get("maxAppVersions").get("iPhone OS").intValue(), 8);
+        assertEquals(critNode.get("maxAppVersions").get("Android").intValue(), 15);
+        assertEquals(critNode.get("type").textValue(), "Criteria");
         
         assertTrue(node.get("deleted").booleanValue());
-        assertEquals(TIMESTAMP.toString(), node.get("createdOn").textValue());
-        assertEquals(TIMESTAMP.toString(), node.get("modifiedOn").textValue());
-        assertEquals("AppConfig", node.get("type").textValue());
-        assertEquals(LABEL, node.get("label").textValue());
-        assertEquals(3L, node.get("version").longValue());
-        assertEquals(clientData, node.get("clientData"));
-        assertEquals(clientData, node.get("configElements").get("config1"));
-        assertEquals(1, node.get("configElements").size());
+        assertEquals(node.get("createdOn").textValue(), TIMESTAMP.toString());
+        assertEquals(node.get("modifiedOn").textValue(), TIMESTAMP.toString());
+        assertEquals(node.get("type").textValue(), "AppConfig");
+        assertEquals(node.get("label").textValue(), LABEL);
+        assertEquals(node.get("version").longValue(), 3L);
+        assertEquals(node.get("clientData"), clientData);
+        assertEquals(node.get("configElements").get("config1"), clientData);
+        assertEquals(node.get("configElements").size(), 1);
         
-        assertEquals(2, node.get("configReferences").size());
-        assertEquals("config1", node.get("configReferences").get(0).get("id").textValue());
-        assertEquals(1L, node.get("configReferences").get(0).get("revision").longValue());
-        assertEquals("config2", node.get("configReferences").get(1).get("id").textValue());
-        assertEquals(2L, node.get("configReferences").get(1).get("revision").longValue());
+        assertEquals(node.get("configReferences").size(), 2);
+        assertEquals(node.get("configReferences").get(0).get("id").textValue(), "config1");
+        assertEquals(node.get("configReferences").get(0).get("revision").longValue(), 1L);
+        assertEquals(node.get("configReferences").get(1).get("id").textValue(), "config2");
+        assertEquals(node.get("configReferences").get(1).get("revision").longValue(), 2L);
         
-        assertEquals(2, node.get("schemaReferences").size());
-        assertEquals("schemaA", node.get("schemaReferences").get(0).get("id").textValue());
-        assertEquals(1L, node.get("schemaReferences").get(0).get("revision").longValue());
-        assertEquals("schemaB", node.get("schemaReferences").get(1).get("id").textValue());
-        assertEquals(2L, node.get("schemaReferences").get(1).get("revision").longValue());
+        assertEquals(node.get("schemaReferences").size(), 2);
+        assertEquals(node.get("schemaReferences").get(0).get("id").textValue(), "schemaA");
+        assertEquals(node.get("schemaReferences").get(0).get("revision").longValue(), 1L);
+        assertEquals(node.get("schemaReferences").get(1).get("id").textValue(), "schemaB");
+        assertEquals(node.get("schemaReferences").get(1).get("revision").longValue(), 2L);
         
-        assertEquals(2, node.get("surveyReferences").size());
-        assertEquals("surveyA", node.get("surveyReferences").get(0).get("identifier").textValue());
-        assertEquals(appConfig.getSurveyReferences().get(0).getGuid(),
-                node.get("surveyReferences").get(0).get("guid").textValue());
-        assertEquals(SURVEY_PUB_DATE.toString(), node.get("surveyReferences").get(0).get("createdOn").textValue());
-        assertEquals("surveyB", node.get("surveyReferences").get(1).get("identifier").textValue());
-        assertEquals(appConfig.getSurveyReferences().get(1).getGuid(),
-                node.get("surveyReferences").get(1).get("guid").textValue());
-        assertEquals(SURVEY_PUB_DATE.toString(), node.get("surveyReferences").get(1).get("createdOn").textValue());
+        assertEquals(node.get("surveyReferences").size(), 2);
+        assertEquals(node.get("surveyReferences").get(0).get("identifier").textValue(), "surveyA");
+        assertEquals(node.get("surveyReferences").get(0).get("guid").textValue(),
+                appConfig.getSurveyReferences().get(0).getGuid());
+        assertEquals(node.get("surveyReferences").get(0).get("createdOn").textValue(), SURVEY_PUB_DATE.toString());
+        assertEquals(node.get("surveyReferences").get(1).get("identifier").textValue(), "surveyB");
+        assertEquals(node.get("surveyReferences").get(1).get("guid").textValue(),
+                appConfig.getSurveyReferences().get(1).getGuid());
+        assertEquals(node.get("surveyReferences").get(1).get("createdOn").textValue(), SURVEY_PUB_DATE.toString());
         
         AppConfig deser = BridgeObjectMapper.get().treeToValue(node, AppConfig.class);
         assertNull(deser.getStudyId());
         
-        assertEquals(clientData, deser.getClientData());
-        assertEquals(clientData, deser.getConfigElements().get("config1"));
-        assertEquals(appConfig.getCriteria(), deser.getCriteria());
-        assertEquals(appConfig.getLabel(), deser.getLabel());
-        assertEquals(appConfig.getSurveyReferences(), deser.getSurveyReferences());
-        assertEquals(appConfig.getSchemaReferences(), deser.getSchemaReferences());
-        assertEquals(appConfig.getConfigReferences(), deser.getConfigReferences());
-        assertEquals(appConfig.getConfigElements(), deser.getConfigElements());
-        assertEquals(appConfig.getCreatedOn(), deser.getCreatedOn());
-        assertEquals(appConfig.getModifiedOn(), deser.getModifiedOn());
-        assertEquals(appConfig.getGuid(), deser.getGuid());
-        assertEquals(appConfig.getVersion(), deser.getVersion());
-        assertEquals(appConfig.isDeleted(), deser.isDeleted());
+        assertEquals(deser.getClientData(), clientData);
+        assertEquals(deser.getConfigElements().get("config1"), clientData);
+        assertEquals(deser.getCriteria(), appConfig.getCriteria());
+        assertEquals(deser.getLabel(), appConfig.getLabel());
+        assertEquals(deser.getSurveyReferences(), appConfig.getSurveyReferences());
+        assertEquals(deser.getSchemaReferences(), appConfig.getSchemaReferences());
+        assertEquals(deser.getConfigReferences(), appConfig.getConfigReferences());
+        assertEquals(deser.getConfigElements(), appConfig.getConfigElements());
+        assertEquals(deser.getCreatedOn(), appConfig.getCreatedOn());
+        assertEquals(deser.getModifiedOn(), appConfig.getModifiedOn());
+        assertEquals(deser.getGuid(), appConfig.getGuid());
+        assertEquals(deser.getVersion(), appConfig.getVersion());
+        assertEquals(deser.isDeleted(), appConfig.isDeleted());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoBackfillTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoBackfillTaskTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.models.backfill.BackfillStatus;
 
 public class DynamoBackfillTaskTest {
@@ -16,10 +17,10 @@ public class DynamoBackfillTaskTest {
     public void test() {
         final long timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
         DynamoBackfillTask task = new DynamoBackfillTask("name", "user");
-        assertEquals("name", task.getName());
-        assertEquals("user", task.getUser());
+        assertEquals(task.getName(), "name");
+        assertEquals(task.getUser(), "user");
         assertTrue(task.getTimestamp() >= timestamp);
-        assertEquals(BackfillStatus.SUBMITTED.name(), task.getStatus());
+        assertEquals(task.getStatus(), BackfillStatus.SUBMITTED.name());
     }
 
     @Test
@@ -29,11 +30,11 @@ public class DynamoBackfillTaskTest {
         String id = task.getId();
         assertNotNull(id);
         String[] splits =id.split(":");
-        assertEquals(2, splits.length);
-        assertEquals("name", splits[0]);
+        assertEquals(splits.length, 2);
+        assertEquals(splits[0], "name");
         assertTrue(Long.parseLong(splits[1]) >= timestamp);
         task = new DynamoBackfillTask(id);
-        assertEquals("name", task.getName());
+        assertEquals(task.getName(), "name");
         assertNull(task.getUser());
         assertTrue(task.getTimestamp() >= timestamp);
         assertNull(task.getStatus());

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
@@ -1,16 +1,17 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivity;
@@ -37,9 +38,9 @@ public class DynamoCompoundActivityDefinitionTest {
         def.setTaskId(TASK_ID);
 
         CompoundActivity compoundActivity = def.getCompoundActivity();
-        assertEquals(SCHEMA_LIST, compoundActivity.getSchemaList());
-        assertEquals(SURVEY_LIST, compoundActivity.getSurveyList());
-        assertEquals(TASK_ID, compoundActivity.getTaskIdentifier());
+        assertEquals(compoundActivity.getSchemaList(), SCHEMA_LIST);
+        assertEquals(compoundActivity.getSurveyList(), SURVEY_LIST);
+        assertEquals(compoundActivity.getTaskIdentifier(), TASK_ID);
     }
 
     @Test
@@ -64,11 +65,11 @@ public class DynamoCompoundActivityDefinitionTest {
         originalSurveyList.add(JKL_SURVEY);
 
         // verify that the lists in the def are unchanged
-        assertEquals(1, def.getSchemaList().size());
-        assertEquals(FOO_SCHEMA, def.getSchemaList().get(0));
+        assertEquals(def.getSchemaList().size(), 1);
+        assertEquals(def.getSchemaList().get(0), FOO_SCHEMA);
         assertListIsImmutable(def.getSchemaList(), BAR_SCHEMA);
-        assertEquals(1, def.getSurveyList().size());
-        assertEquals(ASDF_SURVEY, def.getSurveyList().get(0));
+        assertEquals(def.getSurveyList().size(), 1);
+        assertEquals(def.getSurveyList().get(0), ASDF_SURVEY);
         assertListIsImmutable(def.getSurveyList(), JKL_SURVEY);
 
         // set lists to null, validate that lists are still empty and immutable
@@ -102,43 +103,43 @@ public class DynamoCompoundActivityDefinitionTest {
         // convert to POJO - deserialize it as the base type, so we know it works with the base type
         DynamoCompoundActivityDefinition def = (DynamoCompoundActivityDefinition) BridgeObjectMapper.get().readValue(
                 jsonText, CompoundActivityDefinition.class);
-        assertEquals("test-study", def.getStudyId());
-        assertEquals("test-task", def.getTaskId());
-        assertEquals(42, def.getVersion().longValue());
+        assertEquals(def.getStudyId(), "test-study");
+        assertEquals(def.getTaskId(), "test-task");
+        assertEquals(def.getVersion().longValue(), 42);
 
         List<SchemaReference> outputSchemaList = def.getSchemaList();
-        assertEquals(2, outputSchemaList.size());
-        assertEquals(FOO_SCHEMA, outputSchemaList.get(0));
-        assertEquals(BAR_SCHEMA, outputSchemaList.get(1));
+        assertEquals(outputSchemaList.size(), 2);
+        assertEquals(outputSchemaList.get(0), FOO_SCHEMA);
+        assertEquals(outputSchemaList.get(1), BAR_SCHEMA);
 
         List<SurveyReference> outputSurveyList = def.getSurveyList();
-        assertEquals(2, outputSurveyList.size());
-        assertEquals(ASDF_SURVEY, outputSurveyList.get(0));
-        assertEquals(JKL_SURVEY, outputSurveyList.get(1));
+        assertEquals(outputSurveyList.size(), 2);
+        assertEquals(outputSurveyList.get(0), ASDF_SURVEY);
+        assertEquals(outputSurveyList.get(1), JKL_SURVEY);
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(def, JsonNode.class);
-        assertEquals(6, jsonNode.size());
-        assertEquals("test-study", jsonNode.get("studyId").textValue());
-        assertEquals("test-task", jsonNode.get("taskId").textValue());
-        assertEquals(42, jsonNode.get("version").intValue());
-        assertEquals("CompoundActivityDefinition", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 6);
+        assertEquals(jsonNode.get("studyId").textValue(), "test-study");
+        assertEquals(jsonNode.get("taskId").textValue(), "test-task");
+        assertEquals(jsonNode.get("version").intValue(), 42);
+        assertEquals(jsonNode.get("type").textValue(), "CompoundActivityDefinition");
 
         // For the lists, this is already tested by the encapsulated classes. Just verify that we have a list of the
         // right size.
         assertTrue(jsonNode.get("schemaList").isArray());
-        assertEquals(2, jsonNode.get("schemaList").size());
+        assertEquals(jsonNode.get("schemaList").size(), 2);
 
         assertTrue(jsonNode.get("surveyList").isArray());
-        assertEquals(2, jsonNode.get("surveyList").size());
+        assertEquals(jsonNode.get("surveyList").size(), 2);
 
         // convert to JSON using the PUBLIC_DEFINITION_WRITER
         // For simplicity, just test that study ID is absent and the other major key values are present
         String publicJsonText = CompoundActivityDefinition.PUBLIC_DEFINITION_WRITER.writeValueAsString(def);
         JsonNode publicJsonNode = BridgeObjectMapper.get().readTree(publicJsonText);
         assertNull(publicJsonNode.get("studyId"));
-        assertEquals("test-task", publicJsonNode.get("taskId").textValue());
-        assertEquals("CompoundActivityDefinition", publicJsonNode.get("type").textValue());
+        assertEquals(publicJsonNode.get("taskId").textValue(), "test-task");
+        assertEquals(publicJsonNode.get("type").textValue(), "CompoundActivityDefinition");
     }
 
     private static <T> void assertListIsImmutable(List<T> list, T objToAdd) {

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCriteriaTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Map;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.AppVersionHelper;
 import org.sagebionetworks.bridge.TestUtils;
@@ -47,36 +47,36 @@ public class DynamoCriteriaTest {
         criteria.setLanguage("fr");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(criteria);
-        assertEquals("fr", node.get("language").asText());
-        assertEquals(SET_A, JsonUtils.asStringSet(node, "allOfGroups"));
-        assertEquals(SET_B, JsonUtils.asStringSet(node, "noneOfGroups"));
-        assertEquals(SET_A, JsonUtils.asStringSet(node, "allOfSubstudyIds"));
-        assertEquals(SET_B, JsonUtils.asStringSet(node, "noneOfSubstudyIds"));
+        assertEquals(node.get("language").asText(), "fr");
+        assertEquals(JsonUtils.asStringSet(node, "allOfGroups"), SET_A);
+        assertEquals(JsonUtils.asStringSet(node, "noneOfGroups"), SET_B);
+        assertEquals(JsonUtils.asStringSet(node, "allOfSubstudyIds"), SET_A);
+        assertEquals(JsonUtils.asStringSet(node, "noneOfSubstudyIds"), SET_B);
         
         JsonNode minValues = node.get("minAppVersions");
-        assertEquals(2, minValues.get(IOS).asInt());
-        assertEquals(10, minValues.get(ANDROID).asInt());
+        assertEquals(minValues.get(IOS).asInt(), 2);
+        assertEquals(minValues.get(ANDROID).asInt(), 10);
         
         JsonNode maxValues = node.get("maxAppVersions");
-        assertEquals(8, maxValues.get(IOS).asInt());
-        assertEquals(15, maxValues.get(ANDROID).asInt());
+        assertEquals(maxValues.get(IOS).asInt(), 8);
+        assertEquals(maxValues.get(ANDROID).asInt(), 15);
         
-        assertEquals("Criteria", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "Criteria");
         assertNull(node.get("key"));
-        assertEquals(8, node.size()); // Nothing else is serialized here. (That's important.)
+        assertEquals(node.size(), 8); // Nothing else is serialized here. (That's important.)
         
         // However, we will except the older variant of JSON for the time being
         String json = makeJson("{'minAppVersion':2,'maxAppVersion':8,'language':'de','allOfGroups':['a','b'],"+
         "'noneOfGroups':['c','d'],'allOfSubstudyIds':['a','b'],'noneOfSubstudyIds':['c','d']}");
         
         Criteria crit = BridgeObjectMapper.get().readValue(json, Criteria.class);
-        assertEquals(new Integer(2), crit.getMinAppVersion(IOS));
-        assertEquals(new Integer(8), crit.getMaxAppVersion(IOS));
-        assertEquals("de", crit.getLanguage());
-        assertEquals(SET_A, crit.getAllOfGroups());
-        assertEquals(SET_B, crit.getNoneOfGroups());
-        assertEquals(SET_A, crit.getAllOfSubstudyIds());
-        assertEquals(SET_B, crit.getNoneOfSubstudyIds());
+        assertEquals(crit.getMinAppVersion(IOS), new Integer(2));
+        assertEquals(crit.getMaxAppVersion(IOS), new Integer(8));
+        assertEquals(crit.getLanguage(), "de");
+        assertEquals(crit.getAllOfGroups(), SET_A);
+        assertEquals(crit.getNoneOfGroups(), SET_B);
+        assertEquals(crit.getAllOfSubstudyIds(), SET_A);
+        assertEquals(crit.getNoneOfSubstudyIds(), SET_B);
         assertNull(crit.getKey());
     }
 
@@ -106,11 +106,11 @@ public class DynamoCriteriaTest {
         criteria.setMinAppVersion(IOS, 8);
         criteria.setMinAppVersion(4);
         // Using legacy setter does not set value if it already exists in the map
-        assertEquals(new Integer(8), criteria.getMinAppVersion(IOS));
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(8));
         
         // But of course you can update the value in the map
         criteria.setMinAppVersion(IOS, 10);
-        assertEquals(new Integer(10), criteria.getMinAppVersion(IOS));
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(10));
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthCodeDaoTest.java
@@ -1,22 +1,20 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoHealthCodeDaoTest {
 
     @Mock
@@ -27,8 +25,9 @@ public class DynamoHealthCodeDaoTest {
     
     private DynamoHealthCodeDao healthCodeDao;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         healthCodeDao = new DynamoHealthCodeDao();
         healthCodeDao.setMapper(mapper);
     }
@@ -46,8 +45,8 @@ public class DynamoHealthCodeDaoTest {
         
         verify(mapper).load(codeCaptor.capture());
         
-        assertEquals("studyId", result);
-        assertEquals("healthCode", codeCaptor.getValue().getCode());
+        assertEquals(result, "studyId");
+        assertEquals(codeCaptor.getValue().getCode(), "healthCode");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,8 +24,8 @@ import com.amazonaws.services.dynamodbv2.document.internal.IteratorSupport;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
@@ -51,7 +51,7 @@ public class DynamoHealthDataDaoTest {
         // validate that the returned ID matches the ID received by the DDB mapper
         ArgumentCaptor<DynamoHealthDataRecord> arg = ArgumentCaptor.forClass(DynamoHealthDataRecord.class);
         verify(mockMapper).save(arg.capture());
-        assertEquals(id, arg.getValue().getId());
+        assertEquals(arg.getValue().getId(), id);
     }
 
     @Test
@@ -81,12 +81,12 @@ public class DynamoHealthDataDaoTest {
         dao.setMapper(mockMapper);
         dao.setHealthCodeIndex(mockIndexHelper);
         int numDeleted = dao.deleteRecordsForHealthCode("test health code");
-        assertEquals(1, numDeleted);
+        assertEquals(numDeleted, 1);
 
         // validate intermediate results
         List<HealthDataRecord> recordKeyList = arg.getValue();
-        assertEquals(1, recordKeyList.size());
-        assertEquals("test ID", recordKeyList.get(0).getId());
+        assertEquals(recordKeyList.size(), 1);
+        assertEquals(recordKeyList.get(0).getId(), "test ID");
     }
 
     @Test
@@ -134,8 +134,8 @@ public class DynamoHealthDataDaoTest {
 
         // validate intermediate results
         List<HealthDataRecord> recordKeyList = arg.getValue();
-        assertEquals(1, recordKeyList.size());
-        assertEquals("error record", recordKeyList.get(0).getId());
+        assertEquals(recordKeyList.size(), 1);
+        assertEquals(recordKeyList.get(0).getId(), "error record");
     }
 
     @Test
@@ -174,7 +174,7 @@ public class DynamoHealthDataDaoTest {
         // Execute and validate.
         List<HealthDataRecord> retVal = dao.getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, TEST_CREATED_ON,
                 TEST_CREATED_ON_END);
-        assertEquals(1, retVal.size());
+        assertEquals(retVal.size(), 1);
         assertSame(record, retVal.get(0));
 
         // Verify query.
@@ -182,13 +182,13 @@ public class DynamoHealthDataDaoTest {
         verify(mockMapper).queryPage(eq(DynamoHealthDataRecord.class), queryCaptor.capture());
 
         DynamoDBQueryExpression<DynamoHealthDataRecord> query = queryCaptor.getValue();
-        assertEquals(TEST_HEALTH_CODE, query.getHashKeyValues().getHealthCode());
+        assertEquals(query.getHashKeyValues().getHealthCode(), TEST_HEALTH_CODE);
         assertFalse(query.isConsistentRead());
-        assertEquals(BridgeConstants.DUPE_RECORDS_MAX_COUNT, query.getLimit().intValue());
+        assertEquals(query.getLimit().intValue(), BridgeConstants.DUPE_RECORDS_MAX_COUNT);
 
         Condition rangeKeyCondition = query.getRangeKeyConditions().get("createdOn");
-        assertEquals(ComparisonOperator.BETWEEN.toString(), rangeKeyCondition.getComparisonOperator());
-        assertEquals(String.valueOf(TEST_CREATED_ON), rangeKeyCondition.getAttributeValueList().get(0).getN());
-        assertEquals(String.valueOf(TEST_CREATED_ON_END), rangeKeyCondition.getAttributeValueList().get(1).getN());
+        assertEquals(rangeKeyCondition.getComparisonOperator(), ComparisonOperator.BETWEEN.toString());
+        assertEquals(rangeKeyCondition.getAttributeValueList().get(0).getN(), String.valueOf(TEST_CREATED_ON));
+        assertEquals(rangeKeyCondition.getAttributeValueList().get(1).getN(), String.valueOf(TEST_CREATED_ON_END));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataDaoTest.java
@@ -150,7 +150,7 @@ public class DynamoHealthDataDaoTest {
 
         // execute and validate
         List<HealthDataRecord> retVal = dao.getRecordsForUploadDate("2015-02-11");
-        assertSame(mockResult, retVal);
+        assertSame(retVal, mockResult);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class DynamoHealthDataDaoTest {
         List<HealthDataRecord> retVal = dao.getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, TEST_CREATED_ON,
                 TEST_CREATED_ON_END);
         assertEquals(retVal.size(), 1);
-        assertSame(record, retVal.get(0));
+        assertSame(retVal.get(0), record);
 
         // Verify query.
         ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoIndexHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoIndexHelperTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import javax.annotation.Nonnull;
 
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class DynamoIndexHelperTest {
@@ -66,9 +66,9 @@ public class DynamoIndexHelperTest {
 
         @Override
         protected Iterable<Item> queryHelper(@Nonnull String indexKeyName, @Nonnull Object indexKeyValue, RangeKeyCondition rangeKeyCondition) {
-            assertEquals(expectedKey, indexKeyName);
-            assertEquals(expectedValue, indexKeyValue);
-            assertEquals(expectedRangeKeyCondition, rangeKeyCondition);
+            assertEquals(indexKeyName, expectedKey);
+            assertEquals(indexKeyValue, expectedValue);
+            assertEquals(rangeKeyCondition, expectedRangeKeyCondition);
             return itemIterable;
         }
     }
@@ -126,17 +126,17 @@ public class DynamoIndexHelperTest {
 
         // Validate final results. Because of wonkiness with maps and ordering, we'll convert the Things into a map and
         // validate the map.
-        assertEquals(4, resultList.size());
+        assertEquals(resultList.size(), 4);
         Map<String, String> thingMap = new HashMap<>();
         for (Thing oneThing : resultList) {
             thingMap.put(oneThing.key, oneThing.value);
         }
 
-        assertEquals(4, thingMap.size());
-        assertEquals("foo value", thingMap.get("foo key"));
-        assertEquals("bar value", thingMap.get("bar key"));
-        assertEquals("asdf value", thingMap.get("asdf key"));
-        assertEquals("jkl; value", thingMap.get("jkl; key"));
+        assertEquals(thingMap.size(), 4);
+        assertEquals(thingMap.get("foo key"), "foo value");
+        assertEquals(thingMap.get("bar key"), "bar value");
+        assertEquals(thingMap.get("asdf key"), "asdf value");
+        assertEquals(thingMap.get("jkl; key"), "jkl; value");
     }
     
     @Test
@@ -144,7 +144,7 @@ public class DynamoIndexHelperTest {
         mockResultsOfQuery(null);
         int count = helper.queryKeyCount("test key", "test value", null);
         // There are two lists of two items each
-        assertEquals(4, count);
+        assertEquals(count, 4);
     }
     
     @Test
@@ -167,23 +167,23 @@ public class DynamoIndexHelperTest {
         
         QueryOutcome result = helper.query(spec);
         
-        assertEquals(result, mockQueryOutcome);
+        assertEquals(mockQueryOutcome, result);
         verify(mockIndex).query(spec);
     }
 
     private static void validateKeyObjects(List<Thing> keyList) {
-        assertEquals(4, keyList.size());
+        assertEquals(keyList.size(), 4);
 
-        assertEquals("foo key", keyList.get(0).key);
+        assertEquals(keyList.get(0).key, "foo key");
         assertNull(keyList.get(0).value);
 
-        assertEquals("bar key", keyList.get(1).key);
+        assertEquals(keyList.get(1).key, "bar key");
         assertNull(keyList.get(1).value);
 
-        assertEquals("asdf key", keyList.get(2).key);
+        assertEquals(keyList.get(2).key, "asdf key");
         assertNull(keyList.get(2).value);
 
-        assertEquals("jkl; key", keyList.get(3).key);
+        assertEquals(keyList.get(3).key, "jkl; key");
         assertNull(keyList.get(3).value);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -95,6 +95,8 @@ public class DynamoNotificationRegistrationDaoTest {
     
     @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         dao = new DynamoNotificationRegistrationDao();
         dao.setNotificationRegistrationMapper(mockMapper);
         dao.setSnsClient(mockSnsClient);
@@ -146,7 +148,7 @@ public class DynamoNotificationRegistrationDaoTest {
         assertNull(snsRequest.getCustomUserData());
         
         assertNotNull(result.getGuid());
-        assertNotEquals(GUID, result.getGuid());
+        assertNotEquals(result.getGuid(), GUID);
         
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         
@@ -199,12 +201,12 @@ public class DynamoNotificationRegistrationDaoTest {
         assertEquals(savedRegistration.getHealthCode(), HEALTH_CODE);
         assertEquals(savedRegistration.getProtocol(), NotificationProtocol.SMS);
         assertEquals(savedRegistration.getEndpoint(), PHONE_ENDPOINT);
-        assertNotEquals(GUID, savedRegistration.getGuid());
+        assertNotEquals(savedRegistration.getGuid(), GUID);
         assertTrue(savedRegistration.getCreatedOn() > 0L);
-        assertNotEquals(CREATED_ON, savedRegistration.getCreatedOn());
+        assertNotEquals(savedRegistration.getCreatedOn(), CREATED_ON);
         assertTrue(savedRegistration.getModifiedOn() > 0L);
 
-        assertSame(result, savedRegistration);
+        assertSame(savedRegistration, result);
     }
 
     @Test
@@ -228,7 +230,7 @@ public class DynamoNotificationRegistrationDaoTest {
         assertEquals(savedRegistration.getCreatedOn(), CREATED_ON);
         assertTrue(savedRegistration.getModifiedOn() > 0L);
 
-        assertSame(result, savedRegistration);
+        assertSame(savedRegistration, result);
     }
 
     @Test
@@ -277,7 +279,7 @@ public class DynamoNotificationRegistrationDaoTest {
         NotificationRegistration registrationToUpdate = getSmsNotificationRegistration();
         registrationToUpdate.setGuid(GUID);
         NotificationRegistration result = dao.updateRegistration(registrationToUpdate);
-        assertSame(existingRegistration, result);
+        assertSame(result, existingRegistration);
 
         // No back-ends called.
         verifyZeroInteractions(mockSnsClient);
@@ -297,7 +299,7 @@ public class DynamoNotificationRegistrationDaoTest {
         doReturn(mockGetEndpointAttributesResult).when(mockSnsClient).getEndpointAttributes(any());
         
         NotificationRegistration result = dao.updateRegistration(registration);
-        assertSame(registration, result);
+        assertSame(result, registration);
         
         verify(mockSnsClient, never()).setEndpointAttributes(any());
         verify(mockMapper, never()).save(any());
@@ -334,7 +336,7 @@ public class DynamoNotificationRegistrationDaoTest {
         assertEquals(persisted.getDeviceId(), DEVICE_ID);
         assertEquals(persisted.getOsName(), OS_NAME);
         assertEquals(persisted.getCreatedOn(), CREATED_ON);
-        assertNotEquals(MODIFIED_ON, persisted.getModifiedOn()); // modified is changed
+        assertNotEquals(persisted.getModifiedOn(), MODIFIED_ON); // modified is changed
         assertTrue(persisted.getModifiedOn() > 0L);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationDaoTest.java
@@ -1,12 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doReturn;
@@ -15,18 +8,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationRegistration;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -50,7 +49,6 @@ import com.google.common.collect.Maps;
  * registrations across all environments. Using mocks for this DAO test instead (DynamoDB is a 
  * known system at this point so mock tests are OK).
  */
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoNotificationRegistrationDaoTest {
 
     private static final String PLATFORM_ARN = "platformARN";
@@ -95,7 +93,7 @@ public class DynamoNotificationRegistrationDaoTest {
     @Captor
     ArgumentCaptor<DynamoDBQueryExpression<DynamoNotificationRegistration>> queryCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
         dao = new DynamoNotificationRegistrationDao();
         dao.setNotificationRegistrationMapper(mockMapper);
@@ -108,9 +106,9 @@ public class DynamoNotificationRegistrationDaoTest {
 
         List<NotificationRegistration> list = dao.listRegistrations(HEALTH_CODE);
         
-        assertEquals(2, list.size());
+        assertEquals(list.size(), 2);
         DynamoDBQueryExpression<DynamoNotificationRegistration> query = queryCaptor.getValue();
-        assertEquals(HEALTH_CODE, query.getHashKeyValues().getHealthCode());
+        assertEquals(query.getHashKeyValues().getHealthCode(), HEALTH_CODE);
     }
     
     // Opted here to return an empty list, as it's a list operation and we're not asking for specific registration
@@ -120,9 +118,9 @@ public class DynamoNotificationRegistrationDaoTest {
 
         List<NotificationRegistration> list = dao.listRegistrations(HEALTH_CODE);
         
-        assertEquals(0, list.size());
+        assertEquals(list.size(), 0);
         DynamoDBQueryExpression<DynamoNotificationRegistration> query = queryCaptor.getValue();
-        assertEquals(HEALTH_CODE, query.getHashKeyValues().getHealthCode());
+        assertEquals(query.getHashKeyValues().getHealthCode(), HEALTH_CODE);
     }
     
     @Test
@@ -143,8 +141,8 @@ public class DynamoNotificationRegistrationDaoTest {
         verify(mockSnsClient).createPlatformEndpoint(createPlatformEndpointRequestCaptor.capture());
         
         CreatePlatformEndpointRequest snsRequest = createPlatformEndpointRequestCaptor.getValue();
-        assertEquals(PLATFORM_ARN, snsRequest.getPlatformApplicationArn());
-        assertEquals(DEVICE_ID, snsRequest.getToken());
+        assertEquals(snsRequest.getPlatformApplicationArn(), PLATFORM_ARN);
+        assertEquals(snsRequest.getToken(), DEVICE_ID);
         assertNull(snsRequest.getCustomUserData());
         
         assertNotNull(result.getGuid());
@@ -153,11 +151,11 @@ public class DynamoNotificationRegistrationDaoTest {
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         
         NotificationRegistration reg = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, reg.getHealthCode());
-        assertEquals(result.getGuid(), reg.getGuid());
-        assertEquals(PUSH_NOTIFICATION_ENDPOINT_ARN, reg.getEndpoint());
-        assertEquals(DEVICE_ID, reg.getDeviceId());
-        assertEquals(OperatingSystem.IOS, reg.getOsName());
+        assertEquals(reg.getHealthCode(), HEALTH_CODE);
+        assertEquals(reg.getGuid(), result.getGuid());
+        assertEquals(reg.getEndpoint(), PUSH_NOTIFICATION_ENDPOINT_ARN);
+        assertEquals(reg.getDeviceId(), DEVICE_ID);
+        assertEquals(reg.getOsName(), OperatingSystem.IOS);
         assertTrue(reg.getCreatedOn() > 0L);
         assertTrue(reg.getModifiedOn() > 0L);
     }
@@ -178,13 +176,13 @@ public class DynamoNotificationRegistrationDaoTest {
         
         NotificationRegistration result = dao.createPushNotificationRegistration(PLATFORM_ARN, registration);
         
-        assertEquals(GUID, result.getGuid());
+        assertEquals(result.getGuid(), GUID);
         
         // The save needs to use the same GUID and HEALTH_CODE or it'll be a duplicate
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         NotificationRegistration reg = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, reg.getHealthCode());
-        assertEquals(GUID, reg.getGuid());
+        assertEquals(reg.getHealthCode(), HEALTH_CODE);
+        assertEquals(reg.getGuid(), GUID);
     }
 
     @Test
@@ -198,9 +196,9 @@ public class DynamoNotificationRegistrationDaoTest {
         // Validate saved registration.
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         NotificationRegistration savedRegistration = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, savedRegistration.getHealthCode());
-        assertEquals(NotificationProtocol.SMS, savedRegistration.getProtocol());
-        assertEquals(PHONE_ENDPOINT, savedRegistration.getEndpoint());
+        assertEquals(savedRegistration.getHealthCode(), HEALTH_CODE);
+        assertEquals(savedRegistration.getProtocol(), NotificationProtocol.SMS);
+        assertEquals(savedRegistration.getEndpoint(), PHONE_ENDPOINT);
         assertNotEquals(GUID, savedRegistration.getGuid());
         assertTrue(savedRegistration.getCreatedOn() > 0L);
         assertNotEquals(CREATED_ON, savedRegistration.getCreatedOn());
@@ -223,11 +221,11 @@ public class DynamoNotificationRegistrationDaoTest {
         // Validate saved registration.
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         NotificationRegistration savedRegistration = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, savedRegistration.getHealthCode());
-        assertEquals(NotificationProtocol.SMS, savedRegistration.getProtocol());
-        assertEquals(PHONE_ENDPOINT, savedRegistration.getEndpoint());
-        assertEquals(GUID, savedRegistration.getGuid());
-        assertEquals(CREATED_ON, savedRegistration.getCreatedOn());
+        assertEquals(savedRegistration.getHealthCode(), HEALTH_CODE);
+        assertEquals(savedRegistration.getProtocol(), NotificationProtocol.SMS);
+        assertEquals(savedRegistration.getEndpoint(), PHONE_ENDPOINT);
+        assertEquals(savedRegistration.getGuid(), GUID);
+        assertEquals(savedRegistration.getCreatedOn(), CREATED_ON);
         assertTrue(savedRegistration.getModifiedOn() > 0L);
 
         assertSame(result, savedRegistration);
@@ -242,9 +240,9 @@ public class DynamoNotificationRegistrationDaoTest {
         
         verify(mockMapper).load(notificationRegistrationCaptor.capture());
         NotificationRegistration hashKey = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, hashKey.getHealthCode());
-        assertEquals(GUID, hashKey.getGuid());
-        assertEquals(registration, returned);
+        assertEquals(hashKey.getHealthCode(), HEALTH_CODE);
+        assertEquals(hashKey.getGuid(), GUID);
+        assertEquals(returned, registration);
     }
     
     @Test
@@ -255,11 +253,11 @@ public class DynamoNotificationRegistrationDaoTest {
             dao.getRegistration(HEALTH_CODE, GUID);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
-            assertEquals("NotificationRegistration not found.", e.getMessage());
+            assertEquals(e.getMessage(), "NotificationRegistration not found.");
         }
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateNotExists() {
         // Mock mapper.
         when(mockMapper.load(any())).thenReturn(null);
@@ -321,21 +319,21 @@ public class DynamoNotificationRegistrationDaoTest {
         
         verify(mockSnsClient).setEndpointAttributes(setEndpointAttributesRequestCaptor.capture());
         SetEndpointAttributesRequest request = setEndpointAttributesRequestCaptor.getValue();
-        assertEquals(registration.getEndpoint(), request.getEndpointArn());
+        assertEquals(request.getEndpointArn(), registration.getEndpoint());
 
         Map<String,String> attributes = request.getAttributes();
-        assertEquals(DEVICE_ID, attributes.get("Token"));
-        assertEquals("true", attributes.get("Enabled"));
+        assertEquals(attributes.get("Token"), DEVICE_ID);
+        assertEquals(attributes.get("Enabled"), "true");
         assertNull(attributes.get("CustomUserData"));
         
         verify(mockMapper).save(notificationRegistrationCaptor.capture());
         NotificationRegistration persisted = notificationRegistrationCaptor.getValue();
-        assertEquals(GUID, persisted.getGuid());
-        assertEquals(HEALTH_CODE, persisted.getHealthCode());
-        assertEquals(PUSH_NOTIFICATION_ENDPOINT_ARN, persisted.getEndpoint());
-        assertEquals(DEVICE_ID, persisted.getDeviceId());
-        assertEquals(OS_NAME, persisted.getOsName());
-        assertEquals(CREATED_ON, persisted.getCreatedOn());
+        assertEquals(persisted.getGuid(), GUID);
+        assertEquals(persisted.getHealthCode(), HEALTH_CODE);
+        assertEquals(persisted.getEndpoint(), PUSH_NOTIFICATION_ENDPOINT_ARN);
+        assertEquals(persisted.getDeviceId(), DEVICE_ID);
+        assertEquals(persisted.getOsName(), OS_NAME);
+        assertEquals(persisted.getCreatedOn(), CREATED_ON);
         assertNotEquals(MODIFIED_ON, persisted.getModifiedOn()); // modified is changed
         assertTrue(persisted.getModifiedOn() > 0L);
     }
@@ -364,12 +362,12 @@ public class DynamoNotificationRegistrationDaoTest {
         
         verify(mockMapper).delete(notificationRegistrationCaptor.capture());
         NotificationRegistration del = notificationRegistrationCaptor.getValue();
-        assertEquals(GUID, del.getGuid());
-        assertEquals(HEALTH_CODE, del.getHealthCode());
+        assertEquals(del.getGuid(), GUID);
+        assertEquals(del.getHealthCode(), HEALTH_CODE);
         
         verify(mockSnsClient).deleteEndpoint(deleteEndpointRequestCaptor.capture());
         DeleteEndpointRequest request = deleteEndpointRequestCaptor.getValue();
-        assertEquals(PUSH_NOTIFICATION_ENDPOINT_ARN, request.getEndpointArn());
+        assertEquals(request.getEndpointArn(), PUSH_NOTIFICATION_ENDPOINT_ARN);
     }
     
     @Test
@@ -398,9 +396,9 @@ public class DynamoNotificationRegistrationDaoTest {
         // Verify DDB mapper.
         verify(mockMapper).delete(notificationRegistrationCaptor.capture());
         NotificationRegistration deletedRegistration = notificationRegistrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, deletedRegistration.getHealthCode());
-        assertEquals(NotificationProtocol.SMS, deletedRegistration.getProtocol());
-        assertEquals(PHONE_ENDPOINT, deletedRegistration.getEndpoint());
+        assertEquals(deletedRegistration.getHealthCode(), HEALTH_CODE);
+        assertEquals(deletedRegistration.getProtocol(), NotificationProtocol.SMS);
+        assertEquals(deletedRegistration.getEndpoint(), PHONE_ENDPOINT);
 
         // Verify we don't call SNS delete endpoint for SMS registrations.
         verify(mockSnsClient, never()).deleteEndpoint(any());

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationRegistrationTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.notifications.NotificationProtocol;
 import org.sagebionetworks.bridge.models.notifications.NotificationRegistration;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -28,11 +28,11 @@ public class DynamoNotificationRegistrationTest {
     public void defaultProtocol() {
         // Default value is protocol.
         DynamoNotificationRegistration reg = new DynamoNotificationRegistration();
-        assertEquals(NotificationProtocol.APPLICATION, reg.getProtocol());
+        assertEquals(reg.getProtocol(), NotificationProtocol.APPLICATION);
 
         // Set another value.
         reg.setProtocol(NotificationProtocol.SMS);
-        assertEquals(NotificationProtocol.SMS, reg.getProtocol());
+        assertEquals(reg.getProtocol(), NotificationProtocol.SMS);
     }
 
     @Test
@@ -48,15 +48,15 @@ public class DynamoNotificationRegistrationTest {
         reg.setModifiedOn(MODIFIED_ON);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(reg);
-        assertEquals(GUID, node.get("guid").asText());
-        assertEquals("sms", node.get("protocol").textValue());
-        assertEquals(ENDPOINT, node.get("endpoint").textValue());
-        assertEquals(DEVICE_ID, node.get("deviceId").asText());
-        assertEquals(OperatingSystem.ANDROID, node.get("osName").asText());
-        assertEquals(CREATED_ON_STRING, node.get("createdOn").asText());
-        assertEquals(MODIFIED_ON_STRING, node.get("modifiedOn").asText());
-        assertEquals("NotificationRegistration", node.get("type").asText());
-        assertEquals(8, node.size()); // and no other fields like healthCode;
+        assertEquals(node.get("guid").asText(), GUID);
+        assertEquals(node.get("protocol").textValue(), "sms");
+        assertEquals(node.get("endpoint").textValue(), ENDPOINT);
+        assertEquals(node.get("deviceId").asText(), DEVICE_ID);
+        assertEquals(node.get("osName").asText(), OperatingSystem.ANDROID);
+        assertEquals(node.get("createdOn").asText(), CREATED_ON_STRING);
+        assertEquals(node.get("modifiedOn").asText(), MODIFIED_ON_STRING);
+        assertEquals(node.get("type").asText(), "NotificationRegistration");
+        assertEquals(node.size(), 8); // and no other fields like healthCode;
         
         // In creating a registration, the deviceId, osName and sometimes the  guid, so these must 
         // deserialize correctly. Other fields will be set on the server.
@@ -64,9 +64,9 @@ public class DynamoNotificationRegistrationTest {
                 "'osName':'iPhone OS'}");
         
         NotificationRegistration deser = BridgeObjectMapper.get().readValue(json, NotificationRegistration.class);
-        assertEquals(GUID, deser.getGuid());
-        assertEquals(NotificationProtocol.SMS, deser.getProtocol());
-        assertEquals(DEVICE_ID, deser.getDeviceId());
-        assertEquals(OperatingSystem.IOS, deser.getOsName());
+        assertEquals(deser.getGuid(), GUID);
+        assertEquals(deser.getProtocol(), NotificationProtocol.SMS);
+        assertEquals(deser.getDeviceId(), DEVICE_ID);
+        assertEquals(deser.getOsName(), OperatingSystem.IOS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicDaoTest.java
@@ -3,12 +3,11 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationTopic;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -25,13 +24,12 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
@@ -50,7 +48,6 @@ import com.amazonaws.services.sns.model.CreateTopicResult;
 import com.amazonaws.services.sns.model.DeleteTopicRequest;
 import com.google.common.collect.Lists;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoNotificationTopicDaoTest {
     private static final Set<String> ALL_OF_GROUP_SET = ImmutableSet.of("group1", "group2");
     private static final String GUID_WITH_CRITERIA = "topic-guid-with-criteria";
@@ -58,8 +55,8 @@ public class DynamoNotificationTopicDaoTest {
     private static final String TOPIC_ARN = "topic-arn";
 
     private static void assertCriteria(String expectedTopicGuid, Criteria criteria) {
-        assertEquals(DynamoNotificationTopicDao.CRITERIA_KEY_PREFIX + expectedTopicGuid, criteria.getKey());
-        assertEquals(ALL_OF_GROUP_SET, criteria.getAllOfGroups());
+        assertEquals(criteria.getKey(), DynamoNotificationTopicDao.CRITERIA_KEY_PREFIX + expectedTopicGuid);
+        assertEquals(criteria.getAllOfGroups(), ALL_OF_GROUP_SET);
     }
 
     // Helper method to make a criteria. Note that we can't just make this a constant, because the DAO actually
@@ -97,8 +94,9 @@ public class DynamoNotificationTopicDaoTest {
     
     private DynamoNotificationTopicDao dao;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         // Mock criteria DAO.
         when(mockCriteriaDao.getCriteria(DynamoNotificationTopicDao.CRITERIA_KEY_PREFIX + GUID_WITH_CRITERIA))
                 .thenReturn(makeCriteria());
@@ -132,11 +130,11 @@ public class DynamoNotificationTopicDaoTest {
         // Verify DDB mapper.
         verify(mockMapper).save(topicCaptor.capture());
         DynamoNotificationTopic captured = topicCaptor.getValue();
-        assertEquals(topic.getName(), captured.getName());
-        assertEquals(topic.getDescription(), captured.getDescription());
-        assertEquals(topic.getStudyId(), captured.getStudyId());
-        assertEquals(TOPIC_ARN, captured.getTopicARN());
-        assertEquals(topic.getGuid(), captured.getGuid());
+        assertEquals(captured.getName(), topic.getName());
+        assertEquals(captured.getDescription(), topic.getDescription());
+        assertEquals(captured.getStudyId(), topic.getStudyId());
+        assertEquals(captured.getTopicARN(), TOPIC_ARN);
+        assertEquals(captured.getGuid(), topic.getGuid());
         assertTrue(captured.getCreatedOn() > 0);
         assertTrue(captured.getModifiedOn() > 0);
         // This was set by the methods. Can't be set by the caller.
@@ -185,19 +183,19 @@ public class DynamoNotificationTopicDaoTest {
         
         verify(mockMapper, times(2)).delete(topicCaptor.capture());
         NotificationTopic captured = topicCaptor.getAllValues().get(0);
-        assertEquals(topic1.getStudyId(), captured.getStudyId());
-        assertEquals(topic1.getGuid(), captured.getGuid());
+        assertEquals(captured.getStudyId(), topic1.getStudyId());
+        assertEquals(captured.getGuid(), topic1.getGuid());
         
         captured = topicCaptor.getAllValues().get(1);
-        assertEquals(topic2.getStudyId(), captured.getStudyId());
-        assertEquals(topic2.getGuid(), captured.getGuid());
+        assertEquals(captured.getStudyId(), topic2.getStudyId());
+        assertEquals(captured.getGuid(), topic2.getGuid());
         
         verify(mockSnsClient, times(2)).deleteTopic(deleteTopicRequestCaptor.capture());
         DeleteTopicRequest request = deleteTopicRequestCaptor.getAllValues().get(0);
-        assertEquals(topic1.getTopicARN(), request.getTopicArn());
+        assertEquals(request.getTopicArn(), topic1.getTopicARN());
         
         request = deleteTopicRequestCaptor.getAllValues().get(1);
-        assertEquals(topic2.getTopicARN(), request.getTopicArn());
+        assertEquals(request.getTopicArn(), topic2.getTopicARN());
     }
     
     @Test
@@ -211,7 +209,7 @@ public class DynamoNotificationTopicDaoTest {
         assertTrue(topicCaptor.getValue().isDeleted());
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteTopicAlreadyDeleted() {
         NotificationTopic existingTopic = getNotificationTopic();
         existingTopic.setDeleted(true);
@@ -220,7 +218,7 @@ public class DynamoNotificationTopicDaoTest {
         dao.deleteTopic(TEST_STUDY, "ABC-DEF");
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteTopicNotFound() {
         dao.deleteTopic(TEST_STUDY, "ABC-DEF");
     }
@@ -234,15 +232,15 @@ public class DynamoNotificationTopicDaoTest {
         
         verify(mockSnsClient).deleteTopic(deleteTopicRequestCaptor.capture());
         DeleteTopicRequest capturedRequest = deleteTopicRequestCaptor.getValue();
-        assertEquals(topic.getTopicARN(), capturedRequest.getTopicArn());
+        assertEquals(capturedRequest.getTopicArn(), topic.getTopicARN());
         
         verify(mockMapper).delete(topicCaptor.capture());
         NotificationTopic capturedTopic = topicCaptor.getValue();
-        assertEquals(TEST_STUDY_IDENTIFIER, capturedTopic.getStudyId());
-        assertEquals("anything", capturedTopic.getGuid());
+        assertEquals(capturedTopic.getStudyId(), TEST_STUDY_IDENTIFIER);
+        assertEquals(capturedTopic.getGuid(), "anything");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteTopicPermanentlyNotFound() {
         dao.deleteTopicPermanently(TEST_STUDY, "anything");
     }
@@ -270,17 +268,17 @@ public class DynamoNotificationTopicDaoTest {
         doReturn(topic).when(mockMapper).load(any());
         
         NotificationTopic updated = dao.getTopic(TEST_STUDY, topic.getGuid());
-        assertEquals(TEST_STUDY_IDENTIFIER, updated.getStudyId());
-        assertEquals("topicGuid", updated.getGuid());
+        assertEquals(updated.getStudyId(), TEST_STUDY_IDENTIFIER);
+        assertEquals(updated.getGuid(), "topicGuid");
         assertNull(updated.getCriteria());
         
         verify(mockMapper).load(topicCaptor.capture());
         DynamoNotificationTopic capturedTopic = topicCaptor.getValue();
-        assertEquals(updated.getStudyId(), capturedTopic.getStudyId());
-        assertEquals(updated.getGuid(), capturedTopic.getGuid());
+        assertEquals(capturedTopic.getStudyId(), updated.getStudyId());
+        assertEquals(capturedTopic.getGuid(), updated.getGuid());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getTopicNotFound() {
         dao.getTopic(TEST_STUDY, getNotificationTopic().getGuid());
     }
@@ -295,8 +293,8 @@ public class DynamoNotificationTopicDaoTest {
 
         // Execute and validate.
         NotificationTopic result = dao.getTopic(TEST_STUDY, GUID_WITH_CRITERIA);
-        assertEquals(TEST_STUDY_IDENTIFIER, result.getStudyId());
-        assertEquals(GUID_WITH_CRITERIA, result.getGuid());
+        assertEquals(result.getStudyId(), TEST_STUDY_IDENTIFIER);
+        assertEquals(result.getGuid(), GUID_WITH_CRITERIA);
         assertCriteria(GUID_WITH_CRITERIA, result.getCriteria());
     }
     
@@ -312,8 +310,8 @@ public class DynamoNotificationTopicDaoTest {
         
         // Query expression does include filter of deleted items.
         DynamoDBQueryExpression<DynamoNotificationTopic> capturedQuery = queryExpressionCaptor.getValue();
-        assertEquals("{AttributeValueList: [{N: 1,}],ComparisonOperator: NE}",
-                capturedQuery.getQueryFilter().get("deleted").toString());
+        assertEquals(capturedQuery.getQueryFilter().get("deleted").toString(),
+                "{AttributeValueList: [{N: 1,}],ComparisonOperator: NE}");
     }
     
     @Test
@@ -331,12 +329,12 @@ public class DynamoNotificationTopicDaoTest {
 
         // Execute and verify.
         List<NotificationTopic> topics = dao.listTopics(TEST_STUDY, true);
-        assertEquals(2, topics.size());
+        assertEquals(topics.size(), 2);
 
-        assertEquals(GUID_WITHOUT_CRITERIA, topics.get(0).getGuid());
+        assertEquals(topics.get(0).getGuid(), GUID_WITHOUT_CRITERIA);
         assertNull(topics.get(0).getCriteria());
 
-        assertEquals(GUID_WITH_CRITERIA, topics.get(1).getGuid());
+        assertEquals(topics.get(1).getGuid(), GUID_WITH_CRITERIA);
         assertCriteria(GUID_WITH_CRITERIA, topics.get(1).getCriteria());
 
         // Verify query.
@@ -344,7 +342,7 @@ public class DynamoNotificationTopicDaoTest {
         
         DynamoDBQueryExpression<DynamoNotificationTopic> capturedQuery = queryExpressionCaptor.getValue();
         DynamoNotificationTopic capturedTopic = capturedQuery.getHashKeyValues();
-        assertEquals(TEST_STUDY_IDENTIFIER, capturedTopic.getStudyId());
+        assertEquals(capturedTopic.getStudyId(), TEST_STUDY_IDENTIFIER);
         assertNull(capturedTopic.getGuid());
         assertNull(capturedQuery.getQueryFilter()); // deleted are not being filtered out
     }
@@ -414,16 +412,16 @@ public class DynamoNotificationTopicDaoTest {
         Thread.sleep(3); // forced modifiedOn to be different from timestamp
         
         NotificationTopic updated = dao.updateTopic(topic);
-        assertEquals("The updated name", updated.getName());
-        assertEquals("The updated description", updated.getDescription());
-        assertEquals(timestamp, updated.getCreatedOn());
+        assertEquals(updated.getName(), "The updated name");
+        assertEquals(updated.getDescription(), "The updated description");
+        assertEquals(updated.getCreatedOn(), timestamp);
         assertNotEquals(timestamp, updated.getModifiedOn());
         
         verify(mockMapper).save(topicCaptor.capture());
         NotificationTopic captured = topicCaptor.getValue();
-        assertEquals("The updated name", captured.getName());
-        assertEquals("The updated description", captured.getDescription());
-        assertEquals(topic.getTopicARN(), captured.getTopicARN());
+        assertEquals(captured.getName(), "The updated name");
+        assertEquals(captured.getDescription(), "The updated description");
+        assertEquals(captured.getTopicARN(), topic.getTopicARN());
     }
 
     @Test
@@ -475,7 +473,7 @@ public class DynamoNotificationTopicDaoTest {
         verify(mockCriteriaDao, never()).createOrUpdateCriteria(any());
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateTopicNotFound() {
         dao.updateTopic(getNotificationTopic());
     }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicDaoTest.java
@@ -138,7 +138,7 @@ public class DynamoNotificationTopicDaoTest {
         assertTrue(captured.getCreatedOn() > 0);
         assertTrue(captured.getModifiedOn() > 0);
         // This was set by the methods. Can't be set by the caller.
-        assertNotEquals(getNotificationTopic().getGuid(), captured.getGuid());
+        assertNotEquals(captured.getGuid(), getNotificationTopic().getGuid());
 
         // This topic has no criteria.
         assertNull(captured.getCriteria());
@@ -415,7 +415,7 @@ public class DynamoNotificationTopicDaoTest {
         assertEquals(updated.getName(), "The updated name");
         assertEquals(updated.getDescription(), "The updated description");
         assertEquals(updated.getCreatedOn(), timestamp);
-        assertNotEquals(timestamp, updated.getModifiedOn());
+        assertNotEquals(updated.getModifiedOn(), timestamp);
         
         verify(mockMapper).save(topicCaptor.capture());
         NotificationTopic captured = topicCaptor.getValue();

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicTest.java
@@ -71,7 +71,7 @@ public class DynamoNotificationTopicTest {
         assertEquals(deser.getGuid(), "ABC");
         assertEquals(deser.getName(), "My Test Topic");
         assertEquals(deser.getShortName(), "Test Topic");
-        assertNull("test-study", deser.getStudyId());
+        assertNull(deser.getStudyId(), "test-study");
         assertEquals(deser.getDescription(), "A description.");
         assertEquals(deser.getCreatedOn(), TIMESTAMP);
         assertEquals(deser.getModifiedOn(), TIMESTAMP);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoNotificationTopicTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -10,7 +10,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.Criteria;
@@ -43,40 +43,40 @@ public class DynamoNotificationTopicTest {
 
         // Serialize to JSON.
         JsonNode node = BridgeObjectMapper.get().valueToTree(topic);
-        assertEquals("ABC", node.get("guid").textValue());
-        assertEquals("My Test Topic", node.get("name").textValue());
-        assertEquals("Test Topic", node.get("shortName").textValue());
-        assertEquals("NotificationTopic", node.get("type").textValue());
-        assertEquals("A description.", node.get("description").textValue());
-        assertEquals(DATE_TIME.toString(), node.get("createdOn").textValue());
-        assertEquals(DATE_TIME.toString(), node.get("modifiedOn").textValue());
+        assertEquals(node.get("guid").textValue(), "ABC");
+        assertEquals(node.get("name").textValue(), "My Test Topic");
+        assertEquals(node.get("shortName").textValue(), "Test Topic");
+        assertEquals(node.get("type").textValue(), "NotificationTopic");
+        assertEquals(node.get("description").textValue(), "A description.");
+        assertEquals(node.get("createdOn").textValue(), DATE_TIME.toString());
+        assertEquals(node.get("modifiedOn").textValue(), DATE_TIME.toString());
         assertNull(node.get("studyId"));
         assertNull(node.get("topicARN"));
         assertTrue(node.get("deleted").booleanValue());
 
         JsonNode criteriaNode = node.get("criteria");
         JsonNode allOfGroupsNode = criteriaNode.get("allOfGroups");
-        assertEquals(2, allOfGroupsNode.size());
+        assertEquals(allOfGroupsNode.size(), 2);
 
         Set<String> allOfGroupsJsonSet = new HashSet<>();
         for (JsonNode oneAllOfGroupNode : allOfGroupsNode) {
             allOfGroupsJsonSet.add(oneAllOfGroupNode.textValue());
         }
-        assertEquals(criteria.getAllOfGroups(), allOfGroupsJsonSet);
+        assertEquals(allOfGroupsJsonSet, criteria.getAllOfGroups());
 
         // De-serialize back to POJO.
         // The values that are not serialized are provided by the service, they aren't
         // settable by the API caller.
         NotificationTopic deser = BridgeObjectMapper.get().readValue(node.toString(), NotificationTopic.class);
-        assertEquals("ABC", deser.getGuid());
-        assertEquals("My Test Topic", deser.getName());
-        assertEquals("Test Topic", deser.getShortName());
+        assertEquals(deser.getGuid(), "ABC");
+        assertEquals(deser.getName(), "My Test Topic");
+        assertEquals(deser.getShortName(), "Test Topic");
         assertNull("test-study", deser.getStudyId());
-        assertEquals("A description.", deser.getDescription());
-        assertEquals(TIMESTAMP, deser.getCreatedOn());
-        assertEquals(TIMESTAMP, deser.getModifiedOn());
+        assertEquals(deser.getDescription(), "A description.");
+        assertEquals(deser.getCreatedOn(), TIMESTAMP);
+        assertEquals(deser.getModifiedOn(), TIMESTAMP);
         assertNull(deser.getTopicARN());
-        assertEquals(criteria, deser.getCriteria());
+        assertEquals(deser.getCriteria(), criteria);
         assertTrue(deser.isDeleted());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoReportDataTest.java
@@ -1,18 +1,18 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportType;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -45,24 +45,24 @@ public class DynamoReportDataTest {
         
         JsonNode node = MAPPER.readTree(json);
         assertNull(node.get("key"));
-        assertEquals(DATETIME.toString(), node.get("date").textValue());
-        assertEquals(DATETIME.toString(), node.get("dateTime").textValue());
+        assertEquals(node.get("date").textValue(), DATETIME.toString());
+        assertEquals(node.get("dateTime").textValue(), DATETIME.toString());
         assertTrue(node.get("data").get("a").booleanValue());
-        assertEquals("string", node.get("data").get("b").textValue());
-        assertEquals(10, node.get("data").get("c").intValue());
-        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
-        assertEquals("substudyB", node.get("substudyIds").get(1).textValue());
-        assertEquals("ReportData", node.get("type").textValue());
-        assertEquals(5, node.size());
+        assertEquals(node.get("data").get("b").textValue(), "string");
+        assertEquals(node.get("data").get("c").intValue(), 10);
+        assertEquals(node.get("substudyIds").get(0).textValue(), "substudyA");
+        assertEquals(node.get("substudyIds").get(1).textValue(), "substudyB");
+        assertEquals(node.get("type").textValue(), "ReportData");
+        assertEquals(node.size(), 5);
         
         ReportData deser = MAPPER.readValue(json, ReportData.class);
         assertNull(deser.getKey());
-        assertEquals(DATETIME, deser.getDateTime());
-        assertEquals(DATETIME.toString(), deser.getDate());
+        assertEquals(deser.getDateTime(), DATETIME);
+        assertEquals(deser.getDate(), DATETIME.toString());
         assertTrue(deser.getData().get("a").asBoolean());
-        assertEquals("string", deser.getData().get("b").asText());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, deser.getSubstudyIds());
-        assertEquals(10, deser.getData().get("c").asInt());
+        assertEquals(deser.getData().get("b").asText(), "string");
+        assertEquals(deser.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(deser.getData().get("c").asInt(), 10);
     }
     
     @Test
@@ -72,14 +72,14 @@ public class DynamoReportDataTest {
         
         DynamoReportData report = new DynamoReportData();
         report.setLocalDate(localDate);
-        assertEquals(localDate.toString(), report.getDate());
-        assertEquals(localDate, report.getLocalDate());
+        assertEquals(report.getDate(), localDate.toString());
+        assertEquals(report.getLocalDate(), localDate);
         assertNull(report.getDateTime());
         
         report = new DynamoReportData();
         report.setDateTime(dateTime);
-        assertEquals(dateTime.toString(), report.getDate());
-        assertEquals(dateTime, report.getDateTime());
+        assertEquals(report.getDate(), dateTime.toString());
+        assertEquals(report.getDateTime(), dateTime);
         assertNull(report.getLocalDate());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoReportIndexDaoMockTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -14,13 +14,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -37,7 +36,6 @@ import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.google.common.collect.ImmutableList;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoReportIndexDaoMockTest {
 
     DynamoReportIndexDao dao;
@@ -64,8 +62,9 @@ public class DynamoReportIndexDaoMockTest {
             .withIdentifier("report-name").withStudyIdentifier(TEST_STUDY)
             .withReportType(ReportType.STUDY).build();
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao = new DynamoReportIndexDao();
         dao.setReportIndexMapper(mapper);
     }
@@ -77,8 +76,8 @@ public class DynamoReportIndexDaoMockTest {
         verify(mapper).load(loadIndexCaptor.capture());
         
         DynamoReportIndex index = loadIndexCaptor.getValue();
-        assertEquals(KEY.getIndexKeyString(), index.getKey());
-        assertEquals(KEY.getIdentifier(), index.getIdentifier());
+        assertEquals(index.getKey(), KEY.getIndexKeyString());
+        assertEquals(index.getIdentifier(), KEY.getIdentifier());
     }
 
     @Test
@@ -89,14 +88,14 @@ public class DynamoReportIndexDaoMockTest {
         verify(mapper).save(saveIndexCaptor.capture(), eq(DynamoReportIndexDao.DOES_NOT_EXIST_EXPRESSION));
         
         DynamoReportIndex lookupKey = loadIndexCaptor.getValue();
-        assertEquals(KEY.getIndexKeyString(), lookupKey.getKey());
-        assertEquals(KEY.getIdentifier(), lookupKey.getIdentifier());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, lookupKey.getSubstudyIds());
+        assertEquals(lookupKey.getKey(), KEY.getIndexKeyString());
+        assertEquals(lookupKey.getIdentifier(), KEY.getIdentifier());
+        assertEquals(lookupKey.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
         
         DynamoReportIndex savedIndex = saveIndexCaptor.getValue();
-        assertEquals(KEY.getIndexKeyString(), savedIndex.getKey());
-        assertEquals(KEY.getIdentifier(), savedIndex.getIdentifier());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, savedIndex.getSubstudyIds());
+        assertEquals(savedIndex.getKey(), KEY.getIndexKeyString());
+        assertEquals(savedIndex.getIdentifier(), KEY.getIdentifier());
+        assertEquals(savedIndex.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
     }
     
     @Test
@@ -127,8 +126,8 @@ public class DynamoReportIndexDaoMockTest {
         verify(mapper).delete(index);
         
         DynamoReportIndex lookupKey = loadIndexCaptor.getValue();
-        assertEquals(KEY.getIndexKeyString(), lookupKey.getKey());
-        assertEquals(KEY.getIdentifier(), lookupKey.getIdentifier());
+        assertEquals(lookupKey.getKey(), KEY.getIndexKeyString());
+        assertEquals(lookupKey.getIdentifier(), KEY.getIdentifier());
     }
     
     @Test
@@ -155,18 +154,18 @@ public class DynamoReportIndexDaoMockTest {
         verify(mapper).save(saveIndexCaptor.capture(), saveExpressionCaptor.capture());
         
         DynamoReportIndex index = saveIndexCaptor.getValue();
-        assertEquals("api:STUDY", index.getKey());
-        assertEquals(updatedIndex.getIdentifier(), index.getIdentifier());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, index.getSubstudyIds());
+        assertEquals(index.getKey(), "api:STUDY");
+        assertEquals(index.getIdentifier(), updatedIndex.getIdentifier());
+        assertEquals(index.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
         assertTrue(index.isPublic());
         
         DynamoDBSaveExpression expr = saveExpressionCaptor.getValue();
         Map<String,ExpectedAttributeValue> map = expr.getExpected();
-        assertEquals(index.getKey(), map.get("key").getValue().getS());
-        assertEquals(index.getIdentifier(), map.get("identifier").getValue().getS());
+        assertEquals(map.get("key").getValue().getS(), index.getKey());
+        assertEquals(map.get("identifier").getValue().getS(), index.getIdentifier());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateIndexConditionalCheckFailedThrows() {
         doThrow(new ConditionalCheckFailedException("message"))
             .when(mapper).save(any(), any(DynamoDBSaveExpression.class));
@@ -186,14 +185,14 @@ public class DynamoReportIndexDaoMockTest {
         ReportTypeResourceList<? extends ReportIndex> indices = dao.getIndices(
                 TestConstants.TEST_STUDY, ReportType.PARTICIPANT);
         
-        assertEquals(1, indices.getItems().size());
-        assertEquals(ReportType.PARTICIPANT, indices.getRequestParams().get("reportType"));
+        assertEquals(indices.getItems().size(), 1);
+        assertEquals(indices.getRequestParams().get("reportType"), ReportType.PARTICIPANT);
         
         verify(mapper).query(eq(DynamoReportIndex.class), queryCaptor.capture());
         
         DynamoDBQueryExpression<DynamoReportIndex> query = queryCaptor.getValue();
         DynamoReportIndex hashKey = query.getHashKeyValues();
         
-        assertEquals("api:PARTICIPANT", hashKey.getKey());
+        assertEquals(hashKey.getKey(), "api:PARTICIPANT");
     }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanDaoMockTest.java
@@ -1,10 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -13,17 +8,21 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
@@ -47,7 +46,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoSchedulePlanDaoMockTest {
     
     private static final Set<String> ALL_OF_GROUPS = Sets.newHashSet("a","b");
@@ -72,8 +70,9 @@ public class DynamoSchedulePlanDaoMockTest {
     @Captor
     private ArgumentCaptor<DynamoDBQueryExpression<DynamoSchedulePlan>> queryCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao = new DynamoSchedulePlanDao();
         dao.setSchedulePlanMapper(mapper);
         dao.setCriteriaDao(criteriaDao);
@@ -113,11 +112,11 @@ public class DynamoSchedulePlanDaoMockTest {
     public void getSchedulePlans() {
         mockSchedulePlanQuery();
         List<SchedulePlan> plans = dao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TEST_STUDY, false);
-        assertEquals(1, plans.size());
+        assertEquals(plans.size(), 1);
         
         verify(mapper).queryPage(eq(DynamoSchedulePlan.class), queryCaptor.capture());
         
-        assertEquals(TEST_STUDY.getIdentifier(), queryCaptor.getValue().getHashKeyValues().getStudyKey());
+        assertEquals(queryCaptor.getValue().getHashKeyValues().getStudyKey(), TEST_STUDY.getIdentifier());
     }
     
     @Test
@@ -144,8 +143,8 @@ public class DynamoSchedulePlanDaoMockTest {
         plan = plans.get(0);
         strategy = (CriteriaScheduleStrategy)plan.getStrategy();
         criteria = strategy.getScheduleCriteria().get(0).getCriteria();
-        assertEquals(new Integer(1), criteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(65), criteria.getMaxAppVersion(IOS));
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(1));
+        assertEquals(criteria.getMaxAppVersion(IOS), new Integer(65));
         assertTrue(criteria.getAllOfGroups().isEmpty());
         assertTrue(criteria.getNoneOfGroups().isEmpty());
     }
@@ -171,8 +170,8 @@ public class DynamoSchedulePlanDaoMockTest {
         plan = dao.getSchedulePlan(TEST_STUDY, plan.getGuid());
         strategy = (CriteriaScheduleStrategy)plan.getStrategy();
         criteria = strategy.getScheduleCriteria().get(0).getCriteria();
-        assertEquals(new Integer(1), criteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(65), criteria.getMaxAppVersion(IOS));
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(1));
+        assertEquals(criteria.getMaxAppVersion(IOS), new Integer(65));
         assertTrue(criteria.getAllOfGroups().isEmpty());
         assertTrue(criteria.getNoneOfGroups().isEmpty());
     }
@@ -219,17 +218,17 @@ public class DynamoSchedulePlanDaoMockTest {
         strategy = (CriteriaScheduleStrategy)updated.getStrategy();
         scheduleCriteria = strategy.getScheduleCriteria().get(0);
         Criteria returnedCriteria = scheduleCriteria.getCriteria();
-        assertEquals(new Integer(100), returnedCriteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(200), returnedCriteria.getMaxAppVersion(IOS));        
+        assertEquals(returnedCriteria.getMinAppVersion(IOS), new Integer(100));
+        assertEquals(returnedCriteria.getMaxAppVersion(IOS), new Integer(200));        
         
         // Verify they were persisted
         verify(criteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
         Criteria updatedCriteria = criteriaCaptor.getValue();
-        assertEquals(new Integer(100), updatedCriteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(200), updatedCriteria.getMaxAppVersion(IOS));        
+        assertEquals(updatedCriteria.getMinAppVersion(IOS), new Integer(100));
+        assertEquals(updatedCriteria.getMaxAppVersion(IOS), new Integer(200));        
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateMissingSchedulePlan() {
         when(queryResultsPage.getResults()).thenReturn(ImmutableList.of());
         when(mapper.queryPage(eq(DynamoSchedulePlan.class), any())).thenReturn(queryResultsPage);
@@ -239,7 +238,7 @@ public class DynamoSchedulePlanDaoMockTest {
         dao.updateSchedulePlan(TEST_STUDY, update);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateDeletedSchedulePlan() {
         schedulePlan.setDeleted(true);
         mockSchedulePlanQuery();
@@ -271,7 +270,7 @@ public class DynamoSchedulePlanDaoMockTest {
         Condition condition = new Condition().withComparisonOperator(ComparisonOperator.NE)
                 .withAttributeValueList(new AttributeValue().withN("1"));
         
-        assertEquals(condition, queryCaptor.getValue().getQueryFilter().get("deleted"));
+        assertEquals(queryCaptor.getValue().getQueryFilter().get("deleted"), condition);
     }
     
     @Test
@@ -339,7 +338,7 @@ public class DynamoSchedulePlanDaoMockTest {
         verify(mapper, never()).delete(any());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateLogicallyDeletedSchedulePlanThrows() {
         mockSchedulePlanQuery();
         schedulePlan.setDeleted(true);
@@ -378,7 +377,7 @@ public class DynamoSchedulePlanDaoMockTest {
         assertTrue(schedulePlanCaptor.getValue().isDeleted());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteLogicallyDeletedSchedulePlanThrows() {
         mockSchedulePlanQuery();
         schedulePlan.setDeleted(true);
@@ -397,9 +396,9 @@ public class DynamoSchedulePlanDaoMockTest {
     }
     
     private void assertCriteria(Criteria criteria) {
-        assertEquals(new Integer(2), criteria.getMinAppVersion(IOS));
-        assertEquals(new Integer(10), criteria.getMaxAppVersion(IOS));
-        assertEquals(ALL_OF_GROUPS, criteria.getAllOfGroups());
-        assertEquals(NONE_OF_GROUPS, criteria.getNoneOfGroups());
+        assertEquals(criteria.getMinAppVersion(IOS), new Integer(2));
+        assertEquals(criteria.getMaxAppVersion(IOS), new Integer(10));
+        assertEquals(criteria.getAllOfGroups(), ALL_OF_GROUPS);
+        assertEquals(criteria.getNoneOfGroups(), NONE_OF_GROUPS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSchedulePlanTest.java
@@ -1,19 +1,19 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.schedules.SchedulePlan;
 import org.sagebionetworks.bridge.models.schedules.ScheduleStrategy;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -45,24 +45,24 @@ public class DynamoSchedulePlanTest {
         String json = BridgeObjectMapper.get().writeValueAsString(plan);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("SchedulePlan", node.get("type").textValue());
-        assertEquals(2, node.get("version").intValue());
-        assertEquals("guid", node.get("guid").textValue());
-        assertEquals("Label", node.get("label").textValue());
+        assertEquals(node.get("type").textValue(), "SchedulePlan");
+        assertEquals(node.get("version").intValue(), 2);
+        assertEquals(node.get("guid").textValue(), "guid");
+        assertEquals(node.get("label").textValue(), "Label");
         assertTrue(node.get("deleted").booleanValue());
         assertNull(node.get("studyKey"));
         assertNotNull(node.get("strategy"));
-        assertEquals(datetime, DateTime.parse(node.get("modifiedOn").asText()));
+        assertEquals(DateTime.parse(node.get("modifiedOn").asText()), datetime);
 
         DynamoSchedulePlan plan2 = DynamoSchedulePlan.fromJson(node);
-        assertEquals(plan.getVersion(), plan2.getVersion());
-        assertEquals(plan.getGuid(), plan2.getGuid());
-        assertEquals(plan.getLabel(), plan2.getLabel());
-        assertEquals(plan.getModifiedOn(), plan2.getModifiedOn());
-        assertEquals(plan.isDeleted(), plan2.isDeleted());
+        assertEquals(plan2.getVersion(), plan.getVersion());
+        assertEquals(plan2.getGuid(), plan.getGuid());
+        assertEquals(plan2.getLabel(), plan.getLabel());
+        assertEquals(plan2.getModifiedOn(), plan.getModifiedOn());
+        assertEquals(plan2.isDeleted(), plan.isDeleted());
         
         ScheduleStrategy retrievedStrategy = plan.getStrategy();
-        assertEquals(retrievedStrategy, strategy);
+        assertEquals(strategy, retrievedStrategy);
     }
     
     @Test
@@ -77,7 +77,7 @@ public class DynamoSchedulePlanTest {
         assertNull(plan.getStudyKey());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void fromJson_NullStrategyType() throws Exception {
         String json = "{\n" +
                 "   \"strategy\":{}\n" +
@@ -86,7 +86,7 @@ public class DynamoSchedulePlanTest {
         DynamoSchedulePlan.fromJson(node);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void fromJson_NonExistentStrategyType() throws Exception {
         String json = "{\n" +
                 "   \"strategy\":{\n" +
@@ -97,7 +97,7 @@ public class DynamoSchedulePlanTest {
         DynamoSchedulePlan.fromJson(node);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void fromJson_InvalidStrategyType() throws Exception {
         String json = "{\n" +
                 "   \"strategy\":{\n" +

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoScheduledActivityTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
@@ -14,7 +14,8 @@ import nl.jqno.equalsverifier.Warning;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -55,9 +56,9 @@ public class DynamoScheduledActivityTest {
         List<ScheduledActivity> activities = Lists.newArrayList(activity1, activity2, activity3);
         Collections.sort(activities, ScheduledActivity.SCHEDULED_ACTIVITY_COMPARATOR);
         
-        assertEquals(activity1, activities.get(0));
-        assertEquals(activity3, activities.get(1));
-        assertEquals(activity2, activities.get(2));
+        assertEquals(activities.get(0), activity1);
+        assertEquals(activities.get(1), activity3);
+        assertEquals(activities.get(2), activity2);
     }
     
     @Test
@@ -83,9 +84,9 @@ public class DynamoScheduledActivityTest {
         
         // Activity 3 comes first because it's complete, the others follow. This is arbitrary...
         // in reality they are broken activities, but the comparator will not fail.
-        assertEquals(activity3, activities.get(0));
-        assertEquals(activity1, activities.get(1));
-        assertEquals(activity2, activities.get(2));
+        assertEquals(activities.get(0), activity3);
+        assertEquals(activities.get(1), activity1);
+        assertEquals(activities.get(2), activity2);
     }
 
     @Test
@@ -111,22 +112,22 @@ public class DynamoScheduledActivityTest {
         String output = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(schActivity);
         
         JsonNode node = mapper.readTree(output);
-        assertEquals("AAA-BBB-CCC", node.get("guid").asText());
-        assertEquals(scheduledOnString, node.get("scheduledOn").asText());
-        assertEquals(expiresOnString, node.get("expiresOn").asText());
-        assertEquals("available", node.get("status").asText());
-        assertEquals("ScheduledActivity", node.get("type").asText());
+        assertEquals(node.get("guid").asText(), "AAA-BBB-CCC");
+        assertEquals(node.get("scheduledOn").asText(), scheduledOnString);
+        assertEquals(node.get("expiresOn").asText(), expiresOnString);
+        assertEquals(node.get("status").asText(), "available");
+        assertEquals(node.get("type").asText(), "ScheduledActivity");
         assertTrue(node.get("persistent").asBoolean());
         assertNull(node.get("schedule"));
         assertNull(node.get("referentGuid"));
-        assertEquals(8, node.size());
-        assertEquals(TestUtils.getClientData(), node.get("clientData"));
+        assertEquals(node.size(), 8);
+        assertEquals(node.get("clientData"), TestUtils.getClientData());
         
         JsonNode activityNode = node.get("activity");
-        assertEquals("Activity3", activityNode.get("label").asText());
-        assertEquals("tapTest", activityNode.get("task").get("identifier").asText());
-        assertEquals("task", activityNode.get("activityType").asText());
-        assertEquals("Activity", activityNode.get("type").asText());
+        assertEquals(activityNode.get("label").asText(), "Activity3");
+        assertEquals(activityNode.get("task").get("identifier").asText(), "tapTest");
+        assertEquals(activityNode.get("activityType").asText(), "task");
+        assertEquals(activityNode.get("type").asText(), "Activity");
         
         // zero out the health code field, because that will not be serialized
         schActivity.setHealthCode(null);
@@ -140,7 +141,7 @@ public class DynamoScheduledActivityTest {
         newActivity.setReferentGuid("referentGuid");
         
         // Also works without having to reset the timezone.
-        assertEquals(schActivity, newActivity);
+        assertEquals(newActivity, schActivity);
     }
     
     @Test
@@ -150,32 +151,32 @@ public class DynamoScheduledActivityTest {
         DynamoScheduledActivity schActivity = new DynamoScheduledActivity();
         schActivity.setTimeZone(DateTimeZone.UTC);
         
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
 
         schActivity.setLocalScheduledOn(now.plusHours(1));
-        assertEquals(ScheduledActivityStatus.SCHEDULED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.SCHEDULED);
         
         schActivity.setLocalScheduledOn(now.minusHours(3));
         schActivity.setLocalExpiresOn(now.minusHours(1));
-        assertEquals(ScheduledActivityStatus.EXPIRED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.EXPIRED);
         
         schActivity.setLocalScheduledOn(null);
         schActivity.setLocalExpiresOn(null);
         
         schActivity.setStartedOn(now.toDateTime(DateTimeZone.UTC).getMillis());
-        assertEquals(ScheduledActivityStatus.STARTED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.STARTED);
         
         schActivity.setFinishedOn(now.toDateTime(DateTimeZone.UTC).getMillis());
-        assertEquals(ScheduledActivityStatus.FINISHED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.FINISHED);
         
         schActivity = new DynamoScheduledActivity();
         schActivity.setFinishedOn(DateTime.now().getMillis());
-        assertEquals(ScheduledActivityStatus.DELETED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.DELETED);
         
         schActivity = new DynamoScheduledActivity();
         schActivity.setLocalScheduledOn(now.minusHours(1));
         schActivity.setLocalExpiresOn(now.plusHours(1));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
     }
     
     @Test
@@ -186,32 +187,32 @@ public class DynamoScheduledActivityTest {
         schActivity.setPersistent(true);
         schActivity.setTimeZone(DateTimeZone.UTC);
         
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
 
         schActivity.setLocalScheduledOn(now.plusHours(1));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
         
         schActivity.setLocalScheduledOn(now.minusHours(3));
         schActivity.setLocalExpiresOn(now.minusHours(1));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
         
         schActivity.setLocalScheduledOn(null);
         schActivity.setLocalExpiresOn(null);
         
         schActivity.setStartedOn(now.toDateTime(DateTimeZone.UTC).getMillis());
-        assertEquals(ScheduledActivityStatus.STARTED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.STARTED);
         
         schActivity.setFinishedOn(now.toDateTime(DateTimeZone.UTC).getMillis());
-        assertEquals(ScheduledActivityStatus.FINISHED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.FINISHED);
         
         schActivity = new DynamoScheduledActivity();
         schActivity.setFinishedOn(DateTime.now().getMillis());
-        assertEquals(ScheduledActivityStatus.DELETED, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.DELETED);
         
         schActivity = new DynamoScheduledActivity();
         schActivity.setLocalScheduledOn(now.minusHours(1));
         schActivity.setLocalExpiresOn(now.plusHours(1));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
     }
     
     /**
@@ -226,22 +227,22 @@ public class DynamoScheduledActivityTest {
         // Activity with datetime and zone (which is different)
         DynamoScheduledActivity schActivity = new DynamoScheduledActivity();
         // Without a time zone, getStatus() works
-        assertEquals(ScheduledActivityStatus.AVAILABLE, schActivity.getStatus());
+        assertEquals(schActivity.getStatus(), ScheduledActivityStatus.AVAILABLE);
         // Now set some values
         schActivity.setLocalScheduledOn(dateTime.toLocalDateTime());
         schActivity.setTimeZone(DateTimeZone.UTC);
         
         // Scheduled time should be in the time zone that is set
-        assertEquals(DateTimeZone.UTC, schActivity.getScheduledOn().getZone());
+        assertEquals(schActivity.getScheduledOn().getZone(), DateTimeZone.UTC);
         // But the datetime does not itself change (this is one way to test this)
-        assertEquals(dateTimeInZone.toLocalDateTime(), schActivity.getScheduledOn().toLocalDateTime());
+        assertEquals(schActivity.getScheduledOn().toLocalDateTime(), dateTimeInZone.toLocalDateTime());
         
         // setting new time zone everything shifts only in zone, not date or time
         DateTimeZone newZone = DateTimeZone.forOffsetHours(3);
         schActivity.setTimeZone(newZone);
         LocalDateTime copy = schActivity.getScheduledOn().toLocalDateTime();
-        assertEquals(newZone, schActivity.getScheduledOn().getZone());
-        assertEquals(dateTimeInZone.toLocalDateTime(), copy);
+        assertEquals(schActivity.getScheduledOn().getZone(), newZone);
+        assertEquals(copy, dateTimeInZone.toLocalDateTime());
     }
     
     @Test
@@ -254,8 +255,8 @@ public class DynamoScheduledActivityTest {
         schActivity.setTimeZone(timeZone);
         schActivity.setLocalScheduledOn(now.toLocalDateTime());
         schActivity.setLocalExpiresOn(then.toLocalDateTime());
-        assertEquals(schActivity.getLocalScheduledOn(), now.toLocalDateTime());
-        assertEquals(schActivity.getLocalExpiresOn(), then.toLocalDateTime());
+        assertEquals(now.toLocalDateTime(), schActivity.getLocalScheduledOn());
+        assertEquals(then.toLocalDateTime(), schActivity.getLocalExpiresOn());
         
         LocalDateTime local1 = LocalDateTime.parse("2010-01-01T10:10:10");
         LocalDateTime local2 = LocalDateTime.parse("2010-02-02T10:10:10");
@@ -264,8 +265,8 @@ public class DynamoScheduledActivityTest {
         schActivity.setTimeZone(timeZone);
         schActivity.setLocalScheduledOn(local1);
         schActivity.setLocalExpiresOn(local2);
-        assertEquals(schActivity.getScheduledOn(), local1.toDateTime(timeZone));
-        assertEquals(schActivity.getExpiresOn(), local2.toDateTime(timeZone));
+        assertEquals(local1.toDateTime(timeZone), schActivity.getScheduledOn());
+        assertEquals(local2.toDateTime(timeZone), schActivity.getExpiresOn());
     }
     
     @Test
@@ -286,34 +287,34 @@ public class DynamoScheduledActivityTest {
         String json = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(act);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("activityGuid", node.get("guid").textValue());
-        assertEquals("2015-10-10T08:08:08.000Z", node.get("startedOn").textValue());
-        assertEquals("2015-12-05T08:08:08.000Z", node.get("finishedOn").textValue());
+        assertEquals(node.get("guid").textValue(), "activityGuid");
+        assertEquals(node.get("startedOn").textValue(), "2015-10-10T08:08:08.000Z");
+        assertEquals(node.get("finishedOn").textValue(), "2015-12-05T08:08:08.000Z");
         assertTrue(node.get("persistent").booleanValue());
-        assertEquals("finished", node.get("status").textValue());
-        assertEquals("schedulePlanGuid", node.get("schedulePlanGuid").textValue());
-        assertEquals("ScheduledActivity", node.get("type").textValue());
-        assertEquals("2015-10-01T10:10:10.000-06:00", node.get("scheduledOn").textValue());
-        assertEquals("2015-10-01T14:10:10.000-06:00", node.get("expiresOn").textValue());
+        assertEquals(node.get("status").textValue(), "finished");
+        assertEquals(node.get("schedulePlanGuid").textValue(), "schedulePlanGuid");
+        assertEquals(node.get("type").textValue(), "ScheduledActivity");
+        assertEquals(node.get("scheduledOn").textValue(), "2015-10-01T10:10:10.000-06:00");
+        assertEquals(node.get("expiresOn").textValue(), "2015-10-01T14:10:10.000-06:00");
         assertNull(node.get("referentType"));
         // all the above, plus activity, and nothing else
-        assertEquals(10, node.size());
+        assertEquals(node.size(), 10);
 
         JsonNode activityNode = node.get("activity");
-        assertEquals("Activity1", activityNode.get("label").textValue());
+        assertEquals(activityNode.get("label").textValue(), "Activity1");
         assertNotNull(activityNode.get("guid").textValue());
-        assertEquals("survey", activityNode.get("activityType").textValue());
-        assertEquals("Activity", activityNode.get("type").textValue());
+        assertEquals(activityNode.get("activityType").textValue(), "survey");
+        assertEquals(activityNode.get("type").textValue(), "Activity");
         // all the above, plus survey, and nothing else
-        assertEquals(5, activityNode.size());
+        assertEquals(activityNode.size(), 5);
         
         JsonNode surveyNode = activityNode.get("survey");
-        assertEquals("identifier1", surveyNode.get("identifier").textValue());
-        assertEquals("AAA", surveyNode.get("guid").textValue());
+        assertEquals(surveyNode.get("identifier").textValue(), "identifier1");
+        assertEquals(surveyNode.get("guid").textValue(), "AAA");
         assertNotNull("href", surveyNode.get("href").textValue());
-        assertEquals("SurveyReference", surveyNode.get("type").textValue());
+        assertEquals(surveyNode.get("type").textValue(), "SurveyReference");
         // all the above and nothing else
-        assertEquals(4, surveyNode.size());
+        assertEquals(surveyNode.size(), 4);
         
         // Were you to set scheduledOn/expiresOn directly, rather than time zone + local variants,
         // it would still preserve the timezone, that is, the time zone you set separately, not the 
@@ -323,7 +324,7 @@ public class DynamoScheduledActivityTest {
         json = ScheduledActivity.SCHEDULED_ACTIVITY_WRITER.writeValueAsString(act);
         node = BridgeObjectMapper.get().readTree(json);
         // Still in time zone -6 hours.
-        assertEquals("2015-10-01T10:10:10.000-06:00", node.get("scheduledOn").asText());
-        assertEquals("2015-10-01T14:10:10.000-06:00", node.get("expiresOn").asText());
+        assertEquals(node.get("scheduledOn").asText(), "2015-10-01T10:10:10.000-06:00");
+        assertEquals(node.get("expiresOn").asText(), "2015-10-01T14:10:10.000-06:00");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageDaoTest.java
@@ -1,23 +1,23 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.sms.SmsMessage;
 
@@ -28,7 +28,7 @@ public class DynamoSmsMessageDaoTest {
     private DynamoSmsMessageDao dao;
     private DynamoDBMapper mockMapper;
 
-    @Before
+    @BeforeMethod
     public void before() {
         mockMapper = mock(DynamoDBMapper.class);
 
@@ -55,9 +55,9 @@ public class DynamoSmsMessageDaoTest {
         verify(mockMapper).queryPage(eq(DynamoSmsMessage.class), queryCaptor.capture());
 
         DynamoDBQueryExpression<DynamoSmsMessage> query = queryCaptor.getValue();
-        assertEquals(PHONE_NUMBER, query.getHashKeyValues().getPhoneNumber());
+        assertEquals(query.getHashKeyValues().getPhoneNumber(), PHONE_NUMBER);
         assertFalse(query.isScanIndexForward());
-        assertEquals(1, query.getLimit().intValue());
+        assertEquals(query.getLimit().intValue(), 1);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageDaoTest.java
@@ -48,7 +48,7 @@ public class DynamoSmsMessageDaoTest {
 
         // Execute and validate output matches.
         SmsMessage daoOutput = dao.getMostRecentMessage(PHONE_NUMBER);
-        assertSame(mapperOutput, daoOutput);
+        assertSame(daoOutput, mapperOutput);
 
         // Verify query.
         ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessageTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -35,22 +36,22 @@ public class DynamoSmsMessageTest {
 
         // Convert to POJO.
         SmsMessage smsMessage = BridgeObjectMapper.get().readValue(jsonText, SmsMessage.class);
-        assertEquals(PHONE_NUMBER, smsMessage.getPhoneNumber());
-        assertEquals(SENT_ON_MILLIS, smsMessage.getSentOn());
-        assertEquals(HEALTH_CODE, smsMessage.getHealthCode());
-        assertEquals(MESSAGE_BODY, smsMessage.getMessageBody());
-        assertEquals(MESSAGE_ID, smsMessage.getMessageId());
-        assertEquals(SmsType.PROMOTIONAL, smsMessage.getSmsType());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, smsMessage.getStudyId());
+        assertEquals(smsMessage.getPhoneNumber(), PHONE_NUMBER);
+        assertEquals(smsMessage.getSentOn(), SENT_ON_MILLIS);
+        assertEquals(smsMessage.getHealthCode(), HEALTH_CODE);
+        assertEquals(smsMessage.getMessageBody(), MESSAGE_BODY);
+        assertEquals(smsMessage.getMessageId(), MESSAGE_ID);
+        assertEquals(smsMessage.getSmsType(), SmsType.PROMOTIONAL);
+        assertEquals(smsMessage.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Convert back to JSON node.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(smsMessage, JsonNode.class);
-        assertEquals(PHONE_NUMBER, jsonNode.get("phoneNumber").textValue());
-        assertEquals(SENT_ON_STRING, jsonNode.get("sentOn").textValue());
-        assertEquals(HEALTH_CODE, jsonNode.get("healthCode").textValue());
-        assertEquals(MESSAGE_BODY, jsonNode.get("messageBody").textValue());
-        assertEquals(MESSAGE_ID, jsonNode.get("messageId").textValue());
-        assertEquals(SmsType.PROMOTIONAL.getValue().toLowerCase(), jsonNode.get("smsType").textValue());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, jsonNode.get("studyId").textValue());
+        assertEquals(jsonNode.get("phoneNumber").textValue(), PHONE_NUMBER);
+        assertEquals(jsonNode.get("sentOn").textValue(), SENT_ON_STRING);
+        assertEquals(jsonNode.get("healthCode").textValue(), HEALTH_CODE);
+        assertEquals(jsonNode.get("messageBody").textValue(), MESSAGE_BODY);
+        assertEquals(jsonNode.get("messageId").textValue(), MESSAGE_ID);
+        assertEquals(jsonNode.get("smsType").textValue(), SmsType.PROMOTIONAL.getValue().toLowerCase());
+        assertEquals(jsonNode.get("studyId").textValue(), TestConstants.TEST_STUDY_IDENTIFIER);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoStudyConsentTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -32,10 +32,10 @@ public class DynamoStudyConsentTest {
        String json = BridgeObjectMapper.get().writeValueAsString(consent);
        JsonNode node = BridgeObjectMapper.get().readTree(json);
        
-       assertEquals("1970-01-01T00:00:00.123Z", node.get("createdOn").asText());
-       assertEquals("ABC", node.get("subpopulationGuid").asText());
-       assertEquals("StudyConsent", node.get("type").asText());
-       assertEquals(3, node.size());
+       assertEquals(node.get("createdOn").asText(), "1970-01-01T00:00:00.123Z");
+       assertEquals(node.get("subpopulationGuid").asText(), "ABC");
+       assertEquals(node.get("type").asText(), "StudyConsent");
+       assertEquals(node.size(), 3);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoStudyTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +19,9 @@ import com.google.common.collect.Lists;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -54,7 +56,7 @@ public class DynamoStudyTest {
         // Set value works
         Map<String, String> dummyMap = ImmutableMap.of("3-days-after-enrollment", "P3D");
         study.setAutomaticCustomEvents(dummyMap);
-        assertEquals(dummyMap, study.getAutomaticCustomEvents());
+        assertEquals(study.getAutomaticCustomEvents(), dummyMap);
 
         // Set to null makes it empty again
         study.setAutomaticCustomEvents(null);
@@ -74,7 +76,7 @@ public class DynamoStudyTest {
 
         // set value works
         study.setUploadMetadataFieldDefinitions(fieldDefList);
-        assertEquals(fieldDefList, study.getUploadMetadataFieldDefinitions());
+        assertEquals(study.getUploadMetadataFieldDefinitions(), fieldDefList);
 
         // set to null makes it empty again
         study.setUploadMetadataFieldDefinitions(null);
@@ -138,18 +140,18 @@ public class DynamoStudyTest {
                 JsonUtils.asEntity(node, "signedConsentTemplate", EmailTemplate.class));
         assertEqualsAndNotNull(study.getAppInstallLinkTemplate(),
                 JsonUtils.asEntity(node, "appInstallLinkTemplate", EmailTemplate.class));
-        assertEquals(study.getResetPasswordSmsTemplate(),
-                JsonUtils.asEntity(node, "resetPasswordSmsTemplate", SmsTemplate.class));
-        assertEquals(study.getPhoneSignInSmsTemplate(),
-                JsonUtils.asEntity(node, "phoneSignInSmsTemplate", SmsTemplate.class));
-        assertEquals(study.getAppInstallLinkSmsTemplate(),
-                JsonUtils.asEntity(node, "appInstallLinkSmsTemplate", SmsTemplate.class));
-        assertEquals(study.getVerifyPhoneSmsTemplate(),
-                JsonUtils.asEntity(node, "verifyPhoneSmsTemplate", SmsTemplate.class));
-        assertEquals(study.getAccountExistsSmsTemplate(),
-                JsonUtils.asEntity(node, "accountExistsSmsTemplate", SmsTemplate.class));
-        assertEquals(study.getSignedConsentSmsTemplate(),
-                JsonUtils.asEntity(node, "signedConsentSmsTemplate", SmsTemplate.class));
+        assertEquals(JsonUtils.asEntity(node, "resetPasswordSmsTemplate", SmsTemplate.class),
+                study.getResetPasswordSmsTemplate());
+        assertEquals(JsonUtils.asEntity(node, "phoneSignInSmsTemplate", SmsTemplate.class),
+                study.getPhoneSignInSmsTemplate());
+        assertEquals(JsonUtils.asEntity(node, "appInstallLinkSmsTemplate", SmsTemplate.class),
+                study.getAppInstallLinkSmsTemplate());
+        assertEquals(JsonUtils.asEntity(node, "verifyPhoneSmsTemplate", SmsTemplate.class),
+                study.getVerifyPhoneSmsTemplate());
+        assertEquals(JsonUtils.asEntity(node, "accountExistsSmsTemplate", SmsTemplate.class),
+                study.getAccountExistsSmsTemplate());
+        assertEquals(JsonUtils.asEntity(node, "signedConsentSmsTemplate", SmsTemplate.class),
+                study.getSignedConsentSmsTemplate());
         assertEqualsAndNotNull(study.getUserProfileAttributes(), JsonUtils.asStringSet(node, "userProfileAttributes"));
         assertEqualsAndNotNull(study.getTaskIdentifiers(), JsonUtils.asStringSet(node, "taskIdentifiers"));
         assertEqualsAndNotNull(study.getActivityEventKeys(), JsonUtils.asStringSet(node, "activityEventKeys"));
@@ -164,7 +166,7 @@ public class DynamoStudyTest {
         assertTrue(node.get("reauthenticationEnabled").booleanValue());
         assertTrue(node.get("autoVerificationPhoneSuppressed").booleanValue());
         assertTrue(node.get("verifyChannelOnSignInEnabled").booleanValue());
-        assertEquals(0, node.get("accountLimit").asInt());
+        assertEquals(node.get("accountLimit").asInt(), 0);
         assertFalse(node.get("disableExport").asBoolean());
         assertEqualsAndNotNull("Study", node.get("type").asText());
         assertEqualsAndNotNull(study.getPushNotificationARNs().get(OperatingSystem.IOS),
@@ -173,8 +175,8 @@ public class DynamoStudyTest {
                 node.get("pushNotificationARNs").get(OperatingSystem.ANDROID).asText());
 
         JsonNode automaticCustomEventsNode = node.get("automaticCustomEvents");
-        assertEquals(1, automaticCustomEventsNode.size());
-        assertEquals("P3D", automaticCustomEventsNode.get("3-days-after-enrollment").textValue());
+        assertEquals(automaticCustomEventsNode.size(), 1);
+        assertEquals(automaticCustomEventsNode.get("3-days-after-enrollment").textValue(), "P3D");
 
         JsonNode appleLink = node.get("appleAppLinks").get(0);
         assertEquals("studyId", appleLink.get("appID").textValue());
@@ -182,9 +184,9 @@ public class DynamoStudyTest {
         assertEquals("/appId/*", appleLink.get("paths").get(1).textValue());
         
         JsonNode androidLink = node.get("androidAppLinks").get(0);
-        assertEquals("namespace", androidLink.get("namespace").textValue());
-        assertEquals("package_name", androidLink.get("package_name").textValue());
-        assertEquals("sha256_cert_fingerprints", androidLink.get("sha256_cert_fingerprints").get(0).textValue());
+        assertEquals(androidLink.get("namespace").textValue(), "namespace");
+        assertEquals(androidLink.get("package_name").textValue(), "package_name");
+        assertEquals(androidLink.get("sha256_cert_fingerprints").get(0).textValue(), "sha256_cert_fingerprints");
 
         // validate minAppVersion
         JsonNode supportedVersionsNode = JsonUtils.asJsonNode(node, "minSupportedAppVersions");
@@ -195,21 +197,21 @@ public class DynamoStudyTest {
 
         // validate metadata field defs
         JsonNode metadataFieldDefListNode = node.get("uploadMetadataFieldDefinitions");
-        assertEquals(1, metadataFieldDefListNode.size());
+        assertEquals(metadataFieldDefListNode.size(), 1);
         JsonNode oneMetadataFieldDefNode = metadataFieldDefListNode.get(0);
-        assertEquals("test-metadata-field", oneMetadataFieldDefNode.get("name").textValue());
-        assertEquals("int", oneMetadataFieldDefNode.get("type").textValue());
+        assertEquals(oneMetadataFieldDefNode.get("name").textValue(), "test-metadata-field");
+        assertEquals(oneMetadataFieldDefNode.get("type").textValue(), "int");
 
         JsonNode providerNode = node.get("oAuthProviders").get("myProvider");
-        assertEquals("clientId", providerNode.get("clientId").textValue());
-        assertEquals("secret", providerNode.get("secret").textValue());
-        assertEquals("endpoint", providerNode.get("endpoint").textValue());
-        assertEquals(OAuthProviderTest.CALLBACK_URL, providerNode.get("callbackUrl").textValue());
-        assertEquals("OAuthProvider", providerNode.get("type").textValue());
+        assertEquals(providerNode.get("clientId").textValue(), "clientId");
+        assertEquals(providerNode.get("secret").textValue(), "secret");
+        assertEquals(providerNode.get("endpoint").textValue(), "endpoint");
+        assertEquals(providerNode.get("callbackUrl").textValue(), OAuthProviderTest.CALLBACK_URL);
+        assertEquals(providerNode.get("type").textValue(), "OAuthProvider");
         
         // Deserialize back to a POJO and verify.
         final Study deserStudy = BridgeObjectMapper.get().readValue(node.toString(), Study.class);
-        assertEquals(study, deserStudy);
+        assertEquals(deserStudy, study);
     }
     
     @Test
@@ -222,14 +224,14 @@ public class DynamoStudyTest {
 
         // Deserialize back to a POJO and verify.
         final Study deserStudy = BridgeObjectMapper.get().readValue(json, Study.class);
-        assertEquals(study, deserStudy);
+        assertEquals(deserStudy, study);
     }
     
     @Test
     public void settingStringOrObjectStudyIdentifierSetsTheOther() {
         DynamoStudy study = new DynamoStudy();
         study.setIdentifier("test-study");
-        assertEquals(study.getStudyIdentifier(), new StudyIdentifierImpl("test-study"));
+        assertEquals(new StudyIdentifierImpl("test-study"), study.getStudyIdentifier());
         
         study.setIdentifier(null);
         assertNull(study.getStudyIdentifier());
@@ -238,7 +240,7 @@ public class DynamoStudyTest {
     void assertEqualsAndNotNull(Object expected, Object actual) {
         assertNotNull(expected);
         assertNotNull(actual);
-        assertEquals(expected, actual);
+        assertEquals(actual, expected);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
@@ -1,9 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -15,17 +11,20 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
@@ -41,7 +40,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoSubpopulationDaoMockTest {
     
     private static final Criteria CRITERIA = TestUtils.createCriteria(2, 10, 
@@ -67,8 +65,9 @@ public class DynamoSubpopulationDaoMockTest {
     private DynamoSubpopulation persistedSubpop;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao.setMapper(mapper);
         dao.setCriteriaDao(criteriaDao);
         
@@ -100,8 +99,8 @@ public class DynamoSubpopulationDaoMockTest {
         Subpopulation subpop = dao.createDefaultSubpopulation(TEST_STUDY);
         
         Criteria criteria = subpop.getCriteria();
-        assertEquals(new Integer(0), criteria.getMinAppVersion(OperatingSystem.IOS));
-        assertEquals(new Integer(0), criteria.getMinAppVersion(OperatingSystem.ANDROID));
+        assertEquals(criteria.getMinAppVersion(OperatingSystem.IOS), new Integer(0));
+        assertEquals(criteria.getMinAppVersion(OperatingSystem.ANDROID), new Integer(0));
         
         verify(criteriaDao).createOrUpdateCriteria(criteria);
     }
@@ -111,7 +110,7 @@ public class DynamoSubpopulationDaoMockTest {
         Subpopulation subpop = dao.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
         
         Criteria criteria = subpop.getCriteria();
-        assertEquals(CRITERIA, criteria);
+        assertEquals(criteria, CRITERIA);
         
         verify(criteriaDao).getCriteria(criteria.getKey());
         verifyNoMoreInteractions(criteriaDao);
@@ -142,7 +141,7 @@ public class DynamoSubpopulationDaoMockTest {
         verify(criteriaDao, never()).deleteCriteria(createSubpopulation().getCriteria().getKey());
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void doNotAllowLogicalDeleteOfDefault() {
         Subpopulation defaultSubpop = Subpopulation.create();
         defaultSubpop.setGuid(SUBPOP_GUID);
@@ -173,11 +172,11 @@ public class DynamoSubpopulationDaoMockTest {
         subpop.setVersion(1L);
         
         Subpopulation updatedSubpop = dao.updateSubpopulation(subpop);
-        assertEquals(CRITERIA, updatedSubpop.getCriteria());
+        assertEquals(updatedSubpop.getCriteria(), CRITERIA);
         
         verify(criteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
         Criteria savedCriteria = criteriaCaptor.getValue();
-        assertEquals(CRITERIA, savedCriteria);
+        assertEquals(savedCriteria, CRITERIA);
     }
     
     @Test
@@ -192,12 +191,12 @@ public class DynamoSubpopulationDaoMockTest {
         doReturn(subpopWithCritObject).when(mapper).load(any());
         
         Subpopulation updatedSubpop = dao.updateSubpopulation(subpopWithCritObject);
-        assertEquals(CRITERIA, updatedSubpop.getCriteria());
+        assertEquals(updatedSubpop.getCriteria(), CRITERIA);
         
         verify(criteriaDao).getCriteria(subpopWithCritObject.getCriteria().getKey());
         verify(criteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
         Criteria savedCriteria = criteriaCaptor.getValue();
-        assertEquals(CRITERIA, savedCriteria);
+        assertEquals(savedCriteria, CRITERIA);
     }
     
     @Test
@@ -234,7 +233,7 @@ public class DynamoSubpopulationDaoMockTest {
         assertTrue(subpopCaptor.getValue().isDeleted());
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateSubpopulationCannotDeleteDefaultSubpopulation() {
         persistedSubpop.setDefaultGroup(true);
         
@@ -252,7 +251,7 @@ public class DynamoSubpopulationDaoMockTest {
         // The test subpopulation in the list that is returned from the mock mapper does not have
         // a criteria object. So it will be created as part of loading.
         List<Subpopulation> list = dao.getSubpopulations(TEST_STUDY, false, true);
-        assertEquals(CRITERIA, list.get(0).getCriteria());
+        assertEquals(list.get(0).getCriteria(), CRITERIA);
         
         verify(criteriaDao).getCriteria(list.get(0).getCriteria().getKey());
     }
@@ -262,7 +261,7 @@ public class DynamoSubpopulationDaoMockTest {
         // The test subpopulation in the list that is returned from the mock mapper does not have
         // a criteria object. So it will be created as part of loading.
         List<Subpopulation> list = dao.getSubpopulations(TEST_STUDY, false, true);
-        assertEquals(CRITERIA, list.get(0).getCriteria());
+        assertEquals(list.get(0).getCriteria(), CRITERIA);
         
         // In this case it actually returns a criteria object.
         verify(criteriaDao).getCriteria(list.get(0).getCriteria().getKey());
@@ -275,7 +274,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Subpopulation subpop = dao.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
         Criteria retrievedCriteria = subpop.getCriteria();
-        assertEquals(CRITERIA, retrievedCriteria);
+        assertEquals(retrievedCriteria, CRITERIA);
     }
     
     @Test
@@ -285,7 +284,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         List<Subpopulation> subpops = dao.getSubpopulations(TEST_STUDY, false, true);
         Criteria retrievedCriteria = subpops.get(0).getCriteria();
-        assertEquals(CRITERIA, retrievedCriteria);
+        assertEquals(retrievedCriteria, CRITERIA);
     }
     
     private Subpopulation createSubpopulation() {

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -50,54 +50,54 @@ public class DynamoSubpopulationTest {
 
         // This does not need to be passed to the user; the user is never allowed to set it.
         // This should be standard across the API, BTW, but this is leaked out by some classes.
-        assertEquals("Name", node.get("name").textValue());
-        assertEquals("Description", node.get("description").textValue());
-        assertEquals("guid", node.get("guid").textValue());
-        assertEquals(PUBLISHED_CONSENT_TIMESTAMP.toString(), node.get("publishedConsentCreatedOn").textValue());
+        assertEquals(node.get("name").textValue(), "Name");
+        assertEquals(node.get("description").textValue(), "Description");
+        assertEquals(node.get("guid").textValue(), "guid");
+        assertEquals(node.get("publishedConsentCreatedOn").textValue(), PUBLISHED_CONSENT_TIMESTAMP.toString());
         assertTrue(node.get("required").booleanValue());
         assertTrue(node.get("defaultGroup").booleanValue());
         assertTrue(node.get("autoSendConsentSuppressed").booleanValue());
         assertTrue(node.get("deleted").booleanValue()); // users do not see this flag, they never get deleted items
-        assertEquals("study-key", node.get("studyIdentifier").textValue());
+        assertEquals(node.get("studyIdentifier").textValue(), "study-key");
         assertTrue(node.get("deleted").booleanValue());
-        assertEquals(3L, node.get("version").longValue());
+        assertEquals(node.get("version").longValue(), 3L);
         
         Set<String> dataGroups = ImmutableSet.of(node.get("dataGroupsAssignedWhileConsented").get(0).textValue(),
                 node.get("dataGroupsAssignedWhileConsented").get(1).textValue());                
-        assertEquals(TestConstants.USER_DATA_GROUPS, dataGroups);
+        assertEquals(dataGroups, TestConstants.USER_DATA_GROUPS);
         
         Set<String> substudyIds = ImmutableSet.of(node.get("substudyIdsAssignedOnConsent").get(0).textValue(),
                 node.get("substudyIdsAssignedOnConsent").get(1).textValue());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, substudyIds);
-        assertEquals("Subpopulation", node.get("type").textValue());
+        assertEquals(substudyIds, TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(node.get("type").textValue(), "Subpopulation");
         
         JsonNode critNode = node.get("criteria");
-        assertEquals(ALL_OF_GROUPS, JsonUtils.asStringSet(critNode, "allOfGroups"));
-        assertEquals(NONE_OF_GROUPS, JsonUtils.asStringSet(critNode, "noneOfGroups"));
-        assertEquals(2, critNode.get("minAppVersions").get(IOS).asInt());
-        assertEquals(10, critNode.get("maxAppVersions").get(IOS).asInt());
+        assertEquals(JsonUtils.asStringSet(critNode, "allOfGroups"), ALL_OF_GROUPS);
+        assertEquals(JsonUtils.asStringSet(critNode, "noneOfGroups"), NONE_OF_GROUPS);
+        assertEquals(critNode.get("minAppVersions").get(IOS).asInt(), 2);
+        assertEquals(critNode.get("maxAppVersions").get(IOS).asInt(), 10);
         
         Subpopulation newSubpop = BridgeObjectMapper.get().treeToValue(node, Subpopulation.class);
         // Not serialized, these values have to be added back to have equal objects 
         newSubpop.setStudyIdentifier("study-key");
         
-        assertEquals(subpop, newSubpop);
+        assertEquals(newSubpop, subpop);
         
         // Finally, check the publication site URLs
         assertEqualsAndNotNull(newSubpop.getConsentHTML(), JsonUtils.asText(node, "consentHTML"));
         assertEqualsAndNotNull(newSubpop.getConsentPDF(), JsonUtils.asText(node, "consentPDF"));
 
         String htmlURL = "http://" + BridgeConfigFactory.getConfig().getHostnameWithPostfix("docs") + "/" + newSubpop.getGuidString() + "/consent.html";
-        assertEquals(htmlURL, newSubpop.getConsentHTML());
+        assertEquals(newSubpop.getConsentHTML(), htmlURL);
         
         String pdfURL = "http://" + BridgeConfigFactory.getConfig().getHostnameWithPostfix("docs") + "/" + newSubpop.getGuidString() + "/consent.pdf";
-        assertEquals(pdfURL, newSubpop.getConsentPDF());
+        assertEquals(newSubpop.getConsentPDF(), pdfURL);
         
         Criteria critObject = newSubpop.getCriteria();
-        assertEquals(new Integer(2), critObject.getMinAppVersion(IOS));
-        assertEquals(new Integer(10), critObject.getMaxAppVersion(IOS));
-        assertEquals(ALL_OF_GROUPS, critObject.getAllOfGroups());
-        assertEquals(NONE_OF_GROUPS, critObject.getNoneOfGroups());
+        assertEquals(critObject.getMinAppVersion(IOS), new Integer(2));
+        assertEquals(critObject.getMaxAppVersion(IOS), new Integer(10));
+        assertEquals(critObject.getAllOfGroups(), ALL_OF_GROUPS);
+        assertEquals(critObject.getNoneOfGroups(), NONE_OF_GROUPS);
     }
 
     private Subpopulation makeSubpopulation() {
@@ -123,8 +123,8 @@ public class DynamoSubpopulationTest {
         // Set some values to verify that null resets these to the empty set
         subpop.setDataGroupsAssignedWhileConsented(ImmutableSet.of("A"));
         subpop.setSubstudyIdsAssignedOnConsent(ImmutableSet.of("B"));
-        assertEquals(ImmutableSet.of("A"), subpop.getDataGroupsAssignedWhileConsented());
-        assertEquals(ImmutableSet.of("B"), subpop.getSubstudyIdsAssignedOnConsent());
+        assertEquals(subpop.getDataGroupsAssignedWhileConsented(), ImmutableSet.of("A"));
+        assertEquals(subpop.getSubstudyIdsAssignedOnConsent(), ImmutableSet.of("B"));
         
         subpop.setDataGroupsAssignedWhileConsented(null);
         subpop.setSubstudyIdsAssignedOnConsent(null);
@@ -146,37 +146,37 @@ public class DynamoSubpopulationTest {
     public void guidAndGuidStringInterchangeable() throws Exception {
         Subpopulation subpop = Subpopulation.create();
         subpop.setGuid(SubpopulationGuid.create("abc"));
-        assertEquals("abc", subpop.getGuid().getGuid());
+        assertEquals(subpop.getGuid().getGuid(), "abc");
         
         String json = BridgeObjectMapper.get().writeValueAsString(subpop);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("abc", node.get("guid").asText());
+        assertEquals(node.get("guid").asText(), "abc");
         assertNull(node.get("guidString"));
         
         Subpopulation newSubpop = BridgeObjectMapper.get().readValue(json, Subpopulation.class);
-        assertEquals("abc", newSubpop.getGuidString());
-        assertEquals("abc", newSubpop.getGuid().getGuid());
+        assertEquals(newSubpop.getGuidString(), "abc");
+        assertEquals(newSubpop.getGuid().getGuid(), "abc");
 
         subpop = Subpopulation.create();
         subpop.setGuidString("abc");
-        assertEquals("abc", subpop.getGuidString());
+        assertEquals(subpop.getGuidString(), "abc");
         
         json = BridgeObjectMapper.get().writeValueAsString(subpop);
         node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("abc", node.get("guid").asText());
+        assertEquals(node.get("guid").asText(), "abc");
         assertNull(node.get("guidString"));
         
         newSubpop = BridgeObjectMapper.get().readValue(json, Subpopulation.class);
-        assertEquals("abc", newSubpop.getGuidString());
-        assertEquals("abc", newSubpop.getGuid().getGuid());
+        assertEquals(newSubpop.getGuidString(), "abc");
+        assertEquals(newSubpop.getGuid().getGuid(), "abc");
     }
     
     void assertEqualsAndNotNull(Object expected, Object actual) {
         assertNotNull(expected);
         assertNotNull(actual);
-        assertEquals(expected, actual);
+        assertEquals(actual, expected);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyDaoMockTest.java
@@ -1,9 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.eq;
@@ -13,6 +9,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
@@ -26,16 +26,16 @@ import com.google.common.collect.Lists;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -47,7 +47,6 @@ import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.services.UploadSchemaService;
 
-@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class DynamoSurveyDaoMockTest {
     private static final DateTime MOCK_NOW = DateTime.parse("2016-08-24T15:23:57.123-0700");
@@ -88,14 +87,15 @@ public class DynamoSurveyDaoMockTest {
     public static void mockNow() {
         DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
     }
-
+    
     @AfterClass
     public static void unmockNow() {
         DateTimeUtils.setCurrentMillisSystem();
     }
 
-    @Before
+    @BeforeMethod
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         // set up survey
         survey = new DynamoSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
         survey.setIdentifier(SURVEY_ID);
@@ -128,20 +128,20 @@ public class DynamoSurveyDaoMockTest {
 
         // Execute.
         String surveyGuid = surveyDao.getSurveyGuidForIdentifier(TestConstants.TEST_STUDY, SURVEY_ID);
-        assertEquals(SURVEY_GUID, surveyGuid);
+        assertEquals(surveyGuid, SURVEY_GUID);
 
         // Verify query.
         ArgumentCaptor<DynamoDBQueryExpression> queryCaptor = ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
         verify(mockSurveyMapper).queryPage(eq(DynamoSurvey.class), queryCaptor.capture());
 
         DynamoDBQueryExpression<DynamoSurvey> query = queryCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, query.getHashKeyValues().getStudyIdentifier());
+        assertEquals(query.getHashKeyValues().getStudyIdentifier(), TestConstants.TEST_STUDY_IDENTIFIER);
         assertFalse(query.isConsistentRead());
-        assertEquals(1, query.getLimit().intValue());
+        assertEquals(query.getLimit().intValue(), 1);
 
         Condition rangeKeyCondition = query.getRangeKeyConditions().get("identifier");
-        assertEquals(ComparisonOperator.EQ.toString(), rangeKeyCondition.getComparisonOperator());
-        assertEquals(SURVEY_ID, rangeKeyCondition.getAttributeValueList().get(0).getS());
+        assertEquals(rangeKeyCondition.getComparisonOperator(), ComparisonOperator.EQ.toString());
+        assertEquals(rangeKeyCondition.getAttributeValueList().get(0).getS(), SURVEY_ID);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class DynamoSurveyDaoMockTest {
         survey.setName("New title");
         Survey updatedSurvey = surveyDao.updateSurvey(survey);
         
-        assertEquals("New title", updatedSurvey.getName());
+        assertEquals(updatedSurvey.getName(), "New title");
     }
     
     @Test
@@ -185,8 +185,8 @@ public class DynamoSurveyDaoMockTest {
         // execute and validate
         Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, survey, true);
         assertTrue(retval.isPublished());
-        assertEquals(MOCK_NOW_MILLIS, retval.getModifiedOn());
-        assertEquals(SCHEMA_REV, retval.getSchemaRevision().intValue());
+        assertEquals(retval.getModifiedOn(), MOCK_NOW_MILLIS);
+        assertEquals(retval.getSchemaRevision().intValue(), SCHEMA_REV);
 
         verify(mockSurveyMapper).save(same(retval));
     }
@@ -204,7 +204,7 @@ public class DynamoSurveyDaoMockTest {
         // same test as above, except we *don't* call through to the upload schema DAO
         Survey retval = surveyDao.publishSurvey(TestConstants.TEST_STUDY, survey, true);
         assertTrue(retval.isPublished());
-        assertEquals(MOCK_NOW_MILLIS, retval.getModifiedOn());
+        assertEquals(retval.getModifiedOn(), MOCK_NOW_MILLIS);
         assertNull(retval.getSchemaRevision());
 
         verify(mockSurveyMapper).save(same(retval));
@@ -255,6 +255,6 @@ public class DynamoSurveyDaoMockTest {
 
         verify(mockSurveyMapper).save(surveyCaptor.capture());
         assertFalse(surveyCaptor.getValue().isDeleted());
-        assertEquals(1, surveyCaptor.getValue().getElements().size());
+        assertEquals(surveyCaptor.getValue().getElements().size(), 1);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyInfoScreenTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.surveys.Image;
 import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
+
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -31,17 +31,17 @@ public class DynamoSurveyInfoScreenTest {
         screen.setAfterRules(Lists.newArrayList(afterRule));
 
         SurveyInfoScreen copy = new DynamoSurveyInfoScreen(screen);
-        assertEquals("prompt", copy.getPrompt());
-        assertEquals("promptDetail", copy.getPromptDetail());
-        assertEquals("title", copy.getTitle());
-        assertEquals(screen.getImage(), copy.getImage());
-        assertEquals("surveyCompoundKey", copy.getSurveyCompoundKey());
-        assertEquals("guid", copy.getGuid());
-        assertEquals("identifier", copy.getIdentifier());
-        assertEquals("SurveyInfoScreen", copy.getType());
-        assertEquals(1, copy.getBeforeRules().size());
-        assertEquals(beforeRule, copy.getBeforeRules().get(0));
-        assertEquals(1, copy.getAfterRules().size());
-        assertEquals(afterRule, copy.getAfterRules().get(0));
+        assertEquals(copy.getPrompt(), "prompt");
+        assertEquals(copy.getPromptDetail(), "promptDetail");
+        assertEquals(copy.getTitle(), "title");
+        assertEquals(copy.getImage(), screen.getImage());
+        assertEquals(copy.getSurveyCompoundKey(), "surveyCompoundKey");
+        assertEquals(copy.getGuid(), "guid");
+        assertEquals(copy.getIdentifier(), "identifier");
+        assertEquals(copy.getType(), "SurveyInfoScreen");
+        assertEquals(copy.getBeforeRules().size(), 1);
+        assertEquals(copy.getBeforeRules().get(0), beforeRule);
+        assertEquals(copy.getAfterRules().size(), 1);
+        assertEquals(copy.getAfterRules().get(0), afterRule);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyQuestionTest.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
 import org.sagebionetworks.bridge.models.surveys.SurveyQuestion;
@@ -12,6 +10,9 @@ import org.sagebionetworks.bridge.models.surveys.SurveyRule;
 import org.sagebionetworks.bridge.models.surveys.UIHint;
 import org.sagebionetworks.bridge.models.surveys.Unit;
 import org.sagebionetworks.bridge.models.surveys.SurveyRule.Operator;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -36,19 +37,19 @@ public class DynamoSurveyQuestionTest {
         question.setAfterRules(Lists.newArrayList(afterRule));
     
         SurveyQuestion copy = new DynamoSurveyQuestion(question);
-        assertEquals("prompt", copy.getPrompt());
-        assertEquals("promptDetail", copy.getPromptDetail());
+        assertEquals(copy.getPrompt(), "prompt");
+        assertEquals(copy.getPromptDetail(), "promptDetail");
         assertTrue(copy.getFireEvent());
-        assertEquals(UIHint.COMBOBOX, copy.getUiHint());
+        assertEquals(copy.getUiHint(), UIHint.COMBOBOX);
         assertTrue(copy.getConstraints() instanceof IntegerConstraints);
-        assertEquals("surveyCompoundKey", copy.getSurveyCompoundKey());
-        assertEquals("guid", copy.getGuid());
-        assertEquals("identifier", copy.getIdentifier());
-        assertEquals("SurveyQuestion", copy.getType());
-        assertEquals(1, copy.getBeforeRules().size());
-        assertEquals(question.getBeforeRules().get(0), copy.getBeforeRules().get(0));
-        assertEquals(1, copy.getAfterRules().size());
-        assertEquals(question.getAfterRules().get(0), copy.getAfterRules().get(0));
+        assertEquals(copy.getSurveyCompoundKey(), "surveyCompoundKey");
+        assertEquals(copy.getGuid(), "guid");
+        assertEquals(copy.getIdentifier(), "identifier");
+        assertEquals(copy.getType(), "SurveyQuestion");
+        assertEquals(copy.getBeforeRules().size(), 1);
+        assertEquals(copy.getBeforeRules().get(0), question.getBeforeRules().get(0));
+        assertEquals(copy.getAfterRules().size(), 1);
+        assertEquals(copy.getAfterRules().get(0), question.getAfterRules().get(0));
     }
     
     @Test
@@ -73,21 +74,21 @@ public class DynamoSurveyQuestionTest {
         question.setConstraints(c);
         
         String string = BridgeObjectMapper.get().writeValueAsString(question);
-        assertEquals("{\"surveyCompoundKey\":\"AAA:1444471810000\",\"guid\":\"AAA\",\"identifier\":\"identifier\",\"type\":\"type\",\"prompt\":\"Prompt\",\"promptDetail\":\"Prompt Detail\",\"fireEvent\":false,\"constraints\":{\"rules\":[],\"dataType\":\"integer\",\"unit\":\"days\",\"minValue\":2.0,\"maxValue\":6.0,\"step\":2.0,\"type\":\"IntegerConstraints\"},\"uiHint\":\"checkbox\"}", string);
+        assertEquals(string, "{\"surveyCompoundKey\":\"AAA:1444471810000\",\"guid\":\"AAA\",\"identifier\":\"identifier\",\"type\":\"type\",\"prompt\":\"Prompt\",\"promptDetail\":\"Prompt Detail\",\"fireEvent\":false,\"constraints\":{\"rules\":[],\"dataType\":\"integer\",\"unit\":\"days\",\"minValue\":2.0,\"maxValue\":6.0,\"step\":2.0,\"type\":\"IntegerConstraints\"},\"uiHint\":\"checkbox\"}");
 
         SurveyQuestion question2 = (SurveyQuestion)SurveyQuestion.fromJson(BridgeObjectMapper.get().readTree(string));
-        assertEquals(question.getPromptDetail(), question2.getPromptDetail());
-        assertEquals(question.getPrompt(), question2.getPrompt());
-        assertEquals(question.getIdentifier(), question2.getIdentifier());
-        assertEquals(question.getGuid(), question2.getGuid());
-        assertEquals(question.getType(), question2.getType());
-        assertEquals(question.getUiHint(), question2.getUiHint());
+        assertEquals(question2.getPromptDetail(), question.getPromptDetail());
+        assertEquals(question2.getPrompt(), question.getPrompt());
+        assertEquals(question2.getIdentifier(), question.getIdentifier());
+        assertEquals(question2.getGuid(), question.getGuid());
+        assertEquals(question2.getType(), question.getType());
+        assertEquals(question2.getUiHint(), question.getUiHint());
         
         IntegerConstraints c2 = (IntegerConstraints)question2.getConstraints();
-        assertEquals(c.getMinValue(), c2.getMinValue());
-        assertEquals(c.getMaxValue(), c2.getMaxValue());
-        assertEquals(c.getStep(), c2.getStep());
-        assertEquals(c.getUnit(), c2.getUnit());
+        assertEquals(c2.getMinValue(), c.getMinValue());
+        assertEquals(c2.getMaxValue(), c.getMaxValue());
+        assertEquals(c2.getStep(), c.getStep());
+        assertEquals(c2.getUnit(), c.getUnit());
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
@@ -13,7 +13,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.DataType;
@@ -67,50 +67,50 @@ public class DynamoSurveyTest {
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(survey, JsonNode.class);
 
         // Convert JSON to map to validate JSON. Note that study ID is intentionally omitted, but type is added.
-        assertEquals(14, jsonNode.size());
-        assertEquals("test-survey-guid", jsonNode.get("guid").textValue());
-        assertEquals(2, jsonNode.get("version").intValue());
-        assertEquals(TEST_COPYRIGHT_NOTICE, jsonNode.get("copyrightNotice").textValue());
-        assertEquals(MODULE_ID, jsonNode.get("moduleId").textValue());
-        assertEquals(MODULE_VERSION, jsonNode.get("moduleVersion").intValue());
-        assertEquals(survey.getName(), jsonNode.get("name").textValue());
-        assertEquals(survey.getIdentifier(), jsonNode.get("identifier").textValue());
+        assertEquals(jsonNode.size(), 14);
+        assertEquals(jsonNode.get("guid").textValue(), "test-survey-guid");
+        assertEquals(jsonNode.get("version").intValue(), 2);
+        assertEquals(jsonNode.get("copyrightNotice").textValue(), TEST_COPYRIGHT_NOTICE);
+        assertEquals(jsonNode.get("moduleId").textValue(), MODULE_ID);
+        assertEquals(jsonNode.get("moduleVersion").intValue(), MODULE_VERSION);
+        assertEquals(jsonNode.get("name").textValue(), survey.getName());
+        assertEquals(jsonNode.get("identifier").textValue(), survey.getIdentifier());
         assertTrue(jsonNode.get("published").booleanValue());
         assertTrue(jsonNode.get("deleted").booleanValue());
-        assertEquals(42, jsonNode.get("schemaRevision").intValue());
-        assertEquals("Survey", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.get("schemaRevision").intValue(), 42);
+        assertEquals(jsonNode.get("type").textValue(), "Survey");
 
         // Timestamps are stored as long, but serialized as ISO timestamps. Convert them back to long millis so we
         // don't have to deal with timezones and formatting issues.
-        assertEquals(TEST_CREATED_ON_MILLIS, DateTime.parse(jsonNode.get("createdOn").textValue()).getMillis());
-        assertEquals(TEST_MODIFIED_ON_MILLIS, DateTime.parse(jsonNode.get("modifiedOn").textValue()).getMillis());
+        assertEquals(DateTime.parse(jsonNode.get("createdOn").textValue()).getMillis(), TEST_CREATED_ON_MILLIS);
+        assertEquals(DateTime.parse(jsonNode.get("modifiedOn").textValue()).getMillis(), TEST_MODIFIED_ON_MILLIS);
 
         // Just test that we have the right number of elements. In-depth serialization testing is done by
         // SurveyElementTest
         JsonNode jsonElementList = jsonNode.get("elements");
-        assertEquals(12, jsonElementList.size());
+        assertEquals(jsonElementList.size(), 12);
 
         // Convert back to POJO and validate. Note that study ID is still missing, since it was removed from the JSON.
         Survey convertedSurvey = BridgeObjectMapper.get().convertValue(jsonNode, Survey.class);
         assertNull(convertedSurvey.getStudyIdentifier());
-        assertEquals("test-survey-guid", convertedSurvey.getGuid());
-        assertEquals(TEST_CREATED_ON_MILLIS, convertedSurvey.getCreatedOn());
-        assertEquals(TEST_MODIFIED_ON_MILLIS, convertedSurvey.getModifiedOn());
-        assertEquals(TEST_COPYRIGHT_NOTICE, convertedSurvey.getCopyrightNotice());
-        assertEquals(MODULE_ID, convertedSurvey.getModuleId());
-        assertEquals(MODULE_VERSION, convertedSurvey.getModuleVersion().intValue());
-        assertEquals(2, convertedSurvey.getVersion().longValue());
-        assertEquals(survey.getName(), convertedSurvey.getName());
-        assertEquals(survey.getIdentifier(), convertedSurvey.getIdentifier());
+        assertEquals(convertedSurvey.getGuid(), "test-survey-guid");
+        assertEquals(convertedSurvey.getCreatedOn(), TEST_CREATED_ON_MILLIS);
+        assertEquals(convertedSurvey.getModifiedOn(), TEST_MODIFIED_ON_MILLIS);
+        assertEquals(convertedSurvey.getCopyrightNotice(), TEST_COPYRIGHT_NOTICE);
+        assertEquals(convertedSurvey.getModuleId(), MODULE_ID);
+        assertEquals(convertedSurvey.getModuleVersion().intValue(), MODULE_VERSION);
+        assertEquals(convertedSurvey.getVersion().longValue(), 2);
+        assertEquals(convertedSurvey.getName(), survey.getName());
+        assertEquals(convertedSurvey.getIdentifier(), survey.getIdentifier());
         assertTrue(convertedSurvey.isPublished());
-        assertEquals(42, convertedSurvey.getSchemaRevision().longValue());
-        assertEquals(12, convertedSurvey.getElements().size());
+        assertEquals(convertedSurvey.getSchemaRevision().longValue(), 42);
+        assertEquals(convertedSurvey.getElements().size(), 12);
         for (int i = 0; i < 12; i++) {
             assertEqualsSurveyElement(survey.getElements().get(i), convertedSurvey.getElements().get(i));
         }
 
         // There are 11 survey elements, but only the first 10 are questions.
-        assertEquals(11, convertedSurvey.getUnmodifiableQuestionList().size());
+        assertEquals(convertedSurvey.getUnmodifiableQuestionList().size(), 11);
         for (int i = 0; i < 11; i++) {
             assertEqualsSurveyElement(convertedSurvey.getElements().get(i),
                     convertedSurvey.getUnmodifiableQuestionList().get(i));
@@ -119,24 +119,24 @@ public class DynamoSurveyTest {
         // validate that date constraints are persisted
         SurveyQuestion convertedDateQuestion = (SurveyQuestion)TestSurvey.selectBy(convertedSurvey, DataType.DATE);
         DateConstraints dc = (DateConstraints)convertedDateQuestion.getConstraints();
-        assertNotNull("Earliest date exists", dc.getEarliestValue());
-        assertNotNull("Latest date exists", dc.getLatestValue());
-        assertEquals(rule, convertedDateQuestion.getAfterRules().get(0));
+        assertNotNull(dc.getEarliestValue(), "Earliest date exists");
+        assertNotNull(dc.getLatestValue(), "Latest date exists");
+        assertEquals(convertedDateQuestion.getAfterRules().get(0), rule);
 
         DateTimeConstraints dtc = (DateTimeConstraints) TestSurvey.selectBy(convertedSurvey, DataType.DATETIME).getConstraints();
-        assertNotNull("Earliest date exists", dtc.getEarliestValue());
-        assertNotNull("Latest date exists", dtc.getLatestValue());
+        assertNotNull(dtc.getEarliestValue(), "Earliest date exists");
+        assertNotNull(dtc.getLatestValue(), "Latest date exists");
         
         IntegerConstraints ic = (IntegerConstraints) TestSurvey.selectBy(convertedSurvey, DataType.INTEGER).getConstraints();
-        assertEquals(SurveyRule.Operator.LE, ic.getRules().get(0).getOperator());
-        assertEquals(2, ic.getRules().get(0).getValue());
-        assertEquals("name", ic.getRules().get(0).getSkipToTarget());
+        assertEquals(ic.getRules().get(0).getOperator(), SurveyRule.Operator.LE);
+        assertEquals(ic.getRules().get(0).getValue(), 2);
+        assertEquals(ic.getRules().get(0).getSkipToTarget(), "name");
         
-        assertEquals(SurveyRule.Operator.DE, ic.getRules().get(1).getOperator());
-        assertEquals("name", ic.getRules().get(1).getSkipToTarget());
+        assertEquals(ic.getRules().get(1).getOperator(), SurveyRule.Operator.DE);
+        assertEquals(ic.getRules().get(1).getSkipToTarget(), "name");
         
         SurveyInfoScreen retrievedScreen = (SurveyInfoScreen)convertedSurvey.getElements().get(convertedSurvey.getElements().size()-1);
-        assertEquals(rule, retrievedScreen.getAfterRules().get(0));
+        assertEquals(retrievedScreen.getAfterRules().get(0), rule);
     }
 
     @Test
@@ -146,19 +146,19 @@ public class DynamoSurveyTest {
         Survey copy = new DynamoSurvey(survey);
 
         // validate
-        assertEquals(TEST_STUDY_IDENTIFIER, copy.getStudyIdentifier());
-        assertEquals("test-survey-guid", copy.getGuid());
-        assertEquals(TEST_CREATED_ON_MILLIS, copy.getCreatedOn());
-        assertEquals(TEST_MODIFIED_ON_MILLIS, copy.getModifiedOn());
-        assertEquals(TEST_COPYRIGHT_NOTICE, copy.getCopyrightNotice());
-        assertEquals(MODULE_ID, copy.getModuleId());
-        assertEquals(MODULE_VERSION, copy.getModuleVersion().intValue());
-        assertEquals(2, copy.getVersion().longValue());
-        assertEquals(survey.getName(), copy.getName());
-        assertEquals(survey.getIdentifier(), copy.getIdentifier());
+        assertEquals(copy.getStudyIdentifier(), TEST_STUDY_IDENTIFIER);
+        assertEquals(copy.getGuid(), "test-survey-guid");
+        assertEquals(copy.getCreatedOn(), TEST_CREATED_ON_MILLIS);
+        assertEquals(copy.getModifiedOn(), TEST_MODIFIED_ON_MILLIS);
+        assertEquals(copy.getCopyrightNotice(), TEST_COPYRIGHT_NOTICE);
+        assertEquals(copy.getModuleId(), MODULE_ID);
+        assertEquals(copy.getModuleVersion().intValue(), MODULE_VERSION);
+        assertEquals(copy.getVersion().longValue(), 2);
+        assertEquals(copy.getName(), survey.getName());
+        assertEquals(copy.getIdentifier(), survey.getIdentifier());
         assertTrue(copy.isPublished());
-        assertEquals(42, copy.getSchemaRevision().longValue());
-        assertEquals(11, copy.getElements().size());
+        assertEquals(copy.getSchemaRevision().longValue(), 42);
+        assertEquals(copy.getElements().size(), 11);
         for (int i = 0; i < 11; i++) {
             assertEqualsSurveyElement(survey.getElements().get(i), copy.getElements().get(i));
         }
@@ -186,7 +186,7 @@ public class DynamoSurveyTest {
         // and they have the same ID.
         assertTrue((expected instanceof DynamoSurveyQuestion && actual instanceof DynamoSurveyQuestion)
                 || (expected instanceof DynamoSurveyInfoScreen && actual instanceof DynamoSurveyInfoScreen));
-        assertEquals(expected.getIdentifier(), actual.getIdentifier());
+        assertEquals(actual.getIdentifier(), expected.getIdentifier());
     }
 
     private static DynamoSurvey makeTestSurvey() {

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTopicSubscriptionDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoTopicSubscriptionDaoTest.java
@@ -2,9 +2,8 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static org.sagebionetworks.bridge.TestUtils.getNotificationRegistration;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationTopic;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -12,13 +11,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.notifications.NotificationProtocol;
 import org.sagebionetworks.bridge.models.notifications.NotificationRegistration;
@@ -31,7 +29,6 @@ import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.model.SubscribeRequest;
 import com.amazonaws.services.sns.model.SubscribeResult;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoTopicSubscriptionDaoTest {
     private static final String ENDPOINT_ARN = "endpoint-arn";
     private static final AmazonServiceException EXCEPTION = new AmazonServiceException("Somethin' bad happened [test]");
@@ -61,8 +58,9 @@ public class DynamoTopicSubscriptionDaoTest {
     @Captor
     private ArgumentCaptor<String> unsubscribeStringCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         subDao = new DynamoTopicSubscriptionDao();
         subDao.setTopicSubscriptionMapper(mockMapper);
         subDao.setSnsClient(mockSnsClient);
@@ -88,20 +86,20 @@ public class DynamoTopicSubscriptionDaoTest {
         verify(mockSnsClient).subscribe(subscribeRequestCaptor.capture());
         
         SubscribeRequest request = subscribeRequestCaptor.getValue();
-        assertEquals(TOPIC_ARN, request.getTopicArn());
-        assertEquals("application", request.getProtocol());
-        assertEquals(ENDPOINT_ARN, request.getEndpoint());
+        assertEquals(request.getTopicArn(), TOPIC_ARN);
+        assertEquals(request.getProtocol(), "application");
+        assertEquals(request.getEndpoint(), ENDPOINT_ARN);
         
         verify(mockMapper).save(subscriptionCaptor.capture());
         
         TopicSubscription saved = subscriptionCaptor.getValue();
-        assertEquals("registrationGuid", saved.getRegistrationGuid());
-        assertEquals("subscriptionARN", saved.getSubscriptionARN());
-        assertEquals("topicGuid", saved.getTopicGuid());
+        assertEquals(saved.getRegistrationGuid(), "registrationGuid");
+        assertEquals(saved.getSubscriptionARN(), "subscriptionARN");
+        assertEquals(saved.getTopicGuid(), "topicGuid");
         
-        assertEquals("registrationGuid", sub.getRegistrationGuid());
-        assertEquals("subscriptionARN", sub.getSubscriptionARN());
-        assertEquals("topicGuid", sub.getTopicGuid());
+        assertEquals(sub.getRegistrationGuid(), "registrationGuid");
+        assertEquals(sub.getSubscriptionARN(), "subscriptionARN");
+        assertEquals(sub.getTopicGuid(), "topicGuid");
     }
 
     @Test
@@ -123,9 +121,9 @@ public class DynamoTopicSubscriptionDaoTest {
 
         verify(mockSnsClient).subscribe(subscribeRequestCaptor.capture());
         SubscribeRequest request = subscribeRequestCaptor.getValue();
-        assertEquals(TOPIC_ARN, request.getTopicArn());
-        assertEquals("sms", request.getProtocol());
-        assertEquals(PHONE, request.getEndpoint());
+        assertEquals(request.getTopicArn(), TOPIC_ARN);
+        assertEquals(request.getProtocol(), "sms");
+        assertEquals(request.getEndpoint(), PHONE);
     }
 
     @Test
@@ -164,12 +162,12 @@ public class DynamoTopicSubscriptionDaoTest {
         verify(mockSnsClient).unsubscribe(unsubscribeStringCaptor.capture());
         
         TopicSubscription saved = subscriptionCaptor.getValue();
-        assertEquals("registrationGuid", saved.getRegistrationGuid());
-        assertEquals("subscriptionARN", saved.getSubscriptionARN());
-        assertEquals("topicGuid", saved.getTopicGuid());
+        assertEquals(saved.getRegistrationGuid(), "registrationGuid");
+        assertEquals(saved.getSubscriptionARN(), "subscriptionARN");
+        assertEquals(saved.getTopicGuid(), "topicGuid");
         
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
     }
     
     @Test
@@ -189,15 +187,15 @@ public class DynamoTopicSubscriptionDaoTest {
         verify(mockMapper).delete(subscriptionCaptor.capture());
         
         DynamoTopicSubscription loadKey = subscriptionCaptor.getAllValues().get(0);
-        assertEquals("registrationGuid", loadKey.getRegistrationGuid());
-        assertEquals("topicGuid", loadKey.getTopicGuid());
+        assertEquals(loadKey.getRegistrationGuid(), "registrationGuid");
+        assertEquals(loadKey.getTopicGuid(), "topicGuid");
         
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
         
         DynamoTopicSubscription deleteObj = subscriptionCaptor.getAllValues().get(1);
-        assertEquals("registrationGuid", deleteObj.getRegistrationGuid());
-        assertEquals("topicGuid", deleteObj.getTopicGuid());
+        assertEquals(deleteObj.getRegistrationGuid(), "registrationGuid");
+        assertEquals(deleteObj.getTopicGuid(), "topicGuid");
     }
     
     @Test
@@ -223,11 +221,11 @@ public class DynamoTopicSubscriptionDaoTest {
         verify(mockMapper, never()).delete(subscriptionCaptor.capture());
         
         DynamoTopicSubscription loadKey = subscriptionCaptor.getAllValues().get(0);
-        assertEquals("registrationGuid", loadKey.getRegistrationGuid());
-        assertEquals("topicGuid", loadKey.getTopicGuid());
+        assertEquals(loadKey.getRegistrationGuid(), "registrationGuid");
+        assertEquals(loadKey.getTopicGuid(), "topicGuid");
         
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
     }
     
     @Test
@@ -253,14 +251,14 @@ public class DynamoTopicSubscriptionDaoTest {
         verify(mockMapper).delete(subscriptionCaptor.capture());
         
         DynamoTopicSubscription loadKey = subscriptionCaptor.getAllValues().get(0);
-        assertEquals("registrationGuid", loadKey.getRegistrationGuid());
-        assertEquals("topicGuid", loadKey.getTopicGuid());
+        assertEquals(loadKey.getRegistrationGuid(), "registrationGuid");
+        assertEquals(loadKey.getTopicGuid(), "topicGuid");
         
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
         
         DynamoTopicSubscription deleteObj = subscriptionCaptor.getAllValues().get(1);
-        assertEquals("registrationGuid", deleteObj.getRegistrationGuid());
+        assertEquals(deleteObj.getRegistrationGuid(), "registrationGuid");
         
         // This leaves no SNS topic subscription, but a record in DDB. This is okay and we will
         // attempt to clean this up from the service any time the user updates their subscriptions.
@@ -275,11 +273,11 @@ public class DynamoTopicSubscriptionDaoTest {
         
         verify(mockSnsClient).unsubscribe(unsubscribeStringCaptor.capture());
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
         
         verify(mockMapper).delete(subscriptionCaptor.capture());
         DynamoTopicSubscription capturedSub = subscriptionCaptor.getValue();
-        assertEquals(subscription, capturedSub);
+        assertEquals(capturedSub, subscription);
     }
     
     @Test
@@ -298,10 +296,10 @@ public class DynamoTopicSubscriptionDaoTest {
         
         verify(mockSnsClient).unsubscribe(unsubscribeStringCaptor.capture());
         String subscriptionARN = unsubscribeStringCaptor.getValue();
-        assertEquals("subscriptionARN", subscriptionARN);
+        assertEquals(subscriptionARN, "subscriptionARN");
         
         verify(mockMapper).delete(subscriptionCaptor.capture());
         DynamoTopicSubscription capturedSub = subscriptionCaptor.getValue();
-        assertEquals(subscription, capturedSub);
+        assertEquals(capturedSub, subscription);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
@@ -14,7 +14,7 @@ import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -52,25 +52,25 @@ public class DynamoUpload2Test {
         upload.setVersion(2L);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(upload);
-        assertEquals("s3_worker", node.get("completedBy").textValue());
-        assertEquals(requestedOn.toString(), node.get("requestedOn").textValue());
-        assertEquals(completedOn.toString(), node.get("completedOn").textValue());
-        assertEquals(10000L, node.get("contentLength").longValue());
-        assertEquals("original-upload-id", node.get("duplicateUploadId").textValue());
-        assertEquals("succeeded", node.get("status").textValue());
-        assertEquals("2016-10-10", node.get("uploadDate").textValue());
-        assertEquals("ABC", node.get("recordId").textValue());
-        assertEquals("DEF", node.get("uploadId").textValue());
-        assertEquals("abc", node.get("contentMd5").textValue());
-        assertEquals("application/json", node.get("contentType").textValue());
-        assertEquals("filename.zip", node.get("filename").textValue());
-        assertEquals("api", node.get("studyId").textValue());
-        assertEquals(2L, node.get("version").longValue());
-        assertEquals("healthCode", node.get("healthCode").textValue());
+        assertEquals(node.get("completedBy").textValue(), "s3_worker");
+        assertEquals(node.get("requestedOn").textValue(), requestedOn.toString());
+        assertEquals(node.get("completedOn").textValue(), completedOn.toString());
+        assertEquals(node.get("contentLength").longValue(), 10000L);
+        assertEquals(node.get("duplicateUploadId").textValue(), "original-upload-id");
+        assertEquals(node.get("status").textValue(), "succeeded");
+        assertEquals(node.get("uploadDate").textValue(), "2016-10-10");
+        assertEquals(node.get("recordId").textValue(), "ABC");
+        assertEquals(node.get("uploadId").textValue(), "DEF");
+        assertEquals(node.get("contentMd5").textValue(), "abc");
+        assertEquals(node.get("contentType").textValue(), "application/json");
+        assertEquals(node.get("filename").textValue(), "filename.zip");
+        assertEquals(node.get("studyId").textValue(), "api");
+        assertEquals(node.get("version").longValue(), 2L);
+        assertEquals(node.get("healthCode").textValue(), "healthCode");
         
         ArrayNode messages = (ArrayNode)node.get("validationMessageList");
-        assertEquals("message 1", messages.get(0).textValue());
-        assertEquals("message 2", messages.get(1).textValue());
+        assertEquals(messages.get(0).textValue(), "message 1");
+        assertEquals(messages.get(1).textValue(), "message 2");
     }
     
     @Test
@@ -86,19 +86,19 @@ public class DynamoUpload2Test {
         List<String> list2 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
         // set should overwrite
         upload2.setValidationMessageList(ImmutableList.of("second message"));
         List<String> list3 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
-        assertEquals(1, list3.size());
-        assertEquals("second message", list3.get(0));
+        assertEquals(list3.size(), 1);
+        assertEquals(list3.get(0), "second message");
     }
 
     @Test
@@ -114,20 +114,20 @@ public class DynamoUpload2Test {
         List<String> list2 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
         // append again
         upload2.appendValidationMessages(ImmutableList.of("second message"));
         List<String> list3 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
-        assertEquals(2, list3.size());
-        assertEquals("first message", list3.get(0));
-        assertEquals("second message", list3.get(1));
+        assertEquals(list3.size(), 2);
+        assertEquals(list3.get(0), "first message");
+        assertEquals(list3.get(1), "second message");
     }
 
     @Test
@@ -143,35 +143,35 @@ public class DynamoUpload2Test {
         List<String> list2 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
         // append on a set
         upload2.appendValidationMessages(ImmutableList.of("second message"));
         List<String> list3 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
-        assertEquals(2, list3.size());
-        assertEquals("first message", list3.get(0));
-        assertEquals("second message", list3.get(1));
+        assertEquals(list3.size(), 2);
+        assertEquals(list3.get(0), "first message");
+        assertEquals(list3.get(1), "second message");
 
         // set should overwrite the append
         upload2.setValidationMessageList(ImmutableList.of("third message"));
         List<String> list4 = upload2.getValidationMessageList();
         assertTrue(initialList.isEmpty());
 
-        assertEquals(1, list2.size());
-        assertEquals("first message", list2.get(0));
+        assertEquals(list2.size(), 1);
+        assertEquals(list2.get(0), "first message");
 
-        assertEquals(2, list3.size());
-        assertEquals("first message", list3.get(0));
-        assertEquals("second message", list3.get(1));
+        assertEquals(list3.size(), 2);
+        assertEquals(list3.get(0), "first message");
+        assertEquals(list3.get(1), "second message");
 
-        assertEquals(1, list4.size());
-        assertEquals("third message", list4.get(0));
+        assertEquals(list4.size(), 1);
+        assertEquals(list4.get(0), "third message");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,13 +21,13 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -57,7 +57,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DynamoUploadDaoMockTest {
     
     private static String UPLOAD_ID = "uploadId";
@@ -118,8 +117,9 @@ public class DynamoUploadDaoMockTest {
     
     private DynamoUploadDao dao;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao = new DynamoUploadDao();
         dao.setDdbMapper(mockMapper);
         dao.setHealthCodeDao(healthCodeDao);
@@ -138,15 +138,15 @@ public class DynamoUploadDaoMockTest {
         DynamoUpload2 capturedUpload = uploadCaptor.getValue();
 
         // Validate that our DDB upload object matches our upload request, and that the upload ID matches.
-        assertEquals(upload.getUploadId(), capturedUpload.getUploadId());
+        assertEquals(capturedUpload.getUploadId(), upload.getUploadId());
         assertNull(capturedUpload.getDuplicateUploadId());
-        assertEquals(TEST_STUDY.getIdentifier(), capturedUpload.getStudyId());
+        assertEquals(capturedUpload.getStudyId(), TEST_STUDY.getIdentifier());
         assertTrue(capturedUpload.getRequestedOn() > 0);
-        assertEquals(UploadStatus.REQUESTED, capturedUpload.getStatus());
-        assertEquals(req.getContentLength(), capturedUpload.getContentLength());
-        assertEquals(req.getContentMd5(), capturedUpload.getContentMd5());
-        assertEquals(req.getContentType(), capturedUpload.getContentType());
-        assertEquals(req.getName(), capturedUpload.getFilename());
+        assertEquals(capturedUpload.getStatus(), UploadStatus.REQUESTED);
+        assertEquals(capturedUpload.getContentLength(), req.getContentLength());
+        assertEquals(capturedUpload.getContentMd5(), req.getContentMd5());
+        assertEquals(capturedUpload.getContentType(), req.getContentType());
+        assertEquals(capturedUpload.getFilename(), req.getName());
     }
 
     @Test
@@ -162,10 +162,10 @@ public class DynamoUploadDaoMockTest {
         
         // Validate key values (study ID, requestedOn) and values from the dupe code path.
         // Everything else is tested in the previous test
-        assertEquals("original-upload-id", capturedUpload.getDuplicateUploadId());
-        assertEquals(TEST_STUDY.getIdentifier(), capturedUpload.getStudyId());
+        assertEquals(capturedUpload.getDuplicateUploadId(), "original-upload-id");
+        assertEquals(capturedUpload.getStudyId(), TEST_STUDY.getIdentifier());
         assertTrue(capturedUpload.getRequestedOn() > 0);
-        assertEquals(UploadStatus.DUPLICATE, capturedUpload.getStatus());
+        assertEquals(capturedUpload.getStatus(), UploadStatus.DUPLICATE);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class DynamoUploadDaoMockTest {
         assertSame(upload, retVal);
 
         // validate we passed in the expected key
-        assertEquals("test-get-upload", uploadCaptor.getValue().getUploadId());
+        assertEquals(uploadCaptor.getValue().getUploadId(), "test-get-upload");
     }
     
     @Test
@@ -192,10 +192,10 @@ public class DynamoUploadDaoMockTest {
         when(healthCodeDao.getStudyIdentifier(upload.getHealthCode())).thenReturn("studyId");
         
         Upload retVal = dao.getUpload("test-get-upload");
-        assertEquals("studyId", retVal.getStudyId());
+        assertEquals(retVal.getStudyId(), "studyId");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getUploadWithoutStudyIdAndNoHealthCodeRecord() {
         DynamoUpload2 upload = new DynamoUpload2();
         upload.setHealthCode("healthCode");
@@ -221,7 +221,7 @@ public class DynamoUploadDaoMockTest {
         assertNotNull(thrown);
 
         // validate we passed in the expected key
-        assertEquals("test-get-404", uploadCaptor.getValue().getUploadId());
+        assertEquals(uploadCaptor.getValue().getUploadId(), "test-get-404");
     }
 
     @Test
@@ -232,12 +232,12 @@ public class DynamoUploadDaoMockTest {
         // Verify our mock. We add status=VALIDATION_IN_PROGRESS and uploadDate on save, so only check for those
         // properties.
         verify(mockMapper).save(uploadCaptor.capture());
-        assertEquals(UploadStatus.VALIDATION_IN_PROGRESS, uploadCaptor.getValue().getStatus());
-        assertEquals(UploadCompletionClient.APP, uploadCaptor.getValue().getCompletedBy());
+        assertEquals(uploadCaptor.getValue().getStatus(), UploadStatus.VALIDATION_IN_PROGRESS);
+        assertEquals(uploadCaptor.getValue().getCompletedBy(), UploadCompletionClient.APP);
         assertTrue(uploadCaptor.getValue().getCompletedOn() > 0);
 
         // There is a slim chance that this will fail if it runs just after midnight.
-        assertEquals(LocalDate.now(DateTimeZone.forID("America/Los_Angeles")), uploadCaptor.getValue().getUploadDate());
+        assertEquals(uploadCaptor.getValue().getUploadDate(), LocalDate.now(DateTimeZone.forID("America/Los_Angeles")));
     }
 
     @Test
@@ -252,12 +252,12 @@ public class DynamoUploadDaoMockTest {
 
         // Verify our mock. We set the status and append messages.
         verify(mockMapper).save(uploadCaptor.capture());
-        assertEquals(UploadStatus.SUCCEEDED, uploadCaptor.getValue().getStatus());
+        assertEquals(uploadCaptor.getValue().getStatus(), UploadStatus.SUCCEEDED);
         assertNull(uploadCaptor.getValue().getRecordId());
 
         List<String> messageList = uploadCaptor.getValue().getValidationMessageList();
-        assertEquals(1, messageList.size());
-        assertEquals("wrote new", messageList.get(0));
+        assertEquals(messageList.size(), 1);
+        assertEquals(messageList.get(0), "wrote new");
     }
 
     @Test
@@ -273,13 +273,13 @@ public class DynamoUploadDaoMockTest {
 
         // Verify our mock. We set the status and append messages.
         verify(mockMapper).save(uploadCaptor.capture());
-        assertEquals(UploadStatus.SUCCEEDED, uploadCaptor.getValue().getStatus());
-        assertEquals("test-record-id", uploadCaptor.getValue().getRecordId());
+        assertEquals(uploadCaptor.getValue().getStatus(), UploadStatus.SUCCEEDED);
+        assertEquals(uploadCaptor.getValue().getRecordId(), "test-record-id");
 
         List<String> messageList = uploadCaptor.getValue().getValidationMessageList();
-        assertEquals(2, messageList.size());
-        assertEquals("pre-existing message", messageList.get(0));
-        assertEquals("appended this message", messageList.get(1));
+        assertEquals(messageList.size(), 2);
+        assertEquals(messageList.get(0), "pre-existing message");
+        assertEquals(messageList.get(1), "appended this message");
     }
     
     @Test
@@ -311,22 +311,22 @@ public class DynamoUploadDaoMockTest {
         
         verify(mockIndexHelper).query(querySpecCaptor.capture());
         QuerySpec mockSpec = querySpecCaptor.getValue();
-        assertEquals(new Integer(51), mockSpec.getMaxPageSize());
-        assertEquals(healthCode, mockSpec.getHashKey().getValue());
+        assertEquals(mockSpec.getMaxPageSize(), new Integer(51));
+        assertEquals(mockSpec.getHashKey().getValue(), healthCode);
         
         verify(mockMapper).batchLoad(uploadListCaptor.capture());
         List<Upload> uploads = uploadListCaptor.getValue();
-        assertEquals(2, uploads.size());
+        assertEquals(uploads.size(), 2);
         
         // These have been sorted.
-        assertEquals(2, page.getItems().size());
-        assertEquals(10000, page.getItems().get(0).getRequestedOn());
-        assertEquals(30000, page.getItems().get(1).getRequestedOn());
+        assertEquals(page.getItems().size(), 2);
+        assertEquals(page.getItems().get(0).getRequestedOn(), 10000);
+        assertEquals(page.getItems().get(1).getRequestedOn(), 30000);
         
         // All parameters were returned. No paging in this test
-        assertEquals((Integer)pageSize, page.getRequestParams().get("pageSize"));
-        assertEquals(startTime.toString(), page.getRequestParams().get("startTime"));
-        assertEquals(endTime.toString(), page.getRequestParams().get("endTime"));
+        assertEquals(page.getRequestParams().get("pageSize"), (Integer)pageSize);
+        assertEquals(page.getRequestParams().get("startTime"), startTime.toString());
+        assertEquals(page.getRequestParams().get("endTime"), endTime.toString());
     }
 
     @Test
@@ -365,18 +365,18 @@ public class DynamoUploadDaoMockTest {
         when(mockMapper.batchLoad(any(List.class))).thenReturn(batchLoadMap1, batchLoadMap2);
         
         ForwardCursorPagedResourceList<Upload> page1 = dao.getUploads(healthCode, startTime, endTime, pageSize, null);
-        assertEquals("30000", page1.getNextPageOffsetKey());
+        assertEquals(page1.getNextPageOffsetKey(), "30000");
         assertNull(page1.getRequestParams().get("offsetKey"));
-        assertEquals(pageSize, page1.getRequestParams().get("pageSize"));
-        assertEquals(startTime.toString(), page1.getRequestParams().get("startTime"));
-        assertEquals(endTime.toString(), page1.getRequestParams().get("endTime"));
+        assertEquals(page1.getRequestParams().get("pageSize"), pageSize);
+        assertEquals(page1.getRequestParams().get("startTime"), startTime.toString());
+        assertEquals(page1.getRequestParams().get("endTime"), endTime.toString());
         
         ForwardCursorPagedResourceList<Upload> page2 = dao.getUploads(healthCode, startTime, endTime, pageSize, page1.getNextPageOffsetKey());
         assertNull(page2.getNextPageOffsetKey());
-        assertEquals("30000", page2.getRequestParams().get("offsetKey"));
-        assertEquals(pageSize, page2.getRequestParams().get("pageSize"));
-        assertEquals(startTime.toString(), page2.getRequestParams().get("startTime"));
-        assertEquals(endTime.toString(), page2.getRequestParams().get("endTime"));
+        assertEquals(page2.getRequestParams().get("offsetKey"), "30000");
+        assertEquals(page2.getRequestParams().get("pageSize"), pageSize);
+        assertEquals(page2.getRequestParams().get("startTime"), startTime.toString());
+        assertEquals(page2.getRequestParams().get("endTime"), endTime.toString());
     }
     
     @SuppressWarnings("unchecked")
@@ -418,18 +418,18 @@ public class DynamoUploadDaoMockTest {
         when(mockMapper.batchLoad(any(List.class))).thenReturn(batchLoadMap1, batchLoadMap2);
         
         ForwardCursorPagedResourceList<Upload> page1 = dao.getStudyUploads(studyId, startTime, endTime, pageSize, null);
-        assertEquals("uploadId3", page1.getNextPageOffsetKey());
+        assertEquals(page1.getNextPageOffsetKey(), "uploadId3");
         assertNull(page1.getRequestParams().get("offsetKey"));
-        assertEquals(pageSize, page1.getRequestParams().get("pageSize"));
-        assertEquals(startTime.toString(), page1.getRequestParams().get("startTime"));
-        assertEquals(endTime.toString(), page1.getRequestParams().get("endTime"));
+        assertEquals(page1.getRequestParams().get("pageSize"), pageSize);
+        assertEquals(page1.getRequestParams().get("startTime"), startTime.toString());
+        assertEquals(page1.getRequestParams().get("endTime"), endTime.toString());
         
         ForwardCursorPagedResourceList<Upload> page2 = dao.getStudyUploads(studyId, startTime, endTime, pageSize, page1.getNextPageOffsetKey());
         assertNull(page2.getNextPageOffsetKey());
-        assertEquals("uploadId3", page2.getRequestParams().get("offsetKey"));
-        assertEquals(pageSize, page1.getRequestParams().get("pageSize"));
-        assertEquals(startTime.toString(), page1.getRequestParams().get("startTime"));
-        assertEquals(endTime.toString(), page1.getRequestParams().get("endTime"));
+        assertEquals(page2.getRequestParams().get("offsetKey"), "uploadId3");
+        assertEquals(page1.getRequestParams().get("pageSize"), pageSize);
+        assertEquals(page1.getRequestParams().get("startTime"), startTime.toString());
+        assertEquals(page1.getRequestParams().get("endTime"), endTime.toString());
     }
     
     @Test
@@ -443,7 +443,7 @@ public class DynamoUploadDaoMockTest {
             dao.getStudyUploads(studyId, startTime, endTime, pageSize, "bad-key");
             fail("Should have thrown an exception");
         } catch(BadRequestException e) {
-            assertEquals("Invalid offsetKey: bad-key", e.getMessage());
+            assertEquals(e.getMessage(), "Invalid offsetKey: bad-key");
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoMockTest.java
@@ -177,7 +177,7 @@ public class DynamoUploadDaoMockTest {
 
         // execute
         Upload retVal = dao.getUpload("test-get-upload");
-        assertSame(upload, retVal);
+        assertSame(retVal, upload);
 
         // validate we passed in the expected key
         assertEquals(uploadCaptor.getValue().getUploadId(), "test-get-upload");

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDedupeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDedupeTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class DynamoUploadDedupeTest {
     @Test
@@ -10,14 +10,14 @@ public class DynamoUploadDedupeTest {
         DynamoUploadDedupe dedupe = new DynamoUploadDedupe();
         dedupe.setHealthCode("test-healthcode");
         dedupe.setUploadMd5("test-md5");
-        assertEquals("test-healthcode:test-md5", dedupe.getDdbKey());
+        assertEquals(dedupe.getDdbKey(), "test-healthcode:test-md5");
     }
 
     @Test
     public void getHealthCodeAndMd5FromDdbKey() {
         DynamoUploadDedupe dedupe = new DynamoUploadDedupe();
         dedupe.setDdbKey("test-healthcode:test-md5");
-        assertEquals("test-healthcode", dedupe.getHealthCode());
-        assertEquals("test-md5", dedupe.getUploadMd5());
+        assertEquals(dedupe.getHealthCode(), "test-healthcode");
+        assertEquals(dedupe.getUploadMd5(), "test-md5");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -66,7 +66,7 @@ public class DynamoUploadSchemaDaoMockTest {
         assertFalse(mapperInputSchema.isDeleted());
 
         // schema returned by dao is the same one that was sent to the mapper
-        assertSame(mapperInputSchema, daoOutputSchema);
+        assertSame(daoOutputSchema, mapperInputSchema);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class DynamoUploadSchemaDaoMockTest {
         assertEquals(indexHashKey.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Verify DAO output
-        assertSame(mapperOutputSchemaList, daoOutputSchemaList);
+        assertSame(daoOutputSchemaList, mapperOutputSchemaList);
     }
 
     @Test
@@ -131,7 +131,7 @@ public class DynamoUploadSchemaDaoMockTest {
         assertEquals(indexHashKey.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Verify DAO output
-        assertSame(mapperOutputSchemaList, daoOutputSchemaList);
+        assertSame(daoOutputSchemaList, mapperOutputSchemaList);
     }
 
     @Test
@@ -219,7 +219,7 @@ public class DynamoUploadSchemaDaoMockTest {
         // set up test dao and execute
         UploadSchema daoOutputSchema = dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID,
                 SCHEMA_REV);
-        assertSame(mapperOutputSchema, daoOutputSchema);
+        assertSame(daoOutputSchema, mapperOutputSchema);
 
         // validate intermediate args
         DynamoUploadSchema mapperInputSchema = mapperInputSchemaCaptor.getValue();
@@ -251,7 +251,7 @@ public class DynamoUploadSchemaDaoMockTest {
         assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
 
         // Verify DAO output
-        assertSame(mapperOutputSchema, daoOutputSchema);
+        assertSame(daoOutputSchema, mapperOutputSchema);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -1,10 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -12,6 +7,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -24,9 +24,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
@@ -40,7 +40,7 @@ public class DynamoUploadSchemaDaoMockTest {
     private DynamoUploadSchema daoInputSchema;
     private DynamoUploadSchemaDao dao;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         daoInputSchema = new DynamoUploadSchema();
         mapper = mock(DynamoDBMapper.class);
@@ -109,7 +109,7 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate index hash key
         DynamoUploadSchema indexHashKey = indexHashKeyCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, indexHashKey.getStudyId());
+        assertEquals(indexHashKey.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Verify DAO output
         assertSame(mapperOutputSchemaList, daoOutputSchemaList);
@@ -128,7 +128,7 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate index hash key
         DynamoUploadSchema indexHashKey = indexHashKeyCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, indexHashKey.getStudyId());
+        assertEquals(indexHashKey.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Verify DAO output
         assertSame(mapperOutputSchemaList, daoOutputSchemaList);
@@ -151,13 +151,13 @@ public class DynamoUploadSchemaDaoMockTest {
         when(mapper.batchLoad(pql)).thenReturn(map);
         
         List<UploadSchema> results1 = dao.indexHelper("indexName", new DynamoUploadSchema(), false);
-        assertEquals(1, results1.size());
-        assertEquals(undeletedSchema, results1.get(0));
+        assertEquals(results1.size(), 1);
+        assertEquals(results1.get(0), undeletedSchema);
         
         List<UploadSchema> results2 = dao.indexHelper("indexName", new DynamoUploadSchema(), true);
-        assertEquals(2, results2.size());
-        assertEquals(undeletedSchema, results2.get(0));
-        assertEquals(deletedSchema, results2.get(1));
+        assertEquals(results2.size(), 2);
+        assertEquals(results2.get(0), undeletedSchema);
+        assertEquals(results2.get(1), deletedSchema);
     }
 
     @Test
@@ -175,13 +175,13 @@ public class DynamoUploadSchemaDaoMockTest {
         // validate query
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, mapperQuery.getHashKeyValues().getStudyId());
-        assertEquals(SCHEMA_ID, mapperQuery.getHashKeyValues().getSchemaId());
+        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
         assertNull(mapperQuery.getQueryFilter());
 
         // Verify DAO output is same as mapper output. We use equals because they are different instances, but contain
         // the same objects.
-        assertEquals(mapperOutputSchemaList, daoOutputSchemaList);
+        assertEquals(daoOutputSchemaList, mapperOutputSchemaList);
     }
     
     @Test
@@ -199,14 +199,14 @@ public class DynamoUploadSchemaDaoMockTest {
         // validate query
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, mapperQuery.getHashKeyValues().getStudyId());
-        assertEquals(SCHEMA_ID, mapperQuery.getHashKeyValues().getSchemaId());
-        assertEquals("{deleted={AttributeValueList: [{N: 1,}],ComparisonOperator: NE}}",
-                mapperQuery.getQueryFilter().toString());
+        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
+        assertEquals(mapperQuery.getQueryFilter().toString(),
+                "{deleted={AttributeValueList: [{N: 1,}],ComparisonOperator: NE}}");
 
         // Verify DAO output is same as mapper output. We use equals because they are different instances, but contain
         // the same objects.
-        assertEquals(mapperOutputSchemaList, daoOutputSchemaList);
+        assertEquals(daoOutputSchemaList, mapperOutputSchemaList);
     }
 
     @Test
@@ -223,9 +223,9 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate intermediate args
         DynamoUploadSchema mapperInputSchema = mapperInputSchemaCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, mapperInputSchema.getStudyId());
-        assertEquals(SCHEMA_ID, mapperInputSchema.getSchemaId());
-        assertEquals(SCHEMA_REV, mapperInputSchema.getRevision());
+        assertEquals(mapperInputSchema.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(mapperInputSchema.getSchemaId(), SCHEMA_ID);
+        assertEquals(mapperInputSchema.getRevision(), SCHEMA_REV);
     }
 
     @Test
@@ -246,9 +246,9 @@ public class DynamoUploadSchemaDaoMockTest {
         // validate query
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
-        assertEquals(1, mapperQuery.getLimit().intValue());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, mapperQuery.getHashKeyValues().getStudyId());
-        assertEquals(SCHEMA_ID, mapperQuery.getHashKeyValues().getSchemaId());
+        assertEquals(mapperQuery.getLimit().intValue(), 1);
+        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
 
         // Verify DAO output
         assertSame(mapperOutputSchema, daoOutputSchema);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/EnumMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/EnumMarshallerTest.java
@@ -1,22 +1,22 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class EnumMarshallerTest {
     private static final EnumMarshaller MARSHALLER = new EnumMarshaller(TestEnum.class);
 
     @Test
     public void testMarshall() {
-        assertEquals("FOO", MARSHALLER.convert(TestEnum.FOO));
-        assertEquals("BAR", MARSHALLER.convert(TestEnum.BAR));
+        assertEquals(MARSHALLER.convert(TestEnum.FOO), "FOO");
+        assertEquals(MARSHALLER.convert(TestEnum.BAR), "BAR");
     }
 
     @Test
     public void testUnmarshall() {
-        assertEquals(TestEnum.FOO, MARSHALLER.unconvert("FOO"));
-        assertEquals(TestEnum.BAR, MARSHALLER.unconvert("BAR"));
+        assertEquals(MARSHALLER.unconvert("FOO"), TestEnum.FOO);
+        assertEquals(MARSHALLER.unconvert("BAR"), TestEnum.BAR);
     }
 
     private static enum TestEnum {

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/JsonNodeMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/JsonNodeMarshallerTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
@@ -37,7 +37,7 @@ public class JsonNodeMarshallerTest {
         String json = MARSHALLER.convert(node);
         JsonNode deser = MARSHALLER.unconvert(json);
         
-        assertEquals(node.toString(), deser.toString());
+        assertEquals(deser.toString(), node.toString());
         
         // To simplify testing, convert the deserialized node to a subpopulation
         Subpopulation copy = BridgeObjectMapper.get().treeToValue(deser, Subpopulation.class);
@@ -45,10 +45,10 @@ public class JsonNodeMarshallerTest {
         copy.getCriteria().setKey(subpop.getCriteria().getKey());
         
         // It has serialized/deserialized the object structure, including criteria
-        assertEquals(subpop.getName(), copy.getName());
-        assertEquals(subpop.getGuidString(), copy.getGuidString());
+        assertEquals(copy.getName(), subpop.getName());
+        assertEquals(copy.getGuidString(), subpop.getGuidString());
         assertTrue(copy.isRequired());
-        assertEquals(subpop.getCriteria().getLanguage(), copy.getCriteria().getLanguage());
-        assertEquals(subpop.getCriteria(), copy.getCriteria());
+        assertEquals(copy.getCriteria().getLanguage(), subpop.getCriteria().getLanguage());
+        assertEquals(copy.getCriteria(), subpop.getCriteria());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/ListMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/ListMarshallerTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -40,17 +41,17 @@ public class ListMarshallerTest {
 
         // unconvert from JSON to list
         List<TestObject> list = MARSHALLER.unconvert(jsonText);
-        assertEquals(2, list.size());
-        assertEquals("foo", list.get(0).getValue());
-        assertEquals("bar", list.get(1).getValue());
+        assertEquals(list.size(), 2);
+        assertEquals(list.get(0).getValue(), "foo");
+        assertEquals(list.get(1).getValue(), "bar");
 
         // convert from list to JSON
         String convertedJsonText = MARSHALLER.convert(list);
 
         // use Jackson to convert to a JsonNode for validation
         JsonNode convertedJsonNode = BridgeObjectMapper.get().readTree(convertedJsonText);
-        assertEquals(2, convertedJsonNode.size());
-        assertEquals("foo", convertedJsonNode.get(0).get("value").textValue());
-        assertEquals("bar", convertedJsonNode.get(1).get("value").textValue());
+        assertEquals(convertedJsonNode.size(), 2);
+        assertEquals(convertedJsonNode.get(0).get("value").textValue(), "foo");
+        assertEquals(convertedJsonNode.get(1).get("value").textValue(), "bar");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/LocalDateMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/LocalDateMarshallerTest.java
@@ -1,23 +1,23 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class LocalDateMarshallerTest {
     private static final LocalDateMarshaller MARSHALLER = new LocalDateMarshaller();
 
     @Test
     public void testMarshall() {
-        assertEquals("2014-12-25", MARSHALLER.convert(new LocalDate(2014, 12, 25)));
+        assertEquals(MARSHALLER.convert(new LocalDate(2014, 12, 25)), "2014-12-25");
     }
 
     @Test
     public void testUnmarshall() {
         LocalDate calendarDate = MARSHALLER.unconvert("2014-10-31");
-        assertEquals(2014, calendarDate.getYear());
-        assertEquals(10, calendarDate.getMonthOfYear());
-        assertEquals(31, calendarDate.getDayOfMonth());
+        assertEquals(calendarDate.getYear(), 2014);
+        assertEquals(calendarDate.getMonthOfYear(), 10);
+        assertEquals(calendarDate.getDayOfMonth(), 31);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/LocalDateTimeMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/LocalDateTimeMarshallerTest.java
@@ -1,28 +1,28 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import org.joda.time.LocalDateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class LocalDateTimeMarshallerTest {
     private static final LocalDateTimeMarshaller MARSHALLER = new LocalDateTimeMarshaller();
 
     @Test
     public void testMarshall() {
-        assertEquals("2014-12-25T10:12:37.022", MARSHALLER.convert(new LocalDateTime(2014, 12, 25, 10, 12, 37, 22)));
+        assertEquals(MARSHALLER.convert(new LocalDateTime(2014, 12, 25, 10, 12, 37, 22)), "2014-12-25T10:12:37.022");
     }
 
     @Test
     public void testUnmarshall() {
         LocalDateTime dateTime = MARSHALLER.unconvert("2014-10-31T10:12:37.022");
-        assertEquals(2014, dateTime.getYear());
-        assertEquals(10, dateTime.getMonthOfYear());
-        assertEquals(31, dateTime.getDayOfMonth());
-        assertEquals(10, dateTime.getHourOfDay());
-        assertEquals(12, dateTime.getMinuteOfHour());
-        assertEquals(37, dateTime.getSecondOfMinute());
-        assertEquals(22, dateTime.getMillisOfSecond());
+        assertEquals(dateTime.getYear(), 2014);
+        assertEquals(dateTime.getMonthOfYear(), 10);
+        assertEquals(dateTime.getDayOfMonth(), 31);
+        assertEquals(dateTime.getHourOfDay(), 10);
+        assertEquals(dateTime.getMinuteOfHour(), 12);
+        assertEquals(dateTime.getSecondOfMinute(), 37);
+        assertEquals(dateTime.getMillisOfSecond(), 22);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/StringSetMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/StringSetMarshallerTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.Test;
-
 import com.google.common.collect.Sets;
+
+import org.testng.annotations.Test;
 
 public class StringSetMarshallerTest {
     private static final StringSetMarshaller MARSHALLER = new StringSetMarshaller();
@@ -20,11 +20,11 @@ public class StringSetMarshallerTest {
         orderedSet.add("London");
         
         String ser = MARSHALLER.convert(orderedSet);
-        assertEquals("[\"Brussels\",\"London\",\"Paris\"]", ser);
+        assertEquals(ser, "[\"Brussels\",\"London\",\"Paris\"]");
         
         Set<String> deser = MARSHALLER.unconvert(ser);
         
-        assertEquals(orderedSet, deser);
+        assertEquals(deser, orderedSet);
     }
     
     @Test
@@ -33,7 +33,7 @@ public class StringSetMarshallerTest {
         assertEquals("[]", ser);
         
         Set<String> deser = MARSHALLER.unconvert(ser);
-        assertEquals(Sets.newHashSet(), deser);
+        assertEquals(deser, Sets.newHashSet());
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
@@ -51,7 +51,7 @@ public class AccountPersistenceExceptionConverterTest {
     public void noConversion() { 
         PersistenceException ex = new PersistenceException(new RuntimeException("message"));
         
-        assertSame(ex, converter.convert(ex, null));
+        assertSame(converter.convert(ex, null), ex);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
@@ -1,20 +1,19 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.mockito.Mockito.verify;
 
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 
 import org.hibernate.NonUniqueObjectException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
@@ -29,7 +28,6 @@ import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 
 import com.google.common.collect.ImmutableSet;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AccountPersistenceExceptionConverterTest {
 
     private AccountPersistenceExceptionConverter converter;
@@ -37,13 +35,14 @@ public class AccountPersistenceExceptionConverterTest {
     @Mock
     private AccountDao accountDao;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
         converter = new AccountPersistenceExceptionConverter(accountDao);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
     }
@@ -74,9 +73,9 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
-        assertEquals("Email address has already been used by another account.", result.getMessage());
-        assertEquals("userId", ((EntityAlreadyExistsException)result).getEntityKeys().get("userId"));
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
+        assertEquals(result.getMessage(), "Email address has already been used by another account.");
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), "userId");
     }
     
     @Test
@@ -98,9 +97,9 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
-        assertEquals("Phone number has already been used by another account.", result.getMessage());
-        assertEquals("userId", ((EntityAlreadyExistsException)result).getEntityKeys().get("userId"));
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
+        assertEquals(result.getMessage(), "Phone number has already been used by another account.");
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), "userId");
     }
 
     @Test
@@ -122,9 +121,9 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
-        assertEquals("External ID has already been used by another account.", result.getMessage());
-        assertEquals("userId", ((EntityAlreadyExistsException)result).getEntityKeys().get("userId"));
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
+        assertEquals(result.getMessage(), "External ID has already been used by another account.");
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), "userId");
     }
     
     @Test
@@ -152,9 +151,9 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
-        assertEquals("External ID has already been used by another account.", result.getMessage());
-        assertEquals("userId", ((EntityAlreadyExistsException)result).getEntityKeys().get("userId"));
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
+        assertEquals(result.getMessage(), "External ID has already been used by another account.");
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), "userId");
     }
     
     @Test
@@ -186,9 +185,9 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
-        assertEquals("External ID has already been used by another account.", result.getMessage());
-        assertEquals("userId", ((EntityAlreadyExistsException)result).getEntityKeys().get("userId"));
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
+        assertEquals(result.getMessage(), "External ID has already been used by another account.");
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), "userId");
         
         verify(accountDao).getAccount(AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, "externalIdA"));
     }
@@ -219,7 +218,7 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(EntityAlreadyExistsException.class, result.getClass());
+        assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         
         verify(accountDao).getAccount(AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, "externalIdA"));
     }
@@ -238,8 +237,8 @@ public class AccountPersistenceExceptionConverterTest {
         
         // It is converted to a generic constraint violation exception
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(ConstraintViolationException.class, result.getClass());
-        assertEquals("Accounts table constraint prevented save or update.", result.getMessage());
+        assertEquals(result.getClass(), ConstraintViolationException.class);
+        assertEquals(result.getMessage(), "Accounts table constraint prevented save or update.");
     }    
     
     // This scenario should not happen, but were it to happen, it would not generate an NPE exception.
@@ -250,7 +249,7 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, null);
-        assertEquals(ConstraintViolationException.class, result.getClass());
+        assertEquals(result.getClass(), ConstraintViolationException.class);
     }
     
     @Test
@@ -263,8 +262,8 @@ public class AccountPersistenceExceptionConverterTest {
         PersistenceException pe = new PersistenceException(cve);
         
         RuntimeException result = converter.convert(pe, account);
-        assertEquals(ConstraintViolationException.class, result.getClass());
-        assertEquals("Accounts table constraint prevented save or update.", result.getMessage());
+        assertEquals(result.getClass(), ConstraintViolationException.class);
+        assertEquals(result.getMessage(), "Accounts table constraint prevented save or update.");
     }
     
     @Test
@@ -275,8 +274,8 @@ public class AccountPersistenceExceptionConverterTest {
         OptimisticLockException ole = new OptimisticLockException();
         
         RuntimeException result = converter.convert(ole, account);
-        assertEquals(ConcurrentModificationException.class, result.getClass());
-        assertEquals("Account has the wrong version number; it may have been saved in the background.", result.getMessage());
+        assertEquals(result.getClass(), ConcurrentModificationException.class);
+        assertEquals(result.getMessage(), "Account has the wrong version number; it may have been saved in the background.");
     }
     
     @Test
@@ -287,8 +286,8 @@ public class AccountPersistenceExceptionConverterTest {
         NonUniqueObjectException nuoe = new NonUniqueObjectException("message", null, null);
         
         RuntimeException result = converter.convert(nuoe, account);
-        assertEquals(ConstraintViolationException.class, result.getClass());
-        assertEquals(AccountPersistenceExceptionConverter.NON_UNIQUE_MSG, result.getMessage());
+        assertEquals(result.getClass(), ConstraintViolationException.class);
+        assertEquals(result.getMessage(), AccountPersistenceExceptionConverter.NON_UNIQUE_MSG);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/AccountSecretsExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/AccountSecretsExceptionConverterTest.java
@@ -13,7 +13,7 @@ public class AccountSecretsExceptionConverterTest {
         AccountSecretsExceptionConverter converter = new AccountSecretsExceptionConverter();
         PersistenceException ex = new PersistenceException();
         RuntimeException returnValue = converter.convert(ex, new Object());
-        assertSame(ex, returnValue);
+        assertSame(returnValue, ex);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/AccountSecretsExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/AccountSecretsExceptionConverterTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertSame;
+import static org.testng.Assert.assertSame;
 
 import javax.persistence.PersistenceException;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class AccountSecretsExceptionConverterTest {
     

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/DateTimeToLongAttributeConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/DateTimeToLongAttributeConverterTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 public class DateTimeToLongAttributeConverterTest {
 
@@ -14,19 +14,19 @@ public class DateTimeToLongAttributeConverterTest {
     
     private DateTimeToLongAttributeConverter converter;
     
-    @Before
+    @BeforeMethod
     public void before() {
         converter = new DateTimeToLongAttributeConverter();
     }
     
     @Test
     public void convertToDatabaseColumn() {
-        assertEquals(MILLIS, converter.convertToDatabaseColumn(DATETIME));
+        assertEquals(converter.convertToDatabaseColumn(DATETIME), MILLIS);
     }
 
     @Test
     public void convertToEntityAttribute() {
-        assertEquals(DATETIME, converter.convertToEntityAttribute(MILLIS));
+        assertEquals(converter.convertToEntityAttribute(MILLIS), DATETIME);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/DateTimeZoneAttributeConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/DateTimeZoneAttributeConverterTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 public class DateTimeZoneAttributeConverterTest {
     
@@ -14,19 +14,19 @@ public class DateTimeZoneAttributeConverterTest {
 
     private DateTimeZoneAttributeConverter converter;
     
-    @Before
+    @BeforeMethod
     public void before() {
         converter = new DateTimeZoneAttributeConverter();
     }
     
     @Test
     public void convertToDatabaseColumn() {
-        assertEquals(OFFSET_STRING, converter.convertToDatabaseColumn(ZONE));
+        assertEquals(converter.convertToDatabaseColumn(ZONE), OFFSET_STRING);
     }
 
     @Test
     public void convertToEntityAttribute() {
-        assertEquals(ZONE, converter.convertToEntityAttribute(OFFSET_STRING));
+        assertEquals(converter.convertToEntityAttribute(OFFSET_STRING), ZONE);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountConsentKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountConsentKeyTest.java
@@ -1,8 +1,9 @@
 package org.sagebionetworks.bridge.hibernate;
 
+import org.testng.annotations.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
 
 public class HibernateAccountConsentKeyTest {
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,18 +28,18 @@ import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestConstants;
@@ -65,7 +65,6 @@ import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 
-@RunWith(MockitoJUnitRunner.class)
 public class HibernateAccountDaoTest {
     private static final String ACCOUNT_ID = "account-id";
     private static final DateTime CREATED_ON = DateTime.parse("2017-05-19T11:03:50.224-0700");
@@ -82,12 +81,17 @@ public class HibernateAccountDaoTest {
     // The default hashing algorithm uses a randomized salt... use a static value to simplify testing
     private static final String REAUTH_TOKEN_HASH = "250000$Ph4WKc/3LXK+dY/dcu5ZzQ==$5MjK39+bMrwsFVUc2kK/sYkWctvm1ne270bVZiajs3Q=";
     private static final String EXTERNAL_ID = "an-external-id";
-    private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER, ACCOUNT_ID);
-    private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TestConstants.TEST_STUDY_IDENTIFIER, EMAIL);
-    private static final AccountId ACCOUNT_ID_WITH_PHONE = AccountId.forPhone(TestConstants.TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
-    private static final AccountId ACCOUNT_ID_WITH_HEALTHCODE = AccountId.forHealthCode(TestConstants.TEST_STUDY_IDENTIFIER, HEALTH_CODE);
-    private static final AccountId ACCOUNT_ID_WITH_EXTID = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER, EXTERNAL_ID);
-    
+    private static final AccountId ACCOUNT_ID_WITH_ID = AccountId.forId(TestConstants.TEST_STUDY_IDENTIFIER,
+            ACCOUNT_ID);
+    private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TestConstants.TEST_STUDY_IDENTIFIER,
+            EMAIL);
+    private static final AccountId ACCOUNT_ID_WITH_PHONE = AccountId.forPhone(TestConstants.TEST_STUDY_IDENTIFIER,
+            TestConstants.PHONE);
+    private static final AccountId ACCOUNT_ID_WITH_HEALTHCODE = AccountId
+            .forHealthCode(TestConstants.TEST_STUDY_IDENTIFIER, HEALTH_CODE);
+    private static final AccountId ACCOUNT_ID_WITH_EXTID = AccountId.forExternalId(TestConstants.TEST_STUDY_IDENTIFIER,
+            EXTERNAL_ID);
+
     private static final String SUBSTUDY_A = "substudyA";
     private static final String SUBSTUDY_B = "substudyB";
     private static final Set<AccountSubstudy> ACCOUNT_SUBSTUDIES = ImmutableSet
@@ -99,37 +103,32 @@ public class HibernateAccountDaoTest {
     private static final SignIn PASSWORD_SIGNIN = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
             .withEmail(EMAIL).withPassword(DUMMY_PASSWORD).build();
 
-    private static final Map<String,Object> STUDY_QUERY_PARAMS = new ImmutableMap.Builder<String,Object>()
+    private static final Map<String, Object> STUDY_QUERY_PARAMS = new ImmutableMap.Builder<String, Object>()
             .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER).build();
-    private static final Map<String,Object> EMAIL_QUERY_PARAMS = new ImmutableMap.Builder<String,Object>()
-            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER)
-            .put("email", EMAIL).build();
-    private static final Map<String,Object> HEALTHCODE_QUERY_PARAMS = new ImmutableMap.Builder<String,Object>()
-            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER)
-            .put("healthCode", HEALTH_CODE).build();
-    private static final Map<String,Object> PHONE_QUERY_PARAMS = new ImmutableMap.Builder<String,Object>()
-            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER)
-            .put("number", TestConstants.PHONE.getNumber())
+    private static final Map<String, Object> EMAIL_QUERY_PARAMS = new ImmutableMap.Builder<String, Object>()
+            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER).put("email", EMAIL).build();
+    private static final Map<String, Object> HEALTHCODE_QUERY_PARAMS = new ImmutableMap.Builder<String, Object>()
+            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER).put("healthCode", HEALTH_CODE).build();
+    private static final Map<String, Object> PHONE_QUERY_PARAMS = new ImmutableMap.Builder<String, Object>()
+            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER).put("number", TestConstants.PHONE.getNumber())
             .put("regionCode", TestConstants.PHONE.getRegionCode()).build();
-    private static final Map<String,Object> EXTID_QUERY_PARAMS = new ImmutableMap.Builder<String,Object>()
-            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER)
-            .put("externalId", EXTERNAL_ID).build();
-    
+    private static final Map<String, Object> EXTID_QUERY_PARAMS = new ImmutableMap.Builder<String, Object>()
+            .put("studyId", TestConstants.TEST_STUDY_IDENTIFIER).put("externalId", EXTERNAL_ID).build();
+
     @Captor
-    ArgumentCaptor<Map<String,Object>> paramCaptor;
-    
+    ArgumentCaptor<Map<String, Object>> paramCaptor;
+
     @Mock
     Consumer<Account> accountConsumer;
-    
+
     @Mock
     private AccountSecretDao mockAccountSecretDao;
-    
+
     @Mock
     private HibernateHelper mockHibernateHelper;
-    
+
     private Study study;
     private HibernateAccountDao dao;
-    
 
     @BeforeClass
     public static void mockNow() {
@@ -141,29 +140,30 @@ public class HibernateAccountDaoTest {
         DateTimeUtils.setCurrentMillisSystem();
     }
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         // Mock successful update.
         when(mockHibernateHelper.update(any(), eq(null))).thenAnswer(invocation -> {
             HibernateAccount account = invocation.getArgument(0);
             if (account != null) {
-                account.setVersion(account.getVersion()+1);    
+                account.setVersion(account.getVersion() + 1);
             }
             return account;
         });
-        
+
         dao = spy(new HibernateAccountDao());
         dao.setHibernateHelper(mockHibernateHelper);
         dao.setAccountSecretDao(mockAccountSecretDao);
-        
+
         study = Study.create();
         study.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         study.setReauthenticationEnabled(true);
         study.setEmailVerificationEnabled(true);
     }
-    
-    @After
-    public void after() { 
+
+    @AfterMethod
+    public void after() {
         BridgeUtils.setRequestContext(null);
     }
 
@@ -172,22 +172,22 @@ public class HibernateAccountDaoTest {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         hibernateAccount.setEmailVerified(Boolean.FALSE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
+
         dao.verifyChannel(ChannelType.EMAIL, account);
-        
-        assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
-        assertEquals(Boolean.TRUE, hibernateAccount.getEmailVerified());
+
+        assertEquals(hibernateAccount.getStatus(), AccountStatus.ENABLED);
+        assertEquals(hibernateAccount.getEmailVerified(), Boolean.TRUE);
         // modifiedOn is stored as a long, which loses the time zone of the original time stamp.
-        assertEquals(MOCK_DATETIME.withZone(DateTimeZone.UTC).toString(), hibernateAccount.getModifiedOn().toString());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(hibernateAccount.getModifiedOn().toString(), MOCK_DATETIME.withZone(DateTimeZone.UTC).toString());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
         verify(mockHibernateHelper).update(hibernateAccount, null);
     }
 
@@ -196,57 +196,57 @@ public class HibernateAccountDaoTest {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         hibernateAccount.setEmailVerified(Boolean.FALSE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(Boolean.FALSE);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
-        
-        assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
-        assertEquals(Boolean.TRUE, hibernateAccount.getEmailVerified());
+
+        assertEquals(hibernateAccount.getStatus(), AccountStatus.ENABLED);
+        assertEquals(hibernateAccount.getEmailVerified(), Boolean.TRUE);
         // modifiedOn is stored as a long, which loses the time zone of the original time stamp.
-        assertEquals(MOCK_DATETIME.withZone(DateTimeZone.UTC).toString(), hibernateAccount.getModifiedOn().toString());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(hibernateAccount.getModifiedOn().toString(), MOCK_DATETIME.withZone(DateTimeZone.UTC).toString());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
         verify(mockHibernateHelper).update(hibernateAccount, null);
     }
-    
+
     @Test
     public void verifyEmailUsingAccountNoChangeNecessary() {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.ENABLED);
         hibernateAccount.setEmailVerified(Boolean.TRUE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.ENABLED);
         account.setEmailVerified(Boolean.TRUE);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
         verify(mockHibernateHelper, never()).update(hibernateAccount, null);
     }
-    
+
     @Test
     public void verifyEmailWithDisabledAccountMakesNoChanges() {
         Account account = Account.create();
         account.setStatus(AccountStatus.DISABLED);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
         verify(mockHibernateHelper, never()).update(any(), eq(null));
-        assertEquals(AccountStatus.DISABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.DISABLED);
     }
-    
+
     @Test
     public void verifyEmailFailsIfHibernateAccountNotFound() {
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setEmailVerified(null);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
         try {
             dao.verifyChannel(AuthenticationService.ChannelType.EMAIL, account);
@@ -255,90 +255,90 @@ public class HibernateAccountDaoTest {
             // expected exception
         }
         verify(mockHibernateHelper, never()).update(any(), eq(null));
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertNull(account.getEmailVerified());
     }
-    
+
     @Test
     public void verifyPhoneUsingToken() {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         hibernateAccount.setPhoneVerified(Boolean.FALSE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setPhoneVerified(Boolean.FALSE);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
+
         dao.verifyChannel(ChannelType.PHONE, account);
-        
-        assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
-        assertEquals(Boolean.TRUE, hibernateAccount.getPhoneVerified());
+
+        assertEquals(hibernateAccount.getStatus(), AccountStatus.ENABLED);
+        assertEquals(hibernateAccount.getPhoneVerified(), Boolean.TRUE);
         // modifiedOn is stored as a long, which loses the time zone of the original time stamp.
-        assertEquals(MOCK_DATETIME.withZone(DateTimeZone.UTC).toString(), hibernateAccount.getModifiedOn().toString());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getPhoneVerified());
+        assertEquals(hibernateAccount.getModifiedOn().toString(), MOCK_DATETIME.withZone(DateTimeZone.UTC).toString());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getPhoneVerified(), Boolean.TRUE);
         verify(mockHibernateHelper).update(hibernateAccount, null);
     }
-    
+
     @Test
     public void verifyPhoneUsingAccount() {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
         hibernateAccount.setPhoneVerified(Boolean.FALSE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setPhoneVerified(Boolean.FALSE);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
-        
-        assertEquals(AccountStatus.ENABLED, hibernateAccount.getStatus());
-        assertEquals(Boolean.TRUE, hibernateAccount.getPhoneVerified());
+
+        assertEquals(hibernateAccount.getStatus(), AccountStatus.ENABLED);
+        assertEquals(hibernateAccount.getPhoneVerified(), Boolean.TRUE);
         // modifiedOn is stored as a long, which loses the time zone of the original time stamp.
-        assertEquals(MOCK_DATETIME.withZone(DateTimeZone.UTC).toString(), hibernateAccount.getModifiedOn().toString());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getPhoneVerified());
+        assertEquals(hibernateAccount.getModifiedOn().toString(), MOCK_DATETIME.withZone(DateTimeZone.UTC).toString());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getPhoneVerified(), Boolean.TRUE);
         verify(mockHibernateHelper).update(hibernateAccount, null);
     }
-    
+
     @Test
     public void verifyPhoneUsingAccountNoChangeNecessary() {
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setStatus(AccountStatus.ENABLED);
         hibernateAccount.setPhoneVerified(Boolean.TRUE);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.ENABLED);
         account.setPhoneVerified(Boolean.TRUE);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
         verify(mockHibernateHelper, never()).update(hibernateAccount, null);
     }
-    
+
     @Test
     public void verifyPhoneWithDisabledAccountMakesNoChanges() {
         Account account = Account.create();
         account.setStatus(AccountStatus.DISABLED);
-        
+
         dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
         verify(mockHibernateHelper, never()).update(any(), eq(null));
-        assertEquals(AccountStatus.DISABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.DISABLED);
     }
-    
+
     @Test
     public void verifyPhoneFailsIfHibernateAccountNotFound() {
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setStatus(AccountStatus.UNVERIFIED);
         account.setPhoneVerified(null);
-        
+
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
         try {
             dao.verifyChannel(AuthenticationService.ChannelType.PHONE, account);
@@ -347,10 +347,10 @@ public class HibernateAccountDaoTest {
             // expected exception
         }
         verify(mockHibernateHelper, never()).update(any(), eq(null));
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertNull(account.getPhoneVerified());
-    }    
-    
+    }
+
     @Test
     public void changePasswordSuccess() throws Exception {
         // mock hibernate
@@ -369,13 +369,13 @@ public class HibernateAccountDaoTest {
         verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
-        assertEquals(ACCOUNT_ID, updatedAccount.getId());
-        assertEquals(MOCK_DATETIME.getMillis(), updatedAccount.getModifiedOn().getMillis());
-        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, updatedAccount.getPasswordAlgorithm());
-        assertEquals(MOCK_DATETIME.getMillis(), updatedAccount.getPasswordModifiedOn().getMillis());
+        assertEquals(updatedAccount.getId(), ACCOUNT_ID);
+        assertEquals(updatedAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(updatedAccount.getPasswordAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
+        assertEquals(updatedAccount.getPasswordModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertTrue(updatedAccount.getEmailVerified());
         assertNull(updatedAccount.getPhoneVerified());
-        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
+        assertEquals(updatedAccount.getStatus(), AccountStatus.ENABLED);
 
         // validate password hash
         assertTrue(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM.checkHash(updatedAccount.getPasswordHash(),
@@ -403,10 +403,10 @@ public class HibernateAccountDaoTest {
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
         assertNull(updatedAccount.getEmailVerified());
         assertTrue(updatedAccount.getPhoneVerified());
-        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
+        assertEquals(updatedAccount.getStatus(), AccountStatus.ENABLED);
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void changePasswordAccountNotFound() {
         // mock hibernate
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(null);
@@ -418,7 +418,7 @@ public class HibernateAccountDaoTest {
         // execute
         dao.changePassword(account, ChannelType.EMAIL, DUMMY_PASSWORD);
     }
-    
+
     @Test
     public void changePasswordForExternalId() {
         // mock hibernate
@@ -440,29 +440,30 @@ public class HibernateAccountDaoTest {
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
         assertNull(updatedAccount.getEmailVerified());
         assertNull(updatedAccount.getPhoneVerified());
-        assertEquals(AccountStatus.ENABLED, updatedAccount.getStatus());
+        assertEquals(updatedAccount.getStatus(), AccountStatus.ENABLED);
     }
 
     @Test
     public void authenticateSuccessWithHealthCode() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         Account account = dao.authenticate(study, PASSWORD_SIGNIN);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(HEALTH_CODE, account.getHealthCode());
-        assertEquals(1, account.getVersion()); // version not incremented by update
-        
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), HEALTH_CODE);
+        assertEquals(account.getVersion(), 1); // version not incremented by update
+
         // verify query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
-        
+
         // We don't create a new health code mapping nor update the account.
         verify(mockHibernateHelper, never()).update(any(), any());
     }
@@ -470,11 +471,11 @@ public class HibernateAccountDaoTest {
     @Test
     public void authenticateSuccessCreateNewHealthCode() throws Exception {
         when(dao.generateGUID()).thenReturn(HEALTH_CODE);
-        
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
-        
+
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
+
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         // Clear these fields to verify that they are created
@@ -484,22 +485,22 @@ public class HibernateAccountDaoTest {
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         Account account = dao.authenticate(study, PASSWORD_SIGNIN);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(HEALTH_CODE, account.getHealthCode());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), HEALTH_CODE);
 
         // verify query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
         verifyCreatedHealthCode();
     }
-    
+
     @Test
     public void authenticateSuccessNoReauthentication() throws Exception {
         study.setReauthenticationEnabled(false);
-        
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
@@ -507,14 +508,14 @@ public class HibernateAccountDaoTest {
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         Account account = dao.authenticate(study, PASSWORD_SIGNIN);
         // not incremented by reauthentication
-        assertEquals(1, account.getVersion());
-        
+        assertEquals(account.getVersion(), 1);
+
         // No reauthentication token rotation occurs
         verify(mockHibernateHelper, never()).update(any(), eq(null));
         assertNull(account.getReauthToken());
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void authenticateAccountNotFound() throws Exception {
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of());
@@ -523,55 +524,58 @@ public class HibernateAccountDaoTest {
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void authenticateAccountUnverified() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
 
-    @Test(expected = AccountDisabledException.class)
+    @Test(expectedExceptions = AccountDisabledException.class)
     public void authenticateAccountDisabled() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setStatus(AccountStatus.DISABLED);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void authenticateAccountHasNoPassword() throws Exception {
         // mock hibernate
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(
-                ImmutableList.of(makeValidHibernateAccount(false)));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(makeValidHibernateAccount(false)));
 
         // execute
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
 
     // branch coverage
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void authenticateAccountHasPasswordAlgorithmNoHash() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setPasswordAlgorithm(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void authenticateBadPassword() throws Exception {
         // mock hibernate
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(
-                makeValidHibernateAccount(true)));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(makeValidHibernateAccount(true)));
 
         // execute
         dao.authenticate(study, new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withEmail(EMAIL)
@@ -580,30 +584,31 @@ public class HibernateAccountDaoTest {
 
     @Test
     public void reauthenticateSuccessWithMigration() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "
+                + "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         setReauthInAccount(hibernateAccount);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         AccountSecret secret = AccountSecret.create();
         when(mockAccountSecretDao.verifySecret(AccountSecretType.REAUTH, hibernateAccount.getId(), REAUTH_TOKEN,
                 HibernateAccountDao.ROTATIONS)).thenReturn(Optional.of(secret));
-        
+
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         Account account = dao.reauthenticate(study, REAUTH_SIGNIN);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
         assertNull(account.getReauthTokenHash());
         assertNull(account.getReauthTokenAlgorithm());
         assertNull(account.getReauthTokenModifiedOn());
-        assertEquals(2, account.getVersion());
-        
+        assertEquals(account.getVersion(), 2);
+
         InOrder inOrder = Mockito.inOrder(mockHibernateHelper, mockAccountSecretDao);
-        
+
         // verify query
         inOrder.verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
 
@@ -611,40 +616,41 @@ public class HibernateAccountDaoTest {
         ArgumentCaptor<AccountSecret> secretCaptor = ArgumentCaptor.forClass(AccountSecret.class);
         inOrder.verify(mockHibernateHelper).create(secretCaptor.capture(), eq(null));
         inOrder.verify(mockHibernateHelper).update(hibernateAccount, null);
-        
+
         AccountSecret savedSecret = secretCaptor.getValue();
-        assertEquals(ACCOUNT_ID, savedSecret.getAccountId());
-        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, savedSecret.getAlgorithm());
-        assertEquals(REAUTH_TOKEN_HASH, savedSecret.getHash());
-        assertEquals(MOCK_DATETIME.getMillis(), savedSecret.getCreatedOn().getMillis());
-        assertEquals(AccountSecretType.REAUTH, savedSecret.getType());
-        
+        assertEquals(savedSecret.getAccountId(), ACCOUNT_ID);
+        assertEquals(savedSecret.getAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
+        assertEquals(savedSecret.getHash(), REAUTH_TOKEN_HASH);
+        assertEquals(savedSecret.getCreatedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(savedSecret.getType(), AccountSecretType.REAUTH);
+
         // verify token verification
         inOrder.verify(mockAccountSecretDao).verifySecret(AccountSecretType.REAUTH, ACCOUNT_ID, REAUTH_TOKEN, 3);
     }
-    
+
     @Test
     public void reauthenticateSuccessNoMigration() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "
+                + "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
-        
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         AccountSecret secret = AccountSecret.create();
         when(mockAccountSecretDao.verifySecret(AccountSecretType.REAUTH, hibernateAccount.getId(), REAUTH_TOKEN,
                 HibernateAccountDao.ROTATIONS)).thenReturn(Optional.of(secret));
-        
+
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
         Account account = dao.reauthenticate(study, REAUTH_SIGNIN);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
         // Version has not been incremented by an update
-        assertEquals(1, account.getVersion());
-        
+        assertEquals(account.getVersion(), 1);
+
         // verify query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
 
@@ -655,26 +661,26 @@ public class HibernateAccountDaoTest {
         assertNull(hibernateAccount.getReauthTokenHash());
         assertNull(hibernateAccount.getReauthTokenAlgorithm());
         assertNull(hibernateAccount.getReauthTokenModifiedOn());
-        
+
         // verify token verification
         verify(mockAccountSecretDao).verifySecret(AccountSecretType.REAUTH, ACCOUNT_ID, REAUTH_TOKEN, 3);
     }
-    
+
     @Test
     public void reauthenticationDisabled() throws Exception {
         study.setReauthenticationEnabled(false);
-        
+
         try {
             dao.reauthenticate(study, REAUTH_SIGNIN);
             fail("Should have thrown exception");
-        } catch(UnauthorizedException e) {
+        } catch (UnauthorizedException e) {
             // expected exception
         }
         verify(mockHibernateHelper, never()).queryGet(any(), any(), any(), any(), eq(HibernateAccount.class));
         verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void reauthenticateAccountNotFound() throws Exception {
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of());
@@ -682,14 +688,15 @@ public class HibernateAccountDaoTest {
         // execute
         dao.reauthenticate(study, REAUTH_SIGNIN);
     }
-    
-    @Test(expected = UnauthorizedException.class)
+
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void reauthenticateAccountUnverified() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setStatus(AccountStatus.UNVERIFIED);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
-        
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
+
         AccountSecret secret = AccountSecret.create();
         when(mockAccountSecretDao.verifySecret(AccountSecretType.REAUTH, hibernateAccount.getId(), REAUTH_TOKEN,
                 HibernateAccountDao.ROTATIONS)).thenReturn(Optional.of(secret));
@@ -697,14 +704,15 @@ public class HibernateAccountDaoTest {
         // execute
         dao.reauthenticate(study, REAUTH_SIGNIN);
     }
-    
-    @Test(expected = AccountDisabledException.class)
+
+    @Test(expectedExceptions = AccountDisabledException.class)
     public void reauthenticateAccountDisabled() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setStatus(AccountStatus.DISABLED);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
-        
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
+
         AccountSecret secret = AccountSecret.create();
         when(mockAccountSecretDao.verifySecret(AccountSecretType.REAUTH, hibernateAccount.getId(), REAUTH_TOKEN,
                 HibernateAccountDao.ROTATIONS)).thenReturn(Optional.of(secret));
@@ -712,34 +720,34 @@ public class HibernateAccountDaoTest {
         // execute
         dao.reauthenticate(study, REAUTH_SIGNIN);
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void reauthenticateAccountHasNoReauthToken() throws Exception {
         // mock hibernate
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(
-                ImmutableList.of(makeValidHibernateAccount(false)));
-        
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(makeValidHibernateAccount(false)));
+
         // It also has no record in the secrets table...
-        
+
         // execute
         dao.reauthenticate(study, REAUTH_SIGNIN);
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void failedSignInOfDisabledAccountDoesNotIndicateAccountExists() throws Exception {
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setStatus(AccountStatus.DISABLED);
-        
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(
-                ImmutableList.of(hibernateAccount));
-        
-        SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
-                .withEmail(EMAIL).withPassword("bad password").build();
+
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
+
+        SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withEmail(EMAIL)
+                .withPassword("bad password").build();
         dao.authenticate(study, signIn);
     }
-    
+
     // branch coverage
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void reauthenticateAccountHasReauthTokenAlgorithmNoHash() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
@@ -750,8 +758,8 @@ public class HibernateAccountDaoTest {
         // execute
         dao.authenticate(study, REAUTH_SIGNIN);
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void reauthenticateBadReauthToken() throws Exception {
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
@@ -770,29 +778,29 @@ public class HibernateAccountDaoTest {
                 .thenReturn(ImmutableList.of(hibernateAccount));
 
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
-        
-        assertEquals(hibernateAccount, account);
+
+        assertEquals(account, hibernateAccount);
     }
 
     @Test
     public void deleteReauthToken() throws Exception {
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         setReauthInAccount(hibernateAccount);
-        
+
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
-        
+
         ArgumentCaptor<HibernateAccount> accountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
-        
+
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
-        
+
         verify(mockHibernateHelper).update(accountCaptor.capture(), eq(null));
         HibernateAccount captured = accountCaptor.getValue();
-        
+
         assertNull(captured.getReauthTokenAlgorithm());
         assertNull(captured.getReauthTokenHash());
         assertNull(captured.getReauthTokenModifiedOn());
-        
+
         verify(mockAccountSecretDao).removeSecrets(AccountSecretType.REAUTH, ACCOUNT_ID);
     }
 
@@ -806,7 +814,7 @@ public class HibernateAccountDaoTest {
         // Just quietly succeeds without doing any account update.
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
         verify(mockHibernateHelper, never()).update(any(), eq(null));
-        
+
         // But we do always call this.
         verify(mockAccountSecretDao).removeSecrets(AccountSecretType.REAUTH, ACCOUNT_ID);
     }
@@ -815,7 +823,7 @@ public class HibernateAccountDaoTest {
     public void deleteReauthTokenAccountNotFound() throws Exception {
         // Just quietly succeeds without doing any work.
         dao.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
-        
+
         verify(mockHibernateHelper, never()).update(any(), eq(null));
         verify(mockAccountSecretDao, never()).removeSecrets(AccountSecretType.REAUTH, ACCOUNT_ID);
     }
@@ -833,20 +841,20 @@ public class HibernateAccountDaoTest {
         dao.createAccount(study, account, null);
 
         // verify hibernate call
-        ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor.forClass(
-                HibernateAccount.class);
+        ArgumentCaptor<HibernateAccount> createdHibernateAccountCaptor = ArgumentCaptor
+                .forClass(HibernateAccount.class);
         verify(mockHibernateHelper).create(createdHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount createdHibernateAccount = createdHibernateAccountCaptor.getValue();
-        assertEquals(ACCOUNT_ID, createdHibernateAccount.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, createdHibernateAccount.getStudyId());
-        assertEquals(MOCK_DATETIME.getMillis(), createdHibernateAccount.getCreatedOn().getMillis());
-        assertEquals(MOCK_DATETIME.getMillis(), createdHibernateAccount.getModifiedOn().getMillis());
-        assertEquals(MOCK_DATETIME.getMillis(), createdHibernateAccount.getPasswordModifiedOn().getMillis());
-        assertEquals(AccountStatus.ENABLED, createdHibernateAccount.getStatus());
-        assertEquals(AccountDao.MIGRATION_VERSION, createdHibernateAccount.getMigrationVersion());
+        assertEquals(createdHibernateAccount.getId(), ACCOUNT_ID);
+        assertEquals(createdHibernateAccount.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(createdHibernateAccount.getCreatedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(createdHibernateAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(createdHibernateAccount.getPasswordModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(createdHibernateAccount.getStatus(), AccountStatus.ENABLED);
+        assertEquals(createdHibernateAccount.getMigrationVersion(), AccountDao.MIGRATION_VERSION);
     }
-    
+
     @Test
     public void updateSuccess() {
         // Some fields can't be modified. Create the persisted account and set the base fields so we can verify they
@@ -872,35 +880,34 @@ public class HibernateAccountDaoTest {
         account.setEmailVerified(Boolean.FALSE);
         account.setPhoneVerified(Boolean.FALSE);
         account.setExternalId(EXTERNAL_ID);
-        
+
         // Execute. Identifiers not allows to change.
         dao.updateAccount(account, null);
 
         // verify hibernate update
-        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
-                HibernateAccount.class);
+        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor
+                .forClass(HibernateAccount.class);
         verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedHibernateAccount = updatedHibernateAccountCaptor.getValue();
-        assertEquals(ACCOUNT_ID, updatedHibernateAccount.getId());
-        assertEquals("persisted-study", updatedHibernateAccount.getStudyId());
-        assertEquals(OTHER_EMAIL, updatedHibernateAccount.getEmail());
-        assertEquals(OTHER_PHONE.getNationalFormat(),
-                updatedHibernateAccount.getPhone().getNationalFormat());
-        assertEquals(Boolean.FALSE, updatedHibernateAccount.getEmailVerified());
-        assertEquals(Boolean.FALSE, updatedHibernateAccount.getPhoneVerified());
-        assertEquals(1234, updatedHibernateAccount.getCreatedOn().getMillis());
-        assertEquals(5678, updatedHibernateAccount.getPasswordModifiedOn().getMillis());
-        assertEquals(MOCK_DATETIME.getMillis(), updatedHibernateAccount.getModifiedOn().getMillis());
-        assertEquals(EXTERNAL_ID, updatedHibernateAccount.getExternalId());
+        assertEquals(updatedHibernateAccount.getId(), ACCOUNT_ID);
+        assertEquals(updatedHibernateAccount.getStudyId(), "persisted-study");
+        assertEquals(updatedHibernateAccount.getEmail(), OTHER_EMAIL);
+        assertEquals(updatedHibernateAccount.getPhone().getNationalFormat(), OTHER_PHONE.getNationalFormat());
+        assertEquals(updatedHibernateAccount.getEmailVerified(), Boolean.FALSE);
+        assertEquals(updatedHibernateAccount.getPhoneVerified(), Boolean.FALSE);
+        assertEquals(updatedHibernateAccount.getCreatedOn().getMillis(), 1234);
+        assertEquals(updatedHibernateAccount.getPasswordModifiedOn().getMillis(), 5678);
+        assertEquals(updatedHibernateAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
+        assertEquals(updatedHibernateAccount.getExternalId(), EXTERNAL_ID);
     }
-    
+
     @Test
     public void updateDoesNotChangePasswordOrReauthToken() throws Exception {
         HibernateAccount persistedAccount = makeValidHibernateAccount(true);
         setReauthInAccount(persistedAccount); // verify these fields are just left alone until migrated
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(persistedAccount);
-        
+
         Account account = Account.create();
         account.setId(ACCOUNT_ID);
         account.setPasswordAlgorithm(PasswordAlgorithm.STORMPATH_HMAC_SHA_256);
@@ -909,24 +916,24 @@ public class HibernateAccountDaoTest {
         account.setReauthTokenAlgorithm(PasswordAlgorithm.STORMPATH_HMAC_SHA_256);
         account.setReauthTokenHash("bad reauth token hash");
         account.setReauthTokenModifiedOn(MOCK_DATETIME);
-        
+
         dao.updateAccount(account, null);
-        
-        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
-                HibernateAccount.class);
+
+        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor
+                .forClass(HibernateAccount.class);
 
         verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
-        
+
         // These values were loaded, have not been changed, and were persisted as is.
         HibernateAccount captured = updatedHibernateAccountCaptor.getValue();
-        assertEquals(persistedAccount.getPasswordAlgorithm(), captured.getPasswordAlgorithm());
-        assertEquals(persistedAccount.getPasswordHash(), captured.getPasswordHash());
-        assertEquals(persistedAccount.getPasswordModifiedOn(), captured.getPasswordModifiedOn());
-        assertEquals(persistedAccount.getReauthTokenAlgorithm(), captured.getReauthTokenAlgorithm());
-        assertEquals(persistedAccount.getReauthTokenHash(), captured.getReauthTokenHash());
-        assertEquals(persistedAccount.getReauthTokenModifiedOn(), captured.getReauthTokenModifiedOn());
+        assertEquals(captured.getPasswordAlgorithm(), persistedAccount.getPasswordAlgorithm());
+        assertEquals(captured.getPasswordHash(), persistedAccount.getPasswordHash());
+        assertEquals(captured.getPasswordModifiedOn(), persistedAccount.getPasswordModifiedOn());
+        assertEquals(captured.getReauthTokenAlgorithm(), persistedAccount.getReauthTokenAlgorithm());
+        assertEquals(captured.getReauthTokenHash(), persistedAccount.getReauthTokenHash());
+        assertEquals(captured.getReauthTokenModifiedOn(), persistedAccount.getReauthTokenModifiedOn());
     }
-    
+
     @Test
     public void updateAccountNotFound() {
         // mock hibernate
@@ -937,10 +944,10 @@ public class HibernateAccountDaoTest {
             dao.updateAccount(makeValidGenericAccount(), null);
             fail("expected exception");
         } catch (EntityNotFoundException ex) {
-            assertEquals("Account " + ACCOUNT_ID + " not found", ex.getMessage());
+            assertEquals(ex.getMessage(), "Account " + ACCOUNT_ID + " not found");
         }
     }
-    
+
     @Test
     public void updateAccountAllowsIdentifierUpdate() {
         // This call will allow identifiers/verification status to be updated.
@@ -967,23 +974,22 @@ public class HibernateAccountDaoTest {
         account.setEmailVerified(Boolean.FALSE);
         account.setPhoneVerified(Boolean.FALSE);
         account.setExternalId(EXTERNAL_ID);
-        
+
         // Identifiers ARE allowed to change here.
         dao.updateAccount(account, null);
 
         // Capture the update
-        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor.forClass(
-                HibernateAccount.class);
+        ArgumentCaptor<HibernateAccount> updatedHibernateAccountCaptor = ArgumentCaptor
+                .forClass(HibernateAccount.class);
         verify(mockHibernateHelper).update(updatedHibernateAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedHibernateAccount = updatedHibernateAccountCaptor.getValue();
-        
-        assertEquals(OTHER_EMAIL, updatedHibernateAccount.getEmail());
-        assertEquals(OTHER_PHONE.getNationalFormat(),
-                updatedHibernateAccount.getPhone().getNationalFormat());
-        assertEquals(Boolean.FALSE, updatedHibernateAccount.getEmailVerified());
-        assertEquals(Boolean.FALSE, updatedHibernateAccount.getPhoneVerified());
-        assertEquals(EXTERNAL_ID, updatedHibernateAccount.getExternalId());
+
+        assertEquals(updatedHibernateAccount.getEmail(), OTHER_EMAIL);
+        assertEquals(updatedHibernateAccount.getPhone().getNationalFormat(), OTHER_PHONE.getNationalFormat());
+        assertEquals(updatedHibernateAccount.getEmailVerified(), Boolean.FALSE);
+        assertEquals(updatedHibernateAccount.getPhoneVerified(), Boolean.FALSE);
+        assertEquals(updatedHibernateAccount.getExternalId(), EXTERNAL_ID);
     }
 
     @Test
@@ -995,30 +1001,29 @@ public class HibernateAccountDaoTest {
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         Account account = (Account) dao.getAccount(ACCOUNT_ID_WITH_ID);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), "original-" + HEALTH_CODE);
         verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
 
     @Test
     public void getByIdSuccessCreateNewHealthCode() throws Exception {
         when(dao.generateGUID()).thenReturn(HEALTH_CODE);
-        
+
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         // Clear these fields to verify that they are created
         hibernateAccount.setHealthCode(null);
-        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(
-                hibernateAccount);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         Account account = dao.getAccount(ACCOUNT_ID_WITH_ID);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(HEALTH_CODE, account.getHealthCode());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), HEALTH_CODE);
 
         // Verify we create the new health code mapping
         verifyCreatedHealthCode();
@@ -1036,21 +1041,22 @@ public class HibernateAccountDaoTest {
 
     @Test
     public void getByEmailSuccessWithHealthCode() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
-        
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
+
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setHealthCode("original-" + HEALTH_CODE);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals("original-" + HEALTH_CODE, account.getHealthCode());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), "original-" + HEALTH_CODE);
 
         // verify hibernate query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
@@ -1062,11 +1068,11 @@ public class HibernateAccountDaoTest {
     @Test
     public void getByEmailSuccessCreateNewHealthCode() throws Exception {
         when(dao.generateGUID()).thenReturn(HEALTH_CODE);
-        
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN "+
-                "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId "+
-                "WHERE acct.studyId = :studyId AND acct.email=:email GROUP BY acct.id";
-        
+
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN "
+                + "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId "
+                + "WHERE acct.studyId = :studyId AND acct.email=:email GROUP BY acct.id";
+
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         // Clear these fields to verify that they are created
@@ -1076,10 +1082,10 @@ public class HibernateAccountDaoTest {
 
         // execute and validate - just validate ID, study, and email, and health code mapping
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
-        assertEquals(ACCOUNT_ID, account.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(HEALTH_CODE, account.getHealthCode());
+        assertEquals(account.getId(), ACCOUNT_ID);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getHealthCode(), HEALTH_CODE);
 
         // verify hibernate query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
@@ -1097,13 +1103,13 @@ public class HibernateAccountDaoTest {
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EMAIL);
         assertNull(account);
     }
-    
+
     @Test
     public void getByPhone() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.phone.number=:number AND acct.phone.regionCode=:regionCode GROUP BY acct.id";
-        
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.phone.number=:number AND acct.phone.regionCode=:regionCode GROUP BY acct.id";
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         // mock hibernate
         when(mockHibernateHelper.queryGet(expQuery, PHONE_QUERY_PARAMS, null, null, HibernateAccount.class))
@@ -1111,9 +1117,9 @@ public class HibernateAccountDaoTest {
 
         // execute and validate
         Account account = dao.getAccount(ACCOUNT_ID_WITH_PHONE);
-        assertEquals(hibernateAccount.getEmail(), account.getEmail());
+        assertEquals(account.getEmail(), hibernateAccount.getEmail());
     }
-    
+
     @Test
     public void getByPhoneNotFound() {
         Account account = dao.getAccount(ACCOUNT_ID_WITH_PHONE);
@@ -1123,20 +1129,20 @@ public class HibernateAccountDaoTest {
     // ACCOUNT_ID_WITH_HEALTHCODE
     @Test
     public void getByHealthCode() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.healthCode=:healthCode GROUP BY acct.id";
-        
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "
+                + "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.healthCode=:healthCode GROUP BY acct.id";
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         // mock hibernate
         when(mockHibernateHelper.queryGet(expQuery, HEALTHCODE_QUERY_PARAMS, null, null, HibernateAccount.class))
                 .thenReturn(ImmutableList.of(hibernateAccount));
-        
+
         // execute and validate
         Account account = dao.getAccount(ACCOUNT_ID_WITH_HEALTHCODE);
-        assertEquals(hibernateAccount.getEmail(), account.getEmail());
+        assertEquals(account.getEmail(), hibernateAccount.getEmail());
     }
-    
+
     @Test
     public void getByHealthCodeNotFound() {
         Account account = dao.getAccount(ACCOUNT_ID_WITH_HEALTHCODE);
@@ -1146,20 +1152,20 @@ public class HibernateAccountDaoTest {
     // ACCOUNT_ID_WITH_EXTID
     @Test
     public void getByExternalId() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId "+
-                "AND (acctSubstudy.externalId=:externalId OR acct.externalId=:externalId) GROUP BY acct.id";
-        
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "
+                + "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId "
+                + "AND (acctSubstudy.externalId=:externalId OR acct.externalId=:externalId) GROUP BY acct.id";
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         // mock hibernate
-        when(mockHibernateHelper.queryGet(expQuery,
-                EXTID_QUERY_PARAMS, null, null, HibernateAccount.class)).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(expQuery, EXTID_QUERY_PARAMS, null, null, HibernateAccount.class))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and validate
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EXTID);
-        assertEquals(hibernateAccount.getEmail(), account.getEmail());
+        assertEquals(account.getEmail(), hibernateAccount.getEmail());
     }
-    
+
     @Test
     public void getByExternalIdNotFound() {
         Account account = dao.getAccount(ACCOUNT_ID_WITH_EXTID);
@@ -1170,35 +1176,36 @@ public class HibernateAccountDaoTest {
     public void deleteWithoutId() throws Exception {
         // Can't use email, so it will do a lookup of the account
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
-        
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
+
         dao.deleteAccount(ACCOUNT_ID_WITH_EMAIL);
-        
+
         verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);
     }
-    
+
     @Test
     public void deleteWithId() throws Exception {
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
+
         // Directly deletes with the ID it has
         dao.deleteAccount(ACCOUNT_ID_WITH_ID);
-        
+
         verify(mockHibernateHelper).deleteById(HibernateAccount.class, ACCOUNT_ID);
     }
 
     @Test
     public void getPaged() throws Exception {
-        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, "+
-                "acct.firstName, acct.lastName, acct.email, acct.phone, acct.externalId, "+
-                "acct.id, acct.status) FROM HibernateAccount AS acct LEFT JOIN "+
-                "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId "+
-                "WHERE acct.studyId = :studyId GROUP BY acct.id";
-        
-        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct "+
-                "LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH acct.id = "+
-                "acctSubstudy.accountId WHERE acct.studyId = :studyId";
+        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, "
+                + "acct.firstName, acct.lastName, acct.email, acct.phone, acct.externalId, "
+                + "acct.id, acct.status) FROM HibernateAccount AS acct LEFT JOIN "
+                + "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId "
+                + "WHERE acct.studyId = :studyId GROUP BY acct.id";
+
+        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct "
+                + "LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH acct.id = "
+                + "acctSubstudy.accountId WHERE acct.studyId = :studyId";
         // mock hibernate
         HibernateAccount hibernateAccount1 = makeValidHibernateAccount(false);
         hibernateAccount1.setId("account-1");
@@ -1208,42 +1215,44 @@ public class HibernateAccountDaoTest {
         hibernateAccount2.setId("account-2");
         hibernateAccount2.setEmail("email2@example.com");
 
-        when(mockHibernateHelper.queryGet(eq(expQuery), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount1,
-                hibernateAccount2));
+        when(mockHibernateHelper.queryGet(eq(expQuery), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount1, hibernateAccount2));
         when(mockHibernateHelper.queryCount(eq(expCountQuery), any())).thenReturn(12);
 
         // Finally, mock the retrieval of substudies to verify this is called to populate the substudies
         List<HibernateAccountSubstudy> list = ImmutableList.of(
-                    (HibernateAccountSubstudy)AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_A, ACCOUNT_ID), 
-                    (HibernateAccountSubstudy)AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_B, ACCOUNT_ID));
+                (HibernateAccountSubstudy) AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_A,
+                        ACCOUNT_ID),
+                (HibernateAccountSubstudy) AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_B,
+                        ACCOUNT_ID));
         when(mockHibernateHelper.queryGet(eq("FROM HibernateAccountSubstudy WHERE accountId=:accountId"), any(), any(),
                 any(), eq(HibernateAccountSubstudy.class))).thenReturn(list);
-        
+
         // execute and validate
         AccountSummarySearch search = new AccountSummarySearch.Builder().withOffsetBy(10).withPageSize(5).build();
-        
+
         PagedResourceList<AccountSummary> accountSummaryResourceList = dao.getPagedAccountSummaries(study, search);
-        assertEquals(10, accountSummaryResourceList.getRequestParams().get("offsetBy"));
-        assertEquals(5, accountSummaryResourceList.getRequestParams().get("pageSize"));
-        assertEquals((Integer)12, accountSummaryResourceList.getTotal());
+        assertEquals(accountSummaryResourceList.getRequestParams().get("offsetBy"), 10);
+        assertEquals(accountSummaryResourceList.getRequestParams().get("pageSize"), 5);
+        assertEquals(accountSummaryResourceList.getTotal(), (Integer) 12);
 
         Map<String, Object> paramsMap = accountSummaryResourceList.getRequestParams();
-        assertEquals(10, paramsMap.get("offsetBy"));
-        assertEquals(5, paramsMap.get("pageSize"));
+        assertEquals(paramsMap.get("offsetBy"), 10);
+        assertEquals(paramsMap.get("pageSize"), 5);
 
         // just ID, study, and email is sufficient
         List<AccountSummary> accountSummaryList = accountSummaryResourceList.getItems();
-        assertEquals(2, accountSummaryList.size());
+        assertEquals(accountSummaryList.size(), 2);
 
-        assertEquals("account-1", accountSummaryList.get(0).getId());
-        assertEquals(TestConstants.TEST_STUDY, accountSummaryList.get(0).getStudyIdentifier());
-        assertEquals("email1@example.com", accountSummaryList.get(0).getEmail());
-        assertEquals(ImmutableSet.of(SUBSTUDY_A, SUBSTUDY_B), accountSummaryList.get(0).getSubstudyIds());
+        assertEquals(accountSummaryList.get(0).getId(), "account-1");
+        assertEquals(accountSummaryList.get(0).getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(accountSummaryList.get(0).getEmail(), "email1@example.com");
+        assertEquals(accountSummaryList.get(0).getSubstudyIds(), ImmutableSet.of(SUBSTUDY_A, SUBSTUDY_B));
 
-        assertEquals("account-2", accountSummaryList.get(1).getId());
-        assertEquals(TestConstants.TEST_STUDY, accountSummaryList.get(1).getStudyIdentifier());
-        assertEquals("email2@example.com", accountSummaryList.get(1).getEmail());
-        assertEquals(ImmutableSet.of(SUBSTUDY_A, SUBSTUDY_B), accountSummaryList.get(1).getSubstudyIds());
+        assertEquals(accountSummaryList.get(1).getId(), "account-2");
+        assertEquals(accountSummaryList.get(1).getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(accountSummaryList.get(1).getEmail(), "email2@example.com");
+        assertEquals(accountSummaryList.get(1).getSubstudyIds(), ImmutableSet.of(SUBSTUDY_A, SUBSTUDY_B));
 
         // verify hibernate calls
         verify(mockHibernateHelper).queryGet(expQuery, STUDY_QUERY_PARAMS, 10, 5, HibernateAccount.class);
@@ -1252,92 +1261,88 @@ public class HibernateAccountDaoTest {
 
     @Test
     public void getPagedRemovesSubstudiesNotInCaller() throws Exception {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(SUBSTUDY_A)).build());
-        
+        BridgeUtils.setRequestContext(
+                new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of(SUBSTUDY_A)).build());
+
         HibernateAccount hibernateAccount1 = makeValidHibernateAccount(false);
         HibernateAccount hibernateAccount2 = makeValidHibernateAccount(false);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount1,
-                hibernateAccount2));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount1, hibernateAccount2));
 
         // Finally, mock the retrieval of substudies to verify this is called to populate the substudies
         List<HibernateAccountSubstudy> list = ImmutableList.of(
-                    (HibernateAccountSubstudy)AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_A, ACCOUNT_ID), 
-                    (HibernateAccountSubstudy)AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_B, ACCOUNT_ID));
+                (HibernateAccountSubstudy) AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_A,
+                        ACCOUNT_ID),
+                (HibernateAccountSubstudy) AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, SUBSTUDY_B,
+                        ACCOUNT_ID));
         when(mockHibernateHelper.queryGet(eq("FROM HibernateAccountSubstudy WHERE accountId=:accountId"), any(), any(),
                 any(), eq(HibernateAccountSubstudy.class))).thenReturn(list);
-        
+
         AccountSummarySearch search = new AccountSummarySearch.Builder().build();
         PagedResourceList<AccountSummary> accountSummaryResourceList = dao.getPagedAccountSummaries(study, search);
         List<AccountSummary> accountSummaryList = accountSummaryResourceList.getItems();
-        
+
         // substudy B is not there
-        assertEquals(ImmutableSet.of(SUBSTUDY_A), accountSummaryList.get(0).getSubstudyIds());
-        assertEquals(ImmutableSet.of(SUBSTUDY_A), accountSummaryList.get(1).getSubstudyIds());
+        assertEquals(accountSummaryList.get(0).getSubstudyIds(), ImmutableSet.of(SUBSTUDY_A));
+        assertEquals(accountSummaryList.get(1).getSubstudyIds(), ImmutableSet.of(SUBSTUDY_A));
     }
-    
+
     @Test
     public void getPagedWithOptionalParams() throws Exception {
-        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, acct.firstName, "+
-                "acct.lastName, acct.email, acct.phone, acct.externalId, acct.id, acct.status) FROM "+
-                "HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH "+
-                "acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND acct.email LIKE "+
-                ":email AND acct.phone.number LIKE :number AND acct.createdOn >= :startTime AND acct.createdOn "+
-                "<= :endTime AND :language IN ELEMENTS(acct.languages) AND (:IN1 IN elements(acct.dataGroups) "+
-                "AND :IN2 IN elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups) AND "+
-                ":NOTIN2 NOT IN elements(acct.dataGroups)) GROUP BY acct.id";
-        
-        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "+
-                "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "+
-                "acct.studyId = :studyId AND acct.email LIKE :email AND acct.phone.number LIKE :number AND "+
-                "acct.createdOn >= :startTime AND acct.createdOn <= :endTime AND :language IN "+
-                "ELEMENTS(acct.languages) AND (:IN1 IN elements(acct.dataGroups) AND :IN2 IN "+
-                "elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups) AND :NOTIN2 NOT "+
-                "IN elements(acct.dataGroups))";
-        
+        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, acct.firstName, "
+                + "acct.lastName, acct.email, acct.phone, acct.externalId, acct.id, acct.status) FROM "
+                + "HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH "
+                + "acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND acct.email LIKE "
+                + ":email AND acct.phone.number LIKE :number AND acct.createdOn >= :startTime AND acct.createdOn "
+                + "<= :endTime AND :language IN ELEMENTS(acct.languages) AND (:IN1 IN elements(acct.dataGroups) "
+                + "AND :IN2 IN elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups) AND "
+                + ":NOTIN2 NOT IN elements(acct.dataGroups)) GROUP BY acct.id";
+
+        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "
+                + "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "
+                + "acct.studyId = :studyId AND acct.email LIKE :email AND acct.phone.number LIKE :number AND "
+                + "acct.createdOn >= :startTime AND acct.createdOn <= :endTime AND :language IN "
+                + "ELEMENTS(acct.languages) AND (:IN1 IN elements(acct.dataGroups) AND :IN2 IN "
+                + "elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups) AND :NOTIN2 NOT "
+                + "IN elements(acct.dataGroups))";
+
         // Setup start and end dates.
         DateTime startDate = DateTime.parse("2017-05-19T11:40:06.247-0700");
         DateTime endDate = DateTime.parse("2017-05-19T18:32:03.434-0700");
 
         // mock hibernate
-        when(mockHibernateHelper.queryGet(eq(expQuery), any(), any(), any(), any())).thenReturn(ImmutableList.of(
-                makeValidHibernateAccount(false)));
+        when(mockHibernateHelper.queryGet(eq(expQuery), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(makeValidHibernateAccount(false)));
         when(mockHibernateHelper.queryCount(eq(expCountQuery), any())).thenReturn(11);
 
         // execute and validate - Just validate filters and query, since everything else is tested in getPaged().
-        AccountSummarySearch search = new AccountSummarySearch.Builder()
-                .withOffsetBy(10)
-                .withPageSize(5)
-                .withEmailFilter(EMAIL)
-                .withPhoneFilter(PHONE.getNationalFormat())
-                .withAllOfGroups(Sets.newHashSet("a", "b"))
-                .withNoneOfGroups(Sets.newHashSet("c", "d"))
-                .withLanguage("de")
-                .withStartTime(startDate)
-                .withEndTime(endDate).build();
-        
+        AccountSummarySearch search = new AccountSummarySearch.Builder().withOffsetBy(10).withPageSize(5)
+                .withEmailFilter(EMAIL).withPhoneFilter(PHONE.getNationalFormat())
+                .withAllOfGroups(Sets.newHashSet("a", "b")).withNoneOfGroups(Sets.newHashSet("c", "d"))
+                .withLanguage("de").withStartTime(startDate).withEndTime(endDate).build();
+
         PagedResourceList<AccountSummary> accountSummaryResourceList = dao.getPagedAccountSummaries(study, search);
 
         Map<String, Object> paramsMap = accountSummaryResourceList.getRequestParams();
-        assertEquals(10, paramsMap.size());
-        assertEquals(5, paramsMap.get("pageSize"));
-        assertEquals(10, paramsMap.get("offsetBy"));
-        assertEquals(EMAIL, paramsMap.get("emailFilter"));
-        assertEquals(PHONE.getNationalFormat(), paramsMap.get("phoneFilter"));
-        assertEquals(startDate.toString(), paramsMap.get("startTime"));
-        assertEquals(endDate.toString(), paramsMap.get("endTime"));
-        assertEquals(Sets.newHashSet("a","b"), paramsMap.get("allOfGroups"));
-        assertEquals(Sets.newHashSet("c","d"), paramsMap.get("noneOfGroups"));
-        assertEquals("de", paramsMap.get("language"));
-        assertEquals(ResourceList.REQUEST_PARAMS, paramsMap.get(ResourceList.TYPE));
+        assertEquals(paramsMap.size(), 10);
+        assertEquals(paramsMap.get("pageSize"), 5);
+        assertEquals(paramsMap.get("offsetBy"), 10);
+        assertEquals(paramsMap.get("emailFilter"), EMAIL);
+        assertEquals(paramsMap.get("phoneFilter"), PHONE.getNationalFormat());
+        assertEquals(paramsMap.get("startTime"), startDate.toString());
+        assertEquals(paramsMap.get("endTime"), endDate.toString());
+        assertEquals(paramsMap.get("allOfGroups"), Sets.newHashSet("a", "b"));
+        assertEquals(paramsMap.get("noneOfGroups"), Sets.newHashSet("c", "d"));
+        assertEquals(paramsMap.get("language"), "de");
+        assertEquals(paramsMap.get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
 
-        String phoneString = PHONE.getNationalFormat().replaceAll("\\D*","");
+        String phoneString = PHONE.getNationalFormat().replaceAll("\\D*", "");
 
         // verify hibernate calls
-        Map<String,Object> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("studyId", TestConstants.TEST_STUDY_IDENTIFIER);
-        params.put("email", "%"+EMAIL+"%");
-        params.put("number", "%"+phoneString+"%");
+        params.put("email", "%" + EMAIL + "%");
+        params.put("number", "%" + phoneString + "%");
         params.put("startTime", startDate);
         params.put("endTime", endDate);
         params.put("in1", "a");
@@ -1345,73 +1350,73 @@ public class HibernateAccountDaoTest {
         params.put("notin1", "c");
         params.put("notin2", "d");
         params.put("language", "de");
-        
-        verify(mockHibernateHelper).queryGet(eq(expQuery), paramCaptor.capture(), eq(10), eq(5), eq(HibernateAccount.class));
+
+        verify(mockHibernateHelper).queryGet(eq(expQuery), paramCaptor.capture(), eq(10), eq(5),
+                eq(HibernateAccount.class));
         verify(mockHibernateHelper).queryCount(eq(expCountQuery), paramCaptor.capture());
-        
-        Map<String,Object> capturedParams = paramCaptor.getAllValues().get(0);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, capturedParams.get("studyId"));
-        assertEquals("%"+EMAIL+"%", capturedParams.get("email"));
-        assertEquals("%"+phoneString+"%", capturedParams.get("number"));
-        assertEquals(startDate, capturedParams.get("startTime"));
-        assertEquals(endDate, capturedParams.get("endTime"));
-        assertEquals("a", capturedParams.get("IN1"));
-        assertEquals("b", capturedParams.get("IN2"));
-        assertEquals("d", capturedParams.get("NOTIN1"));
-        assertEquals("c", capturedParams.get("NOTIN2"));
-        assertEquals("de", capturedParams.get("language"));
-        
+
+        Map<String, Object> capturedParams = paramCaptor.getAllValues().get(0);
+        assertEquals(capturedParams.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(capturedParams.get("email"), "%" + EMAIL + "%");
+        assertEquals(capturedParams.get("number"), "%" + phoneString + "%");
+        assertEquals(capturedParams.get("startTime"), startDate);
+        assertEquals(capturedParams.get("endTime"), endDate);
+        assertEquals(capturedParams.get("IN1"), "a");
+        assertEquals(capturedParams.get("IN2"), "b");
+        assertEquals(capturedParams.get("NOTIN1"), "d");
+        assertEquals(capturedParams.get("NOTIN2"), "c");
+        assertEquals(capturedParams.get("language"), "de");
+
         capturedParams = paramCaptor.getAllValues().get(1);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, capturedParams.get("studyId"));
-        assertEquals("%"+EMAIL+"%", capturedParams.get("email"));
-        assertEquals("%"+phoneString+"%", capturedParams.get("number"));
-        assertEquals(startDate, capturedParams.get("startTime"));
-        assertEquals(endDate, capturedParams.get("endTime"));
-        assertEquals("a", capturedParams.get("IN1"));
-        assertEquals("b", capturedParams.get("IN2"));
-        assertEquals("d", capturedParams.get("NOTIN1"));
-        assertEquals("c", capturedParams.get("NOTIN2"));
-        assertEquals("de", capturedParams.get("language"));
+        assertEquals(capturedParams.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(capturedParams.get("email"), "%" + EMAIL + "%");
+        assertEquals(capturedParams.get("number"), "%" + phoneString + "%");
+        assertEquals(capturedParams.get("startTime"), startDate);
+        assertEquals(capturedParams.get("endTime"), endDate);
+        assertEquals(capturedParams.get("IN1"), "a");
+        assertEquals(capturedParams.get("IN2"), "b");
+        assertEquals(capturedParams.get("NOTIN1"), "d");
+        assertEquals(capturedParams.get("NOTIN2"), "c");
+        assertEquals(capturedParams.get("language"), "de");
     }
-    
+
     @Test
     public void getPagedWithOptionalParamsRespectsSubstudy() throws Exception {
-        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "+
-                "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "+
-                "acct.studyId = :studyId AND acctSubstudy.substudyId IN (:substudies)";
+        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "
+                + "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "
+                + "acct.studyId = :studyId AND acctSubstudy.substudyId IN (:substudies)";
         Set<String> substudyIds = ImmutableSet.of("substudyA", "substudyB");
         try {
-            RequestContext context = new RequestContext.Builder()
-                    .withCallerSubstudies(substudyIds).build();
+            RequestContext context = new RequestContext.Builder().withCallerSubstudies(substudyIds).build();
             BridgeUtils.setRequestContext(context);
-            
+
             AccountSummarySearch search = new AccountSummarySearch.Builder().build();
             dao.getPagedAccountSummaries(study, search);
-            
+
             verify(mockHibernateHelper).queryCount(eq(expCountQuery), paramCaptor.capture());
-            Map<String,Object> params = paramCaptor.getValue();
-            assertEquals(substudyIds, params.get("substudies"));
-            assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, params.get("studyId"));
+            Map<String, Object> params = paramCaptor.getValue();
+            assertEquals(params.get("substudies"), substudyIds);
+            assertEquals(params.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
         } finally {
             BridgeUtils.setRequestContext(null);
         }
     }
-    
+
     @Test
     public void getPagedWithOptionalEmptySetParams() throws Exception {
-        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, acct.firstName, "+
-                "acct.lastName, acct.email, acct.phone, acct.externalId, acct.id, acct.status) FROM "+
-                "HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH "+
-                "acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND acct.email LIKE "+
-                ":email AND acct.phone.number LIKE :number AND acct.createdOn >= :startTime AND "+
-                "acct.createdOn <= :endTime AND :language IN ELEMENTS(acct.languages) GROUP BY acct.id";
-        
-        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "+
-                "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "+
-                "acct.studyId = :studyId AND acct.email LIKE :email AND acct.phone.number LIKE "+
-                ":number AND acct.createdOn >= :startTime AND acct.createdOn <= :endTime AND :language "+
-                "IN ELEMENTS(acct.languages)";
-        
+        String expQuery = "SELECT new HibernateAccount(acct.createdOn, acct.studyId, acct.firstName, "
+                + "acct.lastName, acct.email, acct.phone, acct.externalId, acct.id, acct.status) FROM "
+                + "HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy WITH "
+                + "acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND acct.email LIKE "
+                + ":email AND acct.phone.number LIKE :number AND acct.createdOn >= :startTime AND "
+                + "acct.createdOn <= :endTime AND :language IN ELEMENTS(acct.languages) GROUP BY acct.id";
+
+        String expCountQuery = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct LEFT JOIN "
+                + "acct.accountSubstudies AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE "
+                + "acct.studyId = :studyId AND acct.email LIKE :email AND acct.phone.number LIKE "
+                + ":number AND acct.createdOn >= :startTime AND acct.createdOn <= :endTime AND :language "
+                + "IN ELEMENTS(acct.languages)";
+
         // Setup start and end dates.
         DateTime startDate = DateTime.parse("2017-05-19T11:40:06.247-0700");
         DateTime endDate = DateTime.parse("2017-05-19T18:32:03.434-0700");
@@ -1422,74 +1427,71 @@ public class HibernateAccountDaoTest {
         when(mockHibernateHelper.queryCount(any(), any())).thenReturn(11);
 
         // execute and validate - Just validate filters and query, since everything else is tested in getPaged().
-        AccountSummarySearch search = new AccountSummarySearch.Builder()
-                .withOffsetBy(10)
-                .withPageSize(5)
-                .withEmailFilter(EMAIL)
-                .withPhoneFilter(PHONE.getNationalFormat())
-                .withLanguage("de")
-                .withStartTime(startDate)
-                .withEndTime(endDate).build();
+        AccountSummarySearch search = new AccountSummarySearch.Builder().withOffsetBy(10).withPageSize(5)
+                .withEmailFilter(EMAIL).withPhoneFilter(PHONE.getNationalFormat()).withLanguage("de")
+                .withStartTime(startDate).withEndTime(endDate).build();
         PagedResourceList<AccountSummary> accountSummaryResourceList = dao.getPagedAccountSummaries(study, search);
 
         Map<String, Object> paramsMap = accountSummaryResourceList.getRequestParams();
-        assertEquals(10, paramsMap.size());
-        assertEquals(5, paramsMap.get("pageSize"));
-        assertEquals(10, paramsMap.get("offsetBy"));
-        assertEquals(EMAIL, paramsMap.get("emailFilter"));
-        assertEquals(PHONE.getNationalFormat(), paramsMap.get("phoneFilter"));
-        assertEquals(startDate.toString(), paramsMap.get("startTime"));
-        assertEquals(endDate.toString(), paramsMap.get("endTime"));
-        assertEquals(Sets.newHashSet(), paramsMap.get("allOfGroups"));
-        assertEquals(Sets.newHashSet(), paramsMap.get("noneOfGroups"));
-        assertEquals("de", paramsMap.get("language"));
-        assertEquals(ResourceList.REQUEST_PARAMS, paramsMap.get(ResourceList.TYPE));
+        assertEquals(paramsMap.size(), 10);
+        assertEquals(paramsMap.get("pageSize"), 5);
+        assertEquals(paramsMap.get("offsetBy"), 10);
+        assertEquals(paramsMap.get("emailFilter"), EMAIL);
+        assertEquals(paramsMap.get("phoneFilter"), PHONE.getNationalFormat());
+        assertEquals(paramsMap.get("startTime"), startDate.toString());
+        assertEquals(paramsMap.get("endTime"), endDate.toString());
+        assertEquals(paramsMap.get("allOfGroups"), Sets.newHashSet());
+        assertEquals(paramsMap.get("noneOfGroups"), Sets.newHashSet());
+        assertEquals(paramsMap.get("language"), "de");
+        assertEquals(paramsMap.get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
 
-        String phoneString = PHONE.getNationalFormat().replaceAll("\\D*","");
+        String phoneString = PHONE.getNationalFormat().replaceAll("\\D*", "");
 
         // verify hibernate calls
-        Map<String,Object> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("studyId", TestConstants.TEST_STUDY);
-        params.put("email", "%"+EMAIL+"%");
-        params.put("number", "%"+phoneString+"%");
+        params.put("email", "%" + EMAIL + "%");
+        params.put("number", "%" + phoneString + "%");
         params.put("startTime", startDate);
         params.put("endTime", endDate);
         params.put("language", "de");
-        
-        verify(mockHibernateHelper).queryGet(eq(expQuery), paramCaptor.capture(), eq(10), eq(5), eq(HibernateAccount.class));
+
+        verify(mockHibernateHelper).queryGet(eq(expQuery), paramCaptor.capture(), eq(10), eq(5),
+                eq(HibernateAccount.class));
         verify(mockHibernateHelper).queryCount(eq(expCountQuery), paramCaptor.capture());
-        
-        Map<String,Object> capturedParams = paramCaptor.getAllValues().get(0);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, capturedParams.get("studyId"));
-        assertEquals("%"+EMAIL+"%", capturedParams.get("email"));
-        assertEquals("%"+phoneString+"%", capturedParams.get("number"));
-        assertEquals(startDate, capturedParams.get("startTime"));
-        assertEquals(endDate, capturedParams.get("endTime"));
-        assertEquals("de", capturedParams.get("language"));
-        
+
+        Map<String, Object> capturedParams = paramCaptor.getAllValues().get(0);
+        assertEquals(capturedParams.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(capturedParams.get("email"), "%" + EMAIL + "%");
+        assertEquals(capturedParams.get("number"), "%" + phoneString + "%");
+        assertEquals(capturedParams.get("startTime"), startDate);
+        assertEquals(capturedParams.get("endTime"), endDate);
+        assertEquals(capturedParams.get("language"), "de");
+
         capturedParams = paramCaptor.getAllValues().get(1);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, capturedParams.get("studyId"));
-        assertEquals("%"+EMAIL+"%", capturedParams.get("email"));
-        assertEquals("%"+phoneString+"%", capturedParams.get("number"));
-        assertEquals(startDate, capturedParams.get("startTime"));
-        assertEquals(endDate, capturedParams.get("endTime"));
-        assertEquals("de", capturedParams.get("language"));
+        assertEquals(capturedParams.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(capturedParams.get("email"), "%" + EMAIL + "%");
+        assertEquals(capturedParams.get("number"), "%" + phoneString + "%");
+        assertEquals(capturedParams.get("startTime"), startDate);
+        assertEquals(capturedParams.get("endTime"), endDate);
+        assertEquals(capturedParams.get("language"), "de");
     }
-    
+
     @Test
     public void getHealthCode() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.email=:email GROUP BY acct.id";
-        
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.email=:email GROUP BY acct.id";
+
         // mock hibernate
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setHealthCode(HEALTH_CODE);
-        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any())).thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
+                .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and validate
         String healthCode = dao.getHealthCodeForAccount(ACCOUNT_ID_WITH_EMAIL);
-        assertEquals(HEALTH_CODE, healthCode);
+        assertEquals(healthCode, HEALTH_CODE);
 
         // verify hibernate query
         verify(mockHibernateHelper).queryGet(expQuery, EMAIL_QUERY_PARAMS, null, null, HibernateAccount.class);
@@ -1518,7 +1520,7 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setLastName(LAST_NAME);
         hibernateAccount.setCreatedOn(CREATED_ON);
         hibernateAccount.setStatus(AccountStatus.ENABLED);
-        
+
         HibernateAccountSubstudy as1 = (HibernateAccountSubstudy) AccountSubstudy
                 .create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyA", ACCOUNT_ID);
         as1.setExternalId("externalIdA");
@@ -1526,25 +1528,24 @@ public class HibernateAccountDaoTest {
                 .create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyB", ACCOUNT_ID);
         as2.setExternalId("externalIdB");
 
-        when(mockHibernateHelper.queryGet("FROM HibernateAccountSubstudy WHERE accountId=:accountId", 
-                ImmutableMap.of("accountId", hibernateAccount.getId()), null, null, 
-                HibernateAccountSubstudy.class)).thenReturn(ImmutableList.of(as1, as2));
-        
+        when(mockHibernateHelper.queryGet("FROM HibernateAccountSubstudy WHERE accountId=:accountId",
+                ImmutableMap.of("accountId", hibernateAccount.getId()), null, null, HibernateAccountSubstudy.class))
+                        .thenReturn(ImmutableList.of(as1, as2));
+
         // Unmarshall
         AccountSummary accountSummary = dao.unmarshallAccountSummary(hibernateAccount);
-        assertEquals(ACCOUNT_ID, accountSummary.getId());
-        assertEquals(TestConstants.TEST_STUDY, accountSummary.getStudyIdentifier());
-        assertEquals(EMAIL, accountSummary.getEmail());
-        assertEquals(TestConstants.PHONE, accountSummary.getPhone());
-        assertEquals(EXTERNAL_ID, accountSummary.getExternalId());
-        assertEquals(ImmutableMap.of("substudyA", "externalIdA", "substudyB", "externalIdB"),
-                accountSummary.getExternalIds());
-        assertEquals(FIRST_NAME, accountSummary.getFirstName());
-        assertEquals(LAST_NAME, accountSummary.getLastName());
-        assertEquals(AccountStatus.ENABLED, accountSummary.getStatus());
+        assertEquals(accountSummary.getId(), ACCOUNT_ID);
+        assertEquals(accountSummary.getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(accountSummary.getEmail(), EMAIL);
+        assertEquals(accountSummary.getPhone(), TestConstants.PHONE);
+        assertEquals(accountSummary.getExternalId(), EXTERNAL_ID);
+        assertEquals(accountSummary.getExternalIds(), ImmutableMap.of("substudyA", "externalIdA", "substudyB", "externalIdB"));
+        assertEquals(accountSummary.getFirstName(), FIRST_NAME);
+        assertEquals(accountSummary.getLastName(), LAST_NAME);
+        assertEquals(accountSummary.getStatus(), AccountStatus.ENABLED);
 
         // createdOn is stored as a long, so just compare epoch milliseconds.
-        assertEquals(CREATED_ON.getMillis(), accountSummary.getCreatedOn().getMillis());
+        assertEquals(accountSummary.getCreatedOn().getMillis(), CREATED_ON.getMillis());
     }
 
     // branch coverage, to make sure nothing crashes.
@@ -1553,18 +1554,18 @@ public class HibernateAccountDaoTest {
         AccountSummary accountSummary = dao.unmarshallAccountSummary(new HibernateAccount());
         assertNotNull(accountSummary);
     }
-    
+
     @Test
     public void unmarshallAccountSummaryFiltersSubstudies() throws Exception {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyB", "substudyC")).build());
-        
+        BridgeUtils.setRequestContext(
+                new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of("substudyB", "substudyC")).build());
+
         // Create HibernateAccount. Only fill in values needed for AccountSummary.
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);
         hibernateAccount.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         hibernateAccount.setStatus(AccountStatus.ENABLED);
-        
+
         HibernateAccountSubstudy as1 = (HibernateAccountSubstudy) AccountSubstudy
                 .create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyA", ACCOUNT_ID);
         as1.setExternalId("externalIdA");
@@ -1572,61 +1573,60 @@ public class HibernateAccountDaoTest {
                 .create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyB", ACCOUNT_ID);
         as2.setExternalId("externalIdB");
 
-        when(mockHibernateHelper.queryGet("FROM HibernateAccountSubstudy WHERE accountId=:accountId", 
-                ImmutableMap.of("accountId", hibernateAccount.getId()), null, null, 
-                HibernateAccountSubstudy.class)).thenReturn(ImmutableList.of(as1, as2));
-        
+        when(mockHibernateHelper.queryGet("FROM HibernateAccountSubstudy WHERE accountId=:accountId",
+                ImmutableMap.of("accountId", hibernateAccount.getId()), null, null, HibernateAccountSubstudy.class))
+                        .thenReturn(ImmutableList.of(as1, as2));
+
         // Unmarshall
         AccountSummary accountSummary = dao.unmarshallAccountSummary(hibernateAccount);
-        assertEquals(ImmutableMap.of("substudyB", "externalIdB"), accountSummary.getExternalIds());
-        assertEquals(ImmutableSet.of("substudyB"), accountSummary.getSubstudyIds());
+        assertEquals(accountSummary.getExternalIds(), ImmutableMap.of("substudyB", "externalIdB"));
+        assertEquals(accountSummary.getSubstudyIds(), ImmutableSet.of("substudyB"));
     }
-    
+
     @Test
     public void unmarshallAccountSummaryStillReturnsOldExternalId() throws Exception {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyB", "substudyC")).build());
-        
+        BridgeUtils.setRequestContext(
+                new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of("substudyB", "substudyC")).build());
+
         // Create HibernateAccount. Only fill in values needed for AccountSummary.
         HibernateAccount hibernateAccount = new HibernateAccount();
         hibernateAccount.setId(ACCOUNT_ID);
         hibernateAccount.setExternalId(EXTERNAL_ID);
         hibernateAccount.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
         hibernateAccount.setStatus(AccountStatus.ENABLED);
-        
+
         // Unmarshall
         AccountSummary accountSummary = dao.unmarshallAccountSummary(hibernateAccount);
-        assertEquals(EXTERNAL_ID, accountSummary.getExternalId());
-    }    
-    
+        assertEquals(accountSummary.getExternalId(), EXTERNAL_ID);
+    }
+
     @Test
     public void editAccountSuccess() throws Exception {
-        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "+
-                "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "acct.healthCode=:healthCode GROUP BY acct.id";
-        
-        // Spy this to verify that the editor lambda is called 
+        String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS "
+                + "acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "acct.healthCode=:healthCode GROUP BY acct.id";
+
+        // Spy this to verify that the editor lambda is called
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setHealthCode("A");
         // mock hibernate
-        when(mockHibernateHelper.queryGet(expQuery,
-                HEALTHCODE_QUERY_PARAMS, null, null, HibernateAccount.class))
-                        .thenReturn(ImmutableList.of(hibernateAccount));
+        when(mockHibernateHelper.queryGet(expQuery, HEALTHCODE_QUERY_PARAMS, null, null, HibernateAccount.class))
+                .thenReturn(ImmutableList.of(hibernateAccount));
         when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
 
         // execute and validate
         dao.editAccount(TestConstants.TEST_STUDY, HEALTH_CODE, accountConsumer);
-        
+
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
         InOrder inOrder = Mockito.inOrder(accountConsumer, mockHibernateHelper);
         inOrder.verify(accountConsumer).accept(hibernateAccount);
         inOrder.verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
     }
-    
+
     @Test
     public void editAccountWhenAccountNotFound() throws Exception {
         dao.editAccount(TestConstants.TEST_STUDY, "bad-health-code", account -> account.setEmail("JUNK"));
-        
+
         verify(accountConsumer, never()).accept(any());
         verify(mockHibernateHelper, never()).update(any(), eq(null));
     }
@@ -1634,174 +1634,174 @@ public class HibernateAccountDaoTest {
     @Test
     public void noLanguageQueryCorrect() throws Exception {
         AccountSummarySearch search = new AccountSummarySearch.Builder().build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy "+
-                "WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, builder.getParameters().get("studyId"));
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy "
+                + "WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
     }
 
     @Test
     public void languageQueryCorrect() throws Exception {
         AccountSummarySearch search = new AccountSummarySearch.Builder().withLanguage("en").build();
-        
+
         QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
                 search, false);
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy "+
-                "WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                ":language IN ELEMENTS(acct.languages) GROUP BY acct.id";
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, builder.getParameters().get("studyId"));
-        assertEquals("en", builder.getParameters().get("language"));
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies AS acctSubstudy "
+                + "WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + ":language IN ELEMENTS(acct.languages) GROUP BY acct.id";
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(builder.getParameters().get("language"), "en");
     }
 
     @Test
     public void groupClausesGroupedCorrectly() throws Exception {
-        AccountSummarySearch search = new AccountSummarySearch.Builder()
-                .withNoneOfGroups(Sets.newHashSet("sdk-int-1"))
+        AccountSummarySearch search = new AccountSummarySearch.Builder().withNoneOfGroups(Sets.newHashSet("sdk-int-1"))
                 .withAllOfGroups(Sets.newHashSet("group1")).build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, 
-                null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "(:IN1 IN elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups)) "+
-                "GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals("sdk-int-1", builder.getParameters().get("NOTIN1"));
-        assertEquals("group1", builder.getParameters().get("IN1"));
-        assertEquals("api", builder.getParameters().get("studyId"));
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "(:IN1 IN elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups)) "
+                + "GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("NOTIN1"), "sdk-int-1");
+        assertEquals(builder.getParameters().get("IN1"), "group1");
+        assertEquals(builder.getParameters().get("studyId"), "api");
     }
 
     @Test
     public void oneAllOfGroupsQueryCorrect() throws Exception {
-        AccountSummarySearch search = new AccountSummarySearch.Builder()
-                .withAllOfGroups(Sets.newHashSet("group1")).build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, 
-                null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "(:IN1 IN elements(acct.dataGroups)) GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals("group1", builder.getParameters().get("IN1"));
-        assertEquals("api", builder.getParameters().get("studyId"));
+        AccountSummarySearch search = new AccountSummarySearch.Builder().withAllOfGroups(Sets.newHashSet("group1"))
+                .build();
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "(:IN1 IN elements(acct.dataGroups)) GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("IN1"), "group1");
+        assertEquals(builder.getParameters().get("studyId"), "api");
     }
 
     @Test
     public void twoAllOfGroupsQueryCorrect() throws Exception {
         AccountSummarySearch search = new AccountSummarySearch.Builder()
                 .withAllOfGroups(Sets.newHashSet("sdk-int-1", "group1")).build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, 
-                null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "(:IN1 IN elements(acct.dataGroups) AND :IN2 IN elements(acct.dataGroups)) GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals("sdk-int-1", builder.getParameters().get("IN1"));
-        assertEquals("group1", builder.getParameters().get("IN2"));
-        assertEquals("api", builder.getParameters().get("studyId"));
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "(:IN1 IN elements(acct.dataGroups) AND :IN2 IN elements(acct.dataGroups)) GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("IN1"), "sdk-int-1");
+        assertEquals(builder.getParameters().get("IN2"), "group1");
+        assertEquals(builder.getParameters().get("studyId"), "api");
     }
 
     @Test
     public void oneNoneOfGroupsQueryCorrect() throws Exception {
-        AccountSummarySearch search = new AccountSummarySearch.Builder()
-                .withNoneOfGroups(Sets.newHashSet("group1")).build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, 
-                null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "(:NOTIN1 NOT IN elements(acct.dataGroups)) GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals("group1", builder.getParameters().get("NOTIN1"));
-        assertEquals("api", builder.getParameters().get("studyId"));
+        AccountSummarySearch search = new AccountSummarySearch.Builder().withNoneOfGroups(Sets.newHashSet("group1"))
+                .build();
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "(:NOTIN1 NOT IN elements(acct.dataGroups)) GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("NOTIN1"), "group1");
+        assertEquals(builder.getParameters().get("studyId"), "api");
     }
 
     @Test
     public void twoNoneOfGroupsQueryCorrect() throws Exception {
         AccountSummarySearch search = new AccountSummarySearch.Builder()
                 .withNoneOfGroups(Sets.newHashSet("sdk-int-1", "group1")).build();
-        
-        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, 
-                null, search, false);
-        
-        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "+
-                "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "+
-                "(:NOTIN1 NOT IN elements(acct.dataGroups) AND :NOTIN2 NOT IN elements(acct.dataGroups)) "+
-                "GROUP BY acct.id";
-        
-        assertEquals(finalQuery, builder.getQuery());
-        assertEquals("sdk-int-1", builder.getParameters().get("NOTIN1"));
-        assertEquals("group1", builder.getParameters().get("NOTIN2"));
-        assertEquals("api", builder.getParameters().get("studyId"));
+
+        QueryBuilder builder = dao.makeQuery(HibernateAccountDao.FULL_QUERY, TestConstants.TEST_STUDY_IDENTIFIER, null,
+                search, false);
+
+        String finalQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
+                + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
+                + "(:NOTIN1 NOT IN elements(acct.dataGroups) AND :NOTIN2 NOT IN elements(acct.dataGroups)) "
+                + "GROUP BY acct.id";
+
+        assertEquals(builder.getQuery(), finalQuery);
+        assertEquals(builder.getParameters().get("NOTIN1"), "sdk-int-1");
+        assertEquals(builder.getParameters().get("NOTIN2"), "group1");
+        assertEquals(builder.getParameters().get("studyId"), "api");
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void authenticateAccountUnverifiedEmailFails() throws Exception {
         study.setVerifyChannelOnSignInEnabled(true);
-        
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setEmailVerified(false);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
 
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
-    
-    @Test(expected = UnauthorizedException.class)
+
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void authenticateAccountUnverifiedPhoneFails() throws Exception {
         study.setVerifyChannelOnSignInEnabled(true);
-        
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setPhoneVerified(null);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
-        SignIn phoneSignIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
-                .withPhone(PHONE).withPassword(DUMMY_PASSWORD).build();
-        
+        SignIn phoneSignIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withPhone(PHONE)
+                .withPassword(DUMMY_PASSWORD).build();
+
         dao.authenticate(study, phoneSignIn);
     }
-    
+
     @Test
     public void authenticateAccountEmailUnverifiedWithoutEmailVerificationOK() throws Exception {
         study.setEmailVerificationEnabled(false);
-        
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setEmailVerified(false);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
 
         dao.authenticate(study, PASSWORD_SIGNIN);
     }
-    
+
     @Test
     public void authenticateAccountUnverifiedEmailSucceedsForLegacy() throws Exception {
         study.setVerifyChannelOnSignInEnabled(false);
 
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setEmailVerified(false);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
@@ -1812,47 +1812,46 @@ public class HibernateAccountDaoTest {
     @Test
     public void authenticateAccountUnverifiedPhoneSucceedsForLegacy() throws Exception {
         study.setVerifyChannelOnSignInEnabled(false);
-        
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(true);
         hibernateAccount.setPhoneVerified(null);
-        
+
         // mock hibernate
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), any()))
                 .thenReturn(ImmutableList.of(hibernateAccount));
 
         // execute and verify - Verify just ID, study, and email, and health code mapping is enough.
-        SignIn phoneSignIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
-                .withPhone(PHONE).withPassword(DUMMY_PASSWORD).build();
-        
+        SignIn phoneSignIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withPhone(PHONE)
+                .withPassword(DUMMY_PASSWORD).build();
+
         dao.authenticate(study, phoneSignIn);
     }
-    
+
     @Test
-    public void editAccountFailsAcrossSubstudies() throws Exception { 
-        BridgeUtils.setRequestContext(
-                new RequestContext.Builder().withCallerSubstudies(CALLER_SUBSTUDIES).build());        
-        
+    public void editAccountFailsAcrossSubstudies() throws Exception {
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerSubstudies(CALLER_SUBSTUDIES).build());
+
         HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
         hibernateAccount.setAccountSubstudies(ACCOUNT_SUBSTUDIES);
         when(mockHibernateHelper.queryGet(any(), any(), eq(null), eq(null), eq(HibernateAccount.class)))
                 .thenReturn(Lists.newArrayList(hibernateAccount));
-        
+
         dao.editAccount(TestConstants.TEST_STUDY, HEALTH_CODE, (account) -> {
             fail("Should have thrown exception");
         });
-        
+
         verify(mockHibernateHelper, never()).update(any(), eq(null));
         BridgeUtils.setRequestContext(null);
     }
-    
+
     private void verifyCreatedHealthCode() {
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);
         verify(mockHibernateHelper).update(updatedAccountCaptor.capture(), eq(null));
 
         HibernateAccount updatedAccount = updatedAccountCaptor.getValue();
-        assertEquals(ACCOUNT_ID, updatedAccount.getId());
-        assertEquals(HEALTH_CODE, updatedAccount.getHealthCode());
-        assertEquals(MOCK_DATETIME.getMillis(), updatedAccount.getModifiedOn().getMillis());
+        assertEquals(updatedAccount.getId(), ACCOUNT_ID);
+        assertEquals(updatedAccount.getHealthCode(), HEALTH_CODE);
+        assertEquals(updatedAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
     }
 
     // Create minimal generic account for everything that will be used by HibernateAccountDao.
@@ -1879,17 +1878,15 @@ public class HibernateAccountDaoTest {
         hibernateAccount.setStatus(AccountStatus.ENABLED);
         hibernateAccount.setMigrationVersion(AccountDao.MIGRATION_VERSION);
         hibernateAccount.setVersion(1);
-        
+
         if (generatePasswordHash) {
             // Password hashes are expensive to generate. Only generate them if the test actually needs them.
-            hibernateAccount.setPasswordAlgorithm(
-                    PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
-            hibernateAccount.setPasswordHash(
-                    PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM.generateHash(DUMMY_PASSWORD));
+            hibernateAccount.setPasswordAlgorithm(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
+            hibernateAccount.setPasswordHash(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM.generateHash(DUMMY_PASSWORD));
         }
         return hibernateAccount;
     }
-    
+
     private void setReauthInAccount(Account account) throws Exception {
         account.setReauthTokenAlgorithm(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
         account.setReauthTokenHash(REAUTH_TOKEN_HASH);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSecretDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSecretDaoTest.java
@@ -77,7 +77,7 @@ public class HibernateAccountSecretDaoTest {
         AccountSecret secret = secretCaptor.getValue();
         assertEquals(secret.getAccountId(), ACCOUNT_ID);
         assertEquals(secret.getAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
-        assertNotEquals(TOKEN, secret.getHash());
+        assertNotEquals(secret.getHash(), TOKEN);
         assertEquals(secret.getType(), AccountSecretType.REAUTH);
         assertEquals(secret.getCreatedOn(), CREATED_ON);
     }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSecretDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSecretDaoTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -21,23 +21,21 @@ import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.accounts.AccountSecret;
 import org.sagebionetworks.bridge.models.accounts.AccountSecretType;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
 
-@RunWith(MockitoJUnitRunner.class)
 public class HibernateAccountSecretDaoTest {
 
     private static final DateTime CREATED_ON = DateTime.parse("2018-10-10T03:10:30.000Z");
@@ -57,14 +55,15 @@ public class HibernateAccountSecretDaoTest {
     @Captor
     ArgumentCaptor<Map<String,Object>> paramsCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao.setHibernateHelper(helper);
         //when(dao.generateHash(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, TOKEN)).thenReturn(TOKEN);
         DateTimeUtils.setCurrentMillisFixed(CREATED_ON.getMillis());
     }
     
-    @After
+    @AfterMethod
     public void after() { 
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -76,11 +75,11 @@ public class HibernateAccountSecretDaoTest {
         verify(helper).create(secretCaptor.capture(), eq(null));
         
         AccountSecret secret = secretCaptor.getValue();
-        assertEquals(ACCOUNT_ID, secret.getAccountId());
-        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, secret.getAlgorithm());
+        assertEquals(secret.getAccountId(), ACCOUNT_ID);
+        assertEquals(secret.getAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
         assertNotEquals(TOKEN, secret.getHash());
-        assertEquals(AccountSecretType.REAUTH, secret.getType());
-        assertEquals(CREATED_ON, secret.getCreatedOn());
+        assertEquals(secret.getType(), AccountSecretType.REAUTH);
+        assertEquals(secret.getCreatedOn(), CREATED_ON);
     }
     
     @Test
@@ -94,8 +93,8 @@ public class HibernateAccountSecretDaoTest {
         verify(helper).queryGet(eq(HibernateAccountSecretDao.GET_QUERY), paramsCaptor.capture(), 
                 eq(0), eq(ROTATIONS), eq(HibernateAccountSecret.class));
         Map<String, Object> params = paramsCaptor.getValue();
-        assertEquals(ACCOUNT_ID, params.get("accountId"));
-        assertEquals(AccountSecretType.REAUTH, params.get("type"));
+        assertEquals(params.get("accountId"), ACCOUNT_ID);
+        assertEquals(params.get("type"), AccountSecretType.REAUTH);
     }
     
     @Test
@@ -141,11 +140,11 @@ public class HibernateAccountSecretDaoTest {
         
         verify(helper).query(eq(HibernateAccountSecretDao.DELETE_QUERY), paramsCaptor.capture());
         Map<String, Object> params = paramsCaptor.getValue();
-        assertEquals(ACCOUNT_ID, params.get("accountId"));
-        assertEquals(AccountSecretType.REAUTH, params.get("type"));
+        assertEquals(params.get("accountId"), ACCOUNT_ID);
+        assertEquals(params.get("type"), AccountSecretType.REAUTH);
     }
     
-    @Test(expected = BridgeServiceException.class)
+    @Test(expectedExceptions = BridgeServiceException.class)
     public void generateHashConvertsException() throws Exception {
         PasswordAlgorithm algorithm = Mockito.mock(PasswordAlgorithm.class);
         when(algorithm.generateHash(any())).thenThrow(new InvalidKeyException());

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountSubstudyTest.java
@@ -1,8 +1,9 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dynamodb.DynamoExternalIdentifier;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -23,12 +24,12 @@ public class HibernateAccountSubstudyTest {
         // not yet used, but coming very shortly
         accountSubstudy.setExternalId("externalId");
         
-        assertEquals("studyId", accountSubstudy.getStudyId());
-        assertEquals("substudyId", accountSubstudy.getSubstudyId());
-        assertEquals("accountId", accountSubstudy.getAccountId());
-        assertEquals("externalId", accountSubstudy.getExternalId());
+        assertEquals(accountSubstudy.getStudyId(), "studyId");
+        assertEquals(accountSubstudy.getSubstudyId(), "substudyId");
+        assertEquals(accountSubstudy.getAccountId(), "accountId");
+        assertEquals(accountSubstudy.getExternalId(), "externalId");
         
         accountSubstudy.setSubstudyId("newSubstudyId");
-        assertEquals("newSubstudyId", accountSubstudy.getSubstudyId());
+        assertEquals(accountSubstudy.getSubstudyId(), "newSubstudyId");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -12,7 +12,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.AccountStatus;
@@ -35,16 +36,16 @@ public class HibernateAccountTest {
         account.setAttributes(originalAttrMap);
 
         Map<String, String> gettedAttrMap1 = account.getAttributes();
-        assertEquals(1, gettedAttrMap1.size());
-        assertEquals("foo-value", gettedAttrMap1.get("foo"));
+        assertEquals(gettedAttrMap1.size(), 1);
+        assertEquals(gettedAttrMap1.get("foo"), "foo-value");
 
         // Putting values in the map reflect through to the account object.
         gettedAttrMap1.put("bar", "bar-value");
 
         Map<String, String> gettedAttrMap2 = account.getAttributes();
-        assertEquals(2, gettedAttrMap2.size());
-        assertEquals("foo-value", gettedAttrMap2.get("foo"));
-        assertEquals("bar-value", gettedAttrMap2.get("bar"));
+        assertEquals(gettedAttrMap2.size(), 2);
+        assertEquals(gettedAttrMap2.get("foo"), "foo-value");
+        assertEquals(gettedAttrMap2.get("bar"), "bar-value");
 
         // Setting attributes to null clears it and returns a new empty map.
         account.setAttributes(null);
@@ -56,8 +57,8 @@ public class HibernateAccountTest {
         gettedAttrMap3.put("baz", "baz-value");
 
         Map<String, String> gettedAttrMap4 = account.getAttributes();
-        assertEquals(1, gettedAttrMap4.size());
-        assertEquals("baz-value", gettedAttrMap4.get("baz"));
+        assertEquals(gettedAttrMap4.size(), 1);
+        assertEquals(gettedAttrMap4.get("baz"), "baz-value");
     }
 
     @Test
@@ -79,14 +80,14 @@ public class HibernateAccountTest {
         account.setConsents(originalConsentMap);
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap1 = account.getConsents();
-        assertEquals(1, gettedConsentMap1.size());
+        assertEquals(gettedConsentMap1.size(), 1);
         assertSame(fooConsent, gettedConsentMap1.get(fooConsentKey));
 
         // Putting values in the map reflect through to the account object.
         gettedConsentMap1.put(barConsentKey, barConsent);
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap2 = account.getConsents();
-        assertEquals(2, gettedConsentMap2.size());
+        assertEquals(gettedConsentMap2.size(), 2);
         assertSame(fooConsent, gettedConsentMap2.get(fooConsentKey));
         assertSame(barConsent, gettedConsentMap2.get(barConsentKey));
 
@@ -100,7 +101,7 @@ public class HibernateAccountTest {
         gettedConsentMap3.put(bazConsentKey, bazConsent);
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap4 = account.getConsents();
-        assertEquals(1, gettedConsentMap4.size());
+        assertEquals(gettedConsentMap4.size(), 1);
         assertSame(bazConsent, gettedConsentMap4.get(bazConsentKey));
     }
 
@@ -111,11 +112,11 @@ public class HibernateAccountTest {
         // Can set and get.
         account.setRoles(EnumSet.of(Roles.ADMIN));
         Set<Roles> gettedRoleSet1 = account.getRoles();
-        assertEquals(EnumSet.of(Roles.ADMIN), gettedRoleSet1);
+        assertEquals(gettedRoleSet1, EnumSet.of(Roles.ADMIN));
 
         // Putting values in the set reflect through to the account object.
         gettedRoleSet1.add(Roles.DEVELOPER);
-        assertEquals(EnumSet.of(Roles.ADMIN, Roles.DEVELOPER), account.getRoles());
+        assertEquals(account.getRoles(), EnumSet.of(Roles.ADMIN, Roles.DEVELOPER));
 
         // Setting to null clears the set. Getting again initializes a new empty set.
         account.setRoles(null);
@@ -124,7 +125,7 @@ public class HibernateAccountTest {
 
         // Similarly, putting values to the set reflect through.
         gettedRoleSet2.add(Roles.RESEARCHER);
-        assertEquals(EnumSet.of(Roles.RESEARCHER), account.getRoles());
+        assertEquals(account.getRoles(), EnumSet.of(Roles.RESEARCHER));
     }
     
     @Test
@@ -132,15 +133,15 @@ public class HibernateAccountTest {
         HibernateAccount account = new HibernateAccount(new DateTime(123L), TestConstants.TEST_STUDY_IDENTIFIER, "firstName",
                 "lastName", "email", TestConstants.PHONE, "externalId", "id", AccountStatus.UNVERIFIED);
 
-        assertEquals(123L, account.getCreatedOn().getMillis());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, account.getStudyId());
-        assertEquals("firstName", account.getFirstName());
-        assertEquals("lastName", account.getLastName());
-        assertEquals("email", account.getEmail());
-        assertEquals(TestConstants.PHONE, account.getPhone());
-        assertEquals("externalId", account.getExternalId());
-        assertEquals("id", account.getId());
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getCreatedOn().getMillis(), 123L);
+        assertEquals(account.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getFirstName(), "firstName");
+        assertEquals(account.getLastName(), "lastName");
+        assertEquals(account.getEmail(), "email");
+        assertEquals(account.getPhone(), TestConstants.PHONE);
+        assertEquals(account.getExternalId(), "externalId");
+        assertEquals(account.getId(), "id");
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
     }
     
     @Test
@@ -150,7 +151,7 @@ public class HibernateAccountTest {
 
         // Set works.
         account.setDataGroups(Sets.newHashSet("A","B"));
-        assertEquals(Sets.newHashSet("A","B"), account.getDataGroups());
+        assertEquals(account.getDataGroups(), Sets.newHashSet("A","B"));
 
         // Setting to null makes it an empty set.
         account.setDataGroups(null);
@@ -173,7 +174,7 @@ public class HibernateAccountTest {
         
         // Set works.
         account.setLanguages(langs);
-        assertEquals(langs, account.getLanguages());
+        assertEquals(account.getLanguages(), langs);
         
         // Setting to null makes it an empty set.
         account.setLanguages(null);
@@ -183,7 +184,7 @@ public class HibernateAccountTest {
     @Test
     public void sharingDefaultsToNoSharing() {
         HibernateAccount account = new HibernateAccount();
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
     }
     
     @Test
@@ -230,38 +231,38 @@ public class HibernateAccountTest {
         Map<SubpopulationGuid, List<ConsentSignature>> histories = account.getAllConsentSignatureHistories();
         
         List<ConsentSignature> history1 = histories.get(guid1);
-        assertEquals(3, history1.size());
+        assertEquals(history1.size(), 3);
         // Signed on values are copied over from keys
-        assertEquals(TIME1, history1.get(0).getSignedOn());
-        assertEquals(TIME2, history1.get(1).getSignedOn());
-        assertEquals(TIME3, history1.get(2).getSignedOn());
+        assertEquals(history1.get(0).getSignedOn(), TIME1);
+        assertEquals(history1.get(1).getSignedOn(), TIME2);
+        assertEquals(history1.get(2).getSignedOn(), TIME3);
         
         List<ConsentSignature> history2 = histories.get(guid2);
-        assertEquals(2, history2.size());
+        assertEquals(history2.size(), 2);
         // Signed on values are copied over from keys
-        assertEquals(TIME4, history2.get(0).getSignedOn());
-        assertEquals(TIME5, history2.get(1).getSignedOn());
+        assertEquals(history2.get(0).getSignedOn(), TIME4);
+        assertEquals(history2.get(1).getSignedOn(), TIME5);
         
         // Test getConsentSignatureHistory(guid). Should produce identical results.
         history1 = account.getConsentSignatureHistory(guid1);
-        assertEquals(3, history1.size());
+        assertEquals(history1.size(), 3);
         // Signed on values are copied over from keys
-        assertEquals(TIME1, history1.get(0).getSignedOn());
-        assertEquals(TIME2, history1.get(1).getSignedOn());
-        assertEquals(TIME3, history1.get(2).getSignedOn());
+        assertEquals(history1.get(0).getSignedOn(), TIME1);
+        assertEquals(history1.get(1).getSignedOn(), TIME2);
+        assertEquals(history1.get(2).getSignedOn(), TIME3);
         
         history2 = account.getConsentSignatureHistory(guid2);
-        assertEquals(2, history2.size());
+        assertEquals(history2.size(), 2);
         // Signed on values are copied over from keys
-        assertEquals(TIME4, history2.get(0).getSignedOn());
-        assertEquals(TIME5, history2.get(1).getSignedOn());
+        assertEquals(history2.get(0).getSignedOn(), TIME4);
+        assertEquals(history2.get(1).getSignedOn(), TIME5);
         
         // The last consent in the series was withdrawn, so this consent is not active.
         ConsentSignature sig1 = account.getActiveConsentSignature(guid1);
         assertNull(sig1);
         
         ConsentSignature sig2 = account.getActiveConsentSignature(guid2);
-        assertEquals(sig2, history2.get(1));
+        assertEquals(history2.get(1), sig2);
         
         // Add a consent to the withdrawn series.
         ConsentSignature sig3 = new ConsentSignature.Builder().withBirthdate("1980-01-01")
@@ -273,7 +274,7 @@ public class HibernateAccountTest {
         account.setConsentSignatureHistory(guid1, signatures);
         
         sig1 = account.getActiveConsentSignature(guid1);
-        assertEquals(sig1, account.getAllConsentSignatureHistories().get(guid1).get(3));
+        assertEquals(account.getAllConsentSignatureHistories().get(guid1).get(3), sig1);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -81,15 +81,15 @@ public class HibernateAccountTest {
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap1 = account.getConsents();
         assertEquals(gettedConsentMap1.size(), 1);
-        assertSame(fooConsent, gettedConsentMap1.get(fooConsentKey));
+        assertSame(gettedConsentMap1.get(fooConsentKey), fooConsent);
 
         // Putting values in the map reflect through to the account object.
         gettedConsentMap1.put(barConsentKey, barConsent);
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap2 = account.getConsents();
         assertEquals(gettedConsentMap2.size(), 2);
-        assertSame(fooConsent, gettedConsentMap2.get(fooConsentKey));
-        assertSame(barConsent, gettedConsentMap2.get(barConsentKey));
+        assertSame(gettedConsentMap2.get(fooConsentKey), fooConsent);
+        assertSame(gettedConsentMap2.get(barConsentKey), barConsent);
 
         // Setting to null clears the map. Getting again initializes a new empty map.
         account.setConsents(null);
@@ -102,7 +102,7 @@ public class HibernateAccountTest {
 
         Map<HibernateAccountConsentKey, HibernateAccountConsent> gettedConsentMap4 = account.getConsents();
         assertEquals(gettedConsentMap4.size(), 1);
-        assertSame(bazConsent, gettedConsentMap4.get(bazConsentKey));
+        assertSame(gettedConsentMap4.get(bazConsentKey), bazConsent);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
@@ -130,7 +130,7 @@ public class HibernateHelperTest {
             helper.create(testObj, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, testObj);
     }
@@ -154,7 +154,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         Object helperOutput = helper.getById(Object.class, "test-id");
-        assertSame(hibernateOutput, helperOutput);
+        assertSame(helperOutput, hibernateOutput);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         List<Object> helperOutputList = helper.queryGet(QUERY, null, null, null, Object.class);
-        assertSame(hibernateOutputList, helperOutputList);
+        assertSame(helperOutputList, hibernateOutputList);
     }
 
     @Test
@@ -238,7 +238,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         List<Object> helperOutputList = helper.queryGet(QUERY, PARAMETERS, null, null, Object.class);
-        assertSame(hibernateOutputList, helperOutputList);
+        assertSame(helperOutputList, hibernateOutputList);
         
         verify(mockQuery).setParameter("studyId", "study-test");
         verify(mockQuery).setParameter("id", 10L);
@@ -290,7 +290,7 @@ public class HibernateHelperTest {
     public void update() {
         Object testObj = new Object();
         Object received = helper.update(testObj, null);
-        assertSame(testObj, received);
+        assertSame(received, testObj);
         verify(mockSession).update(testObj);
     }
 
@@ -355,7 +355,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         Object helperOutput = helper.executeWithExceptionHandling(null, mockFunction);
-        assertSame(functionOutput, helperOutput);
+        assertSame(helperOutput, functionOutput);
 
         inOrder.verify(mockSessionFactory).openSession();
         inOrder.verify(mockSession).beginTransaction();
@@ -383,7 +383,7 @@ public class HibernateHelperTest {
             helper.create(account, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, account);
     }
@@ -404,7 +404,7 @@ public class HibernateHelperTest {
             helper.deleteById(HibernateAccount.class, "whatever");
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, null);
     }
@@ -425,7 +425,7 @@ public class HibernateHelperTest {
             helper.getById(HibernateAccount.class, "whatever");
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, null);
     }
@@ -446,7 +446,7 @@ public class HibernateHelperTest {
             helper.queryCount("query string", ImmutableMap.of());
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, null);
     }
@@ -467,7 +467,7 @@ public class HibernateHelperTest {
             helper.queryGet("query string", ImmutableMap.of(), 0, 20, HibernateAccount.class);
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, null);
     }
@@ -491,7 +491,7 @@ public class HibernateHelperTest {
             helper.queryUpdate("query string", ImmutableMap.of());
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, null);
     }
@@ -516,7 +516,7 @@ public class HibernateHelperTest {
             helper.update(account, null);
             fail("Should have thrown exception");
         } catch(Exception e) {
-            assertSame(TEST_EXCEPTION, e);
+            assertSame(e, TEST_EXCEPTION);
         }
         verify(mockExceptionConverter).convert(ex, account);
     }
@@ -540,7 +540,7 @@ public class HibernateHelperTest {
             fail("Should have thrown exception");
         } catch(BridgeServiceException e) {
             // So we wrap it with a BridgeServiceException
-            assertSame(pe, e.getCause());
+            assertSame(e.getCause(), pe);
         }
     }
  

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateHelperTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -13,6 +10,9 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -31,18 +31,17 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.query.Query;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.accounts.Account;
 
-@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
 public class HibernateHelperTest {
     private static final String QUERY = "from DummyTable";
@@ -62,8 +61,9 @@ public class HibernateHelperTest {
     @Mock
     private Transaction mockTransaction;
     
-    @Before
+    @BeforeMethod
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         // Spy Hibernate helper. This allows us to mock execute() and test it independently later.
         helper = spy(new HibernateHelper(mockSessionFactory, mockExceptionConverter));
         doAnswer(invocation -> {
@@ -167,7 +167,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         int count = helper.queryCount(QUERY, null);
-        assertEquals(42, count);
+        assertEquals(count, 42);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         int count = helper.queryCount(QUERY, null);
-        assertEquals(0, count);
+        assertEquals(count, 0);
     }
     
     @Test
@@ -193,7 +193,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         int count = helper.queryCount(QUERY, PARAMETERS);
-        assertEquals(42, count);
+        assertEquals(count, 42);
         
         verify(mockQuery).setParameter("studyId", "study-test");
         verify(mockQuery).setParameter("id", 10L);
@@ -254,7 +254,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         int numRows = helper.queryUpdate(QUERY, null);
-        assertEquals(7, numRows);
+        assertEquals(numRows, 7);
     }
     
     @Test
@@ -267,7 +267,7 @@ public class HibernateHelperTest {
 
         // execute and validate
         int numRows = helper.queryUpdate(QUERY, PARAMETERS);
-        assertEquals(7, numRows);
+        assertEquals(numRows, 7);
         
         verify(mockQuery).setParameter("studyId", "study-test");
         verify(mockQuery).setParameter("id", 10L);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
@@ -68,8 +68,8 @@ public class HibernateSharedModuleMetadataDaoTest {
 
         // validate data flow
         SharedModuleMetadata hibernateInputMetadata = hibernateInputMetadataCaptor.getValue();
-        assertSame(daoInputMetadata, hibernateInputMetadata);
-        assertSame(hibernateInputMetadata, daoOutputMetadata);
+        assertSame(hibernateInputMetadata, daoInputMetadata);
+        assertSame(daoOutputMetadata, hibernateInputMetadata);
     }
 
     @Test(expectedExceptions = ConcurrentModificationException.class)
@@ -153,7 +153,7 @@ public class HibernateSharedModuleMetadataDaoTest {
 
         // execute and validate
         SharedModuleMetadata daoOutputMetadata = dao.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
-        assertSame(hibernateOutputMetadata, daoOutputMetadata);
+        assertSame(daoOutputMetadata, hibernateOutputMetadata);
 
         // validate backends
         verifySessionAndTransaction();
@@ -171,7 +171,7 @@ public class HibernateSharedModuleMetadataDaoTest {
 
         // execute and validate
         List<SharedModuleMetadata> daoOutputMetadataList = dao.queryMetadata("foo='bar'", null);
-        assertSame(hibernateOutputMetadataList, daoOutputMetadataList);
+        assertSame(daoOutputMetadataList, hibernateOutputMetadataList);
 
         // validate backends
         verifySessionAndTransaction();
@@ -189,7 +189,7 @@ public class HibernateSharedModuleMetadataDaoTest {
 
         // execute and validate
         List<SharedModuleMetadata> daoOutputMetadataList = dao.queryMetadata(null, null);
-        assertSame(hibernateOutputMetadataList, daoOutputMetadataList);
+        assertSame(daoOutputMetadataList, hibernateOutputMetadataList);
 
         // validate backends
         verifySessionAndTransaction();
@@ -223,8 +223,8 @@ public class HibernateSharedModuleMetadataDaoTest {
 
         // validate data flow
         SharedModuleMetadata hibernateInputMetadata = hibernateInputMetadataCaptor.getValue();
-        assertSame(daoInputMetadata, hibernateInputMetadata);
-        assertSame(hibernateInputMetadata, daoOutputMetadata);
+        assertSame(hibernateInputMetadata, daoInputMetadata);
+        assertSame(daoOutputMetadata, hibernateInputMetadata);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataDaoTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,9 +19,9 @@ import org.hibernate.Transaction;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.hql.internal.ast.QuerySyntaxException;
 import org.hibernate.query.Query;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
@@ -36,7 +36,7 @@ public class HibernateSharedModuleMetadataDaoTest {
     private Session mockSession;
     private Transaction mockTransaction;
 
-    @Before
+    @BeforeMethod
     public void before() {
         // mock transaction
         mockTransaction = mock(Transaction.class);
@@ -72,7 +72,7 @@ public class HibernateSharedModuleMetadataDaoTest {
         assertSame(hibernateInputMetadata, daoOutputMetadata);
     }
 
-    @Test(expected = ConcurrentModificationException.class)
+    @Test(expectedExceptions = ConcurrentModificationException.class)
     public void createConstraintViolation() {
         // mock dao to throw - Need to mock the ConstraintViolationException, because the exception itself is pretty
         // heavy-weight.
@@ -83,7 +83,7 @@ public class HibernateSharedModuleMetadataDaoTest {
         dao.createMetadata(SharedModuleMetadata.create());
     }
 
-    @Test(expected = PersistenceException.class)
+    @Test(expectedExceptions = PersistenceException.class)
     public void createOtherException() {
         when(mockSession.save(any())).thenThrow(new PersistenceException());
         dao.createMetadata(SharedModuleMetadata.create());
@@ -195,14 +195,14 @@ public class HibernateSharedModuleMetadataDaoTest {
         verifySessionAndTransaction();
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void queryBadQuery() {
         when(mockSession.createQuery("from HibernateSharedModuleMetadata where blargg", SharedModuleMetadata.class))
                 .thenThrow(new IllegalArgumentException(new QuerySyntaxException("error message")));
         dao.queryMetadata("blargg", null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void queryOtherException() {
         when(mockSession.createQuery("from HibernateSharedModuleMetadata where foo='bar'", SharedModuleMetadata.class))
                 .thenThrow(new IllegalArgumentException());

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataKeyTest.java
@@ -1,8 +1,9 @@
 package org.sagebionetworks.bridge.hibernate;
 
+import org.testng.annotations.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Test;
 
 public class HibernateSharedModuleMetadataKeyTest {
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSharedModuleMetadataTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -36,7 +37,7 @@ public class HibernateSharedModuleMetadataTest {
         SharedModuleMetadata metadata = SharedModuleMetadata.create();
         metadata.setSchemaId(SCHEMA_ID);
         metadata.setSchemaRevision(SCHEMA_REV);
-        assertEquals(SharedModuleType.SCHEMA, metadata.getModuleType());
+        assertEquals(metadata.getModuleType(), SharedModuleType.SCHEMA);
     }
 
     @Test
@@ -44,10 +45,10 @@ public class HibernateSharedModuleMetadataTest {
         SharedModuleMetadata metadata = SharedModuleMetadata.create();
         metadata.setSurveyCreatedOn(SURVEY_CREATED_ON_MILLIS);
         metadata.setSurveyGuid(SURVEY_GUID);
-        assertEquals(SharedModuleType.SURVEY, metadata.getModuleType());
+        assertEquals(metadata.getModuleType(), SharedModuleType.SURVEY);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getModuleTypeNeither() {
         SharedModuleMetadata.create().getModuleType();
     }
@@ -61,7 +62,7 @@ public class HibernateSharedModuleMetadataTest {
 
         // set the tags
         metadata.setTags(ImmutableSet.of("foo", "bar", "baz"));
-        assertEquals(ImmutableSet.of("foo", "bar", "baz"), metadata.getTags());
+        assertEquals(metadata.getTags(), ImmutableSet.of("foo", "bar", "baz"));
 
         // Set tag set to null. It should come back as empty.
         metadata.setTags(null);
@@ -87,42 +88,42 @@ public class HibernateSharedModuleMetadataTest {
 
         // Convert to POJO
         SharedModuleMetadata metadata = BridgeObjectMapper.get().readValue(jsonText, SharedModuleMetadata.class);
-        assertEquals(MODULE_ID, metadata.getId());
+        assertEquals(metadata.getId(), MODULE_ID);
         assertTrue(metadata.isLicenseRestricted());
-        assertEquals(MODULE_NAME, metadata.getName());
-        assertEquals(MODULE_NOTES, metadata.getNotes());
-        assertEquals(MODULE_OS, metadata.getOs());
+        assertEquals(metadata.getName(), MODULE_NAME);
+        assertEquals(metadata.getNotes(), MODULE_NOTES);
+        assertEquals(metadata.getOs(), MODULE_OS);
         assertTrue(metadata.isPublished());
-        assertEquals(SCHEMA_ID, metadata.getSchemaId());
-        assertEquals(SCHEMA_REV, metadata.getSchemaRevision().intValue());
-        assertEquals(MODULE_TAGS, metadata.getTags());
+        assertEquals(metadata.getSchemaId(), SCHEMA_ID);
+        assertEquals(metadata.getSchemaRevision().intValue(), SCHEMA_REV);
+        assertEquals(metadata.getTags(), MODULE_TAGS);
         assertFalse(metadata.isDeleted());
-        assertEquals(MODULE_VERSION, metadata.getVersion());
+        assertEquals(metadata.getVersion(), MODULE_VERSION);
 
         // Convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(metadata, JsonNode.class);
-        assertEquals(13, jsonNode.size());
-        assertEquals(MODULE_ID, jsonNode.get("id").textValue());
+        assertEquals(jsonNode.size(), 13);
+        assertEquals(jsonNode.get("id").textValue(), MODULE_ID);
         assertTrue(jsonNode.get("licenseRestricted").booleanValue());
-        assertEquals(MODULE_NAME, jsonNode.get("name").textValue());
-        assertEquals(MODULE_NOTES, jsonNode.get("notes").textValue());
-        assertEquals(MODULE_OS, jsonNode.get("os").textValue());
+        assertEquals(jsonNode.get("name").textValue(), MODULE_NAME);
+        assertEquals(jsonNode.get("notes").textValue(), MODULE_NOTES);
+        assertEquals(jsonNode.get("os").textValue(), MODULE_OS);
         assertTrue(jsonNode.get("published").booleanValue());
-        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
-        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
-        assertEquals(MODULE_VERSION, jsonNode.get("version").intValue());
-        assertEquals("schema", jsonNode.get("moduleType").textValue());
+        assertEquals(jsonNode.get("schemaId").textValue(), SCHEMA_ID);
+        assertEquals(jsonNode.get("schemaRevision").intValue(), SCHEMA_REV);
+        assertEquals(jsonNode.get("version").intValue(), MODULE_VERSION);
+        assertEquals(jsonNode.get("moduleType").textValue(), "schema");
         assertFalse(jsonNode.get("deleted").booleanValue());
-        assertEquals("SharedModuleMetadata", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.get("type").textValue(), "SharedModuleMetadata");
 
         JsonNode tagsNode = jsonNode.get("tags");
-        assertEquals(3, tagsNode.size());
+        assertEquals(tagsNode.size(), 3);
         Set<String> jsonNodeTags = new HashSet<>();
         for (int i = 0; i < 3; i++) {
             String oneTag = tagsNode.get(i).textValue();
             jsonNodeTags.add(oneTag);
         }
-        assertEquals(MODULE_TAGS, jsonNodeTags);
+        assertEquals(jsonNodeTags, MODULE_TAGS);
     }
 
     @Test
@@ -139,28 +140,28 @@ public class HibernateSharedModuleMetadataTest {
 
         // Convert to POJO - Test only the fields we set, so that we don't have exploding tests.
         SharedModuleMetadata metadata = BridgeObjectMapper.get().readValue(jsonText, SharedModuleMetadata.class);
-        assertEquals(MODULE_ID, metadata.getId());
-        assertEquals(MODULE_NAME, metadata.getName());
-        assertEquals(SURVEY_CREATED_ON_MILLIS, metadata.getSurveyCreatedOn().longValue());
-        assertEquals(SURVEY_GUID, metadata.getSurveyGuid());
-        assertEquals(MODULE_VERSION, metadata.getVersion());
+        assertEquals(metadata.getId(), MODULE_ID);
+        assertEquals(metadata.getName(), MODULE_NAME);
+        assertEquals(metadata.getSurveyCreatedOn().longValue(), SURVEY_CREATED_ON_MILLIS);
+        assertEquals(metadata.getSurveyGuid(), SURVEY_GUID);
+        assertEquals(metadata.getVersion(), MODULE_VERSION);
 
         // Convert back to JSON. licenseRestricted and published default to false. tags defaults to empty set.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(metadata, JsonNode.class);
-        assertEquals(11, jsonNode.size());
-        assertEquals(MODULE_ID, jsonNode.get("id").textValue());
+        assertEquals(jsonNode.size(), 11);
+        assertEquals(jsonNode.get("id").textValue(), MODULE_ID);
         assertFalse(jsonNode.get("licenseRestricted").booleanValue());
-        assertEquals(MODULE_NAME, jsonNode.get("name").textValue());
+        assertEquals(jsonNode.get("name").textValue(), MODULE_NAME);
         assertFalse(jsonNode.get("published").booleanValue());
-        assertEquals(SURVEY_GUID, jsonNode.get("surveyGuid").textValue());
+        assertEquals(jsonNode.get("surveyGuid").textValue(), SURVEY_GUID);
         assertTrue(jsonNode.get("tags").isArray());
-        assertEquals(0, jsonNode.get("tags").size());
-        assertEquals(MODULE_VERSION, jsonNode.get("version").intValue());
-        assertEquals("survey", jsonNode.get("moduleType").textValue());
+        assertEquals(jsonNode.get("tags").size(), 0);
+        assertEquals(jsonNode.get("version").intValue(), MODULE_VERSION);
+        assertEquals(jsonNode.get("moduleType").textValue(), "survey");
         assertTrue(jsonNode.get("deleted").booleanValue());
-        assertEquals("SharedModuleMetadata", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.get("type").textValue(), "SharedModuleMetadata");
 
         String surveyCreatedOnString = jsonNode.get("surveyCreatedOn").textValue();
-        assertEquals(SURVEY_CREATED_ON_MILLIS, DateUtils.convertToMillisFromEpoch(surveyCreatedOnString));
+        assertEquals(DateUtils.convertToMillisFromEpoch(surveyCreatedOnString), SURVEY_CREATED_ON_MILLIS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSubstudyDaoTest.java
@@ -1,24 +1,24 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 
 import javax.persistence.PersistenceException;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.substudies.Substudy;
@@ -26,7 +26,6 @@ import org.sagebionetworks.bridge.models.substudies.SubstudyId;
 
 import com.google.common.collect.ImmutableList;
 
-@RunWith(MockitoJUnitRunner.class)
 public class HibernateSubstudyDaoTest {
     private static final List<HibernateSubstudy> SUBSTUDIES = ImmutableList.of(new HibernateSubstudy(),
             new HibernateSubstudy());
@@ -48,8 +47,9 @@ public class HibernateSubstudyDaoTest {
     @Captor
     ArgumentCaptor<HibernateSubstudy> substudyCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         dao = new HibernateSubstudyDao();
         dao.setHibernateHelper(hibernateHelper);
     }
@@ -60,15 +60,14 @@ public class HibernateSubstudyDaoTest {
                 .thenReturn(SUBSTUDIES);
         
         List<Substudy> list = dao.getSubstudies(TestConstants.TEST_STUDY, true);
-        assertEquals(2, list.size());
+        assertEquals(list.size(), 2);
         
         verify(hibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), 
                 eq(null), eq(null), eq(HibernateSubstudy.class));
         
-        assertEquals("from HibernateSubstudy as substudy where studyId=:studyId", 
-                queryCaptor.getValue());
+        assertEquals(queryCaptor.getValue(), "from HibernateSubstudy as substudy where studyId=:studyId");
         Map<String,Object> parameters = paramsCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, parameters.get("studyId"));
+        assertEquals(parameters.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
     }
 
     @Test
@@ -77,15 +76,15 @@ public class HibernateSubstudyDaoTest {
             .thenReturn(SUBSTUDIES);
 
         List<Substudy> list = dao.getSubstudies(TestConstants.TEST_STUDY, false);
-        assertEquals(2, list.size());
+        assertEquals(list.size(), 2);
         
         verify(hibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), 
                 eq(null), eq(null), eq(HibernateSubstudy.class));
         
-        assertEquals("from HibernateSubstudy as substudy where studyId=:studyId and deleted != 1", 
-                queryCaptor.getValue());
+        assertEquals(queryCaptor.getValue(),
+                "from HibernateSubstudy as substudy where studyId=:studyId and deleted != 1");
         Map<String,Object> parameters = paramsCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, parameters.get("studyId"));
+        assertEquals(parameters.get("studyId"), TestConstants.TEST_STUDY_IDENTIFIER);
     }
     
     @Test
@@ -94,13 +93,13 @@ public class HibernateSubstudyDaoTest {
         when(hibernateHelper.getById(eq(HibernateSubstudy.class), any())).thenReturn(substudy);
         
         Substudy returnedValue = dao.getSubstudy(TestConstants.TEST_STUDY, "id");
-        assertEquals(substudy, returnedValue);
+        assertEquals(returnedValue, substudy);
         
         verify(hibernateHelper).getById(eq(HibernateSubstudy.class), substudyIdCaptor.capture());
         
         SubstudyId substudyId = substudyIdCaptor.getValue();
-        assertEquals("id", substudyId.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, substudyId.getStudyId());
+        assertEquals(substudyId.getId(), "id");
+        assertEquals(substudyId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
     }
     
     @Test
@@ -109,12 +108,12 @@ public class HibernateSubstudyDaoTest {
         substudy.setVersion(2L);
         
         VersionHolder holder = dao.createSubstudy(substudy);
-        assertEquals(new Long(2), holder.getVersion());
+        assertEquals(holder.getVersion(), new Long(2));
         
         verify(hibernateHelper).create(substudyCaptor.capture(), eq(null));
         
         Substudy persisted = substudyCaptor.getValue();
-        assertEquals(new Long(2), persisted.getVersion());
+        assertEquals(persisted.getVersion(), new Long(2));
     }
 
     @Test
@@ -123,12 +122,12 @@ public class HibernateSubstudyDaoTest {
         substudy.setVersion(2L);
         
         VersionHolder holder = dao.updateSubstudy(substudy);
-        assertEquals(new Long(2), holder.getVersion());
+        assertEquals(holder.getVersion(), new Long(2));
         
         verify(hibernateHelper).update(substudyCaptor.capture(), eq(null));
         
         Substudy persisted = substudyCaptor.getValue();
-        assertEquals(new Long(2), persisted.getVersion());
+        assertEquals(persisted.getVersion(), new Long(2));
     }
 
     @Test
@@ -137,11 +136,11 @@ public class HibernateSubstudyDaoTest {
         
         verify(hibernateHelper).deleteById(eq(HibernateSubstudy.class), substudyIdCaptor.capture());
         SubstudyId substudyId = substudyIdCaptor.getValue();
-        assertEquals("oneId", substudyId.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, substudyId.getStudyId());
+        assertEquals(substudyId.getId(), "oneId");
+        assertEquals(substudyId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
     }    
 
-    @Test(expected = PersistenceException.class)
+    @Test(expectedExceptions = PersistenceException.class)
     public void deleteSubstudyPermanentlyNotFound() {
         doThrow(new PersistenceException()).when(hibernateHelper).deleteById(eq(HibernateSubstudy.class), any());
             

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSubstudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSubstudyTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.substudies.Substudy;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -30,22 +31,22 @@ public class HibernateSubstudyTest {
         substudy.setVersion(3L);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(substudy);
-        assertEquals(7, node.size());
-        assertEquals("oneId", node.get("id").textValue());
-        assertEquals("name", node.get("name").textValue());
+        assertEquals(node.size(), 7);
+        assertEquals(node.get("id").textValue(), "oneId");
+        assertEquals(node.get("name").textValue(), "name");
         assertTrue(node.get("deleted").booleanValue());
-        assertEquals(CREATED_ON.toString(), node.get("createdOn").textValue());
-        assertEquals(MODIFIED_ON.toString(), node.get("modifiedOn").textValue());
-        assertEquals(3L, node.get("version").longValue());
-        assertEquals("Substudy", node.get("type").textValue());
+        assertEquals(node.get("createdOn").textValue(), CREATED_ON.toString());
+        assertEquals(node.get("modifiedOn").textValue(), MODIFIED_ON.toString());
+        assertEquals(node.get("version").longValue(), 3L);
+        assertEquals(node.get("type").textValue(), "Substudy");
         assertNull(node.get("studyId"));
         
         Substudy deser = BridgeObjectMapper.get().readValue(node.toString(), Substudy.class);
-        assertEquals("oneId", deser.getId());
-        assertEquals("name", deser.getName());
+        assertEquals(deser.getId(), "oneId");
+        assertEquals(deser.getName(), "name");
         assertTrue(deser.isDeleted());
-        assertEquals(CREATED_ON, deser.getCreatedOn());
-        assertEquals(MODIFIED_ON, deser.getModifiedOn());
-        assertEquals(new Long(3), deser.getVersion());
+        assertEquals(deser.getCreatedOn(), CREATED_ON);
+        assertEquals(deser.getModifiedOn(), MODIFIED_ON);
+        assertEquals(deser.getVersion(), new Long(3));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/JsonNodeAttributeConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/JsonNodeAttributeConverterTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,7 +20,7 @@ public class JsonNodeAttributeConverterTest {
     
     private static JsonNodeAttributeConverter converter;
     
-    @Before
+    @BeforeMethod
     public void before() throws IOException {
         converter = new JsonNodeAttributeConverter();
         node = new ObjectMapper().readTree(JSON);
@@ -27,12 +28,12 @@ public class JsonNodeAttributeConverterTest {
     
     @Test
     public void convertToDatabaseColumn() {
-        assertEquals(JSON, converter.convertToDatabaseColumn(node));
+        assertEquals(converter.convertToDatabaseColumn(node), JSON);
     }
 
     @Test
     public void convertToEntityAttribute() {
-        assertEquals(node, converter.convertToEntityAttribute(JSON));
+        assertEquals(converter.convertToEntityAttribute(JSON), node);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
+
+import org.testng.annotations.Test;
 
 public class QueryBuilderTest {
 
@@ -15,10 +15,10 @@ public class QueryBuilderTest {
         builder.append("phrase two=:two", "two", "valueForTwo");
         builder.append("phrase three=:three four=:four", "three", "valueForThree", "four", "valueForFour");
 
-        assertEquals("phrase phrase two=:two phrase three=:three four=:four", builder.getQuery());
-        assertEquals("valueForTwo", builder.getParameters().get("two"));
-        assertEquals("valueForThree", builder.getParameters().get("three"));
-        assertEquals("valueForFour", builder.getParameters().get("four"));
+        assertEquals(builder.getQuery(), "phrase phrase two=:two phrase three=:three four=:four");
+        assertEquals(builder.getParameters().get("two"), "valueForTwo");
+        assertEquals(builder.getParameters().get("three"), "valueForThree");
+        assertEquals(builder.getParameters().get("four"), "valueForFour");
     }
     
     @Test
@@ -27,12 +27,12 @@ public class QueryBuilderTest {
         builder.dataGroups(ImmutableSet.of("A", "B"), "IN");
         builder.dataGroups(ImmutableSet.of("C", "D"), "NOT IN");
         
-        assertEquals("AND (:IN1 IN elements(acct.dataGroups) AND :IN2 IN elements(acct.dataGroups)) AND " +
-                "(:NOTIN1 NOT IN elements(acct.dataGroups) AND :NOTIN2 NOT IN elements(acct.dataGroups))",
-                builder.getQuery());
-        assertEquals("A", builder.getParameters().get("IN1"));
-        assertEquals("B", builder.getParameters().get("IN2"));
-        assertEquals("C", builder.getParameters().get("NOTIN1"));
-        assertEquals("D", builder.getParameters().get("NOTIN2"));
+        assertEquals(builder.getQuery(), "AND (:IN1 IN elements(acct.dataGroups) AND :IN2 IN " + 
+                "elements(acct.dataGroups)) AND (:NOTIN1 NOT IN elements(acct.dataGroups) AND "+
+                ":NOTIN2 NOT IN elements(acct.dataGroups))");
+        assertEquals(builder.getParameters().get("IN1"), "A");
+        assertEquals(builder.getParameters().get("IN2"), "B");
+        assertEquals(builder.getParameters().get("NOTIN1"), "C");
+        assertEquals(builder.getParameters().get("NOTIN2"), "D");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
@@ -33,7 +33,7 @@ public class SubstudyPersistenceExceptionConverterTest {
     public void noConversion() { 
         PersistenceException ex = new PersistenceException(new RuntimeException("message"));
         
-        assertSame(ex, converter.convert(ex, null));
+        assertSame(converter.convert(ex, null), ex);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/SubstudyPersistenceExceptionConverterTest.java
@@ -1,22 +1,21 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 
 import org.hibernate.exception.ConstraintViolationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SubstudyPersistenceExceptionConverterTest {
     
     private SubstudyPersistenceExceptionConverter converter;
@@ -24,8 +23,9 @@ public class SubstudyPersistenceExceptionConverterTest {
     @Mock
     private ConstraintViolationException cve;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         this.converter = new SubstudyPersistenceExceptionConverter();
     }
     
@@ -44,8 +44,8 @@ public class SubstudyPersistenceExceptionConverterTest {
         OptimisticLockException ole = new OptimisticLockException();
         
         RuntimeException result = converter.convert(ole, substudy);
-        assertEquals(ConcurrentModificationException.class, result.getClass());
-        assertEquals("Substudy has the wrong version number; it may have been saved in the background.", result.getMessage());
+        assertEquals(result.getClass(), ConcurrentModificationException.class);
+        assertEquals(result.getMessage(), "Substudy has the wrong version number; it may have been saved in the background.");
     }
     
     @Test
@@ -58,8 +58,8 @@ public class SubstudyPersistenceExceptionConverterTest {
 
         RuntimeException result = converter.convert(ex, substudy);
 
-        assertEquals(org.sagebionetworks.bridge.exceptions.ConstraintViolationException.class, result.getClass());
-        assertEquals("Substudy table constraint prevented save or update.", result.getMessage());
+        assertEquals(result.getClass(), org.sagebionetworks.bridge.exceptions.ConstraintViolationException.class);
+        assertEquals(result.getMessage(), "Substudy table constraint prevented save or update.");
     }
     
     @Test
@@ -72,7 +72,7 @@ public class SubstudyPersistenceExceptionConverterTest {
 
         RuntimeException result = converter.convert(ex, substudy);
 
-        assertEquals(org.sagebionetworks.bridge.exceptions.ConstraintViolationException.class, result.getClass());
-        assertEquals("Substudy cannot be deleted, it is referenced by an account", result.getMessage());
+        assertEquals(result.getClass(), org.sagebionetworks.bridge.exceptions.ConstraintViolationException.class);
+        assertEquals(result.getMessage(), "Substudy cannot be deleted, it is referenced by an account");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/BridgeObjectMapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/BridgeObjectMapperTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -27,10 +28,10 @@ public class BridgeObjectMapperTest {
         BridgeObjectMapper mapper = new BridgeObjectMapper();
         
         JsonNode node = mapper.valueToTree(new NotAnnotated());
-        assertEquals("Type is NotAnnotated", "NotAnnotated", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "NotAnnotated", "Type is NotAnnotated");
         
         node = mapper.valueToTree(new Annotated());
-        assertEquals("Type is AnnotationName", "AnnotationName", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "AnnotationName", "Type is AnnotationName");
     }
     
     // TODO: The serializer doubles up the type property on objects that have a filter. I 
@@ -72,7 +73,7 @@ public class BridgeObjectMapperTest {
         BridgeObjectMapper mapper = new BridgeObjectMapper();
         
         JsonNode node = mapper.valueToTree(new NotAnnotated("ThisIsTheName"));
-        assertEquals("Type is ThisIsTheName", "ThisIsTheName", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "ThisIsTheName", "Type is ThisIsTheName");
     }
         
     /**
@@ -88,14 +89,14 @@ public class BridgeObjectMapperTest {
         String json = "{\"createdOn\":null,\"modifiedOn\":null}";
         
         Survey survey = new BridgeObjectMapper().readValue(json, Survey.class);
-        assertEquals(0, survey.getCreatedOn());
-        assertEquals(0, survey.getModifiedOn());
+        assertEquals(survey.getCreatedOn(), 0);
+        assertEquals(survey.getModifiedOn(), 0);
         
         // No field works as well
         json = "{}";
         survey = new BridgeObjectMapper().readValue(json, Survey.class);
-        assertEquals(0, survey.getCreatedOn());
-        assertEquals(0, survey.getModifiedOn());
+        assertEquals(survey.getCreatedOn(), 0);
+        assertEquals(survey.getModifiedOn(), 0);
         
         // If you were to supply zeroes, you do get a deserialization error, as you would any other 
         // value not recognizable as a date.

--- a/src/test/java/org/sagebionetworks/bridge/json/EnumSerializationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/EnumSerializationTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -23,7 +24,7 @@ public class EnumSerializationTest {
     
     private ObjectMapper mapper;
     
-    @Before
+    @BeforeMethod
     public void before() {
         mapper = BridgeObjectMapper.get();
     }
@@ -35,10 +36,10 @@ public class EnumSerializationTest {
         holder.setType(ScheduleType.ONCE);
         
         String json = mapper.writeValueAsString(holder);
-        assertEquals("{\"type\":\"once\"}", json);
+        assertEquals(json, "{\"type\":\"once\"}");
         
         holder = mapper.readValue(json, EnumSerializationTest.EnumHolder.class);
-        assertEquals(ScheduleType.ONCE, holder.getType());
+        assertEquals(holder.getType(), ScheduleType.ONCE);
     }
     
     @Test
@@ -46,7 +47,7 @@ public class EnumSerializationTest {
         EnumHolder holder = new EnumHolder();
         
         String json = mapper.writeValueAsString(holder);
-        assertEquals("{}", json);
+        assertEquals(json, "{}");
         
         holder = mapper.readValue(json, EnumSerializationTest.EnumHolder.class);
         assertNull(holder.getType());
@@ -57,7 +58,7 @@ public class EnumSerializationTest {
         String json = "{\"type\":\"ONCE\"}";
         
         EnumHolder holder = mapper.readValue(json, EnumSerializationTest.EnumHolder.class);
-        assertEquals(ScheduleType.ONCE, holder.getType());
+        assertEquals(holder.getType(), ScheduleType.ONCE);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/JodaDateTimeDeserializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/JodaDateTimeDeserializerTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -22,7 +23,7 @@ public class JodaDateTimeDeserializerTest {
 
         // execute and validate
         DateTime result = new JodaDateTimeDeserializer().deserialize(mockJP, null);
-        assertEquals(expectedMillis, result.getMillis());
-        assertEquals("2014-02-12T16:07:00.000-08:00", result.toString());
+        assertEquals(result.getMillis(), expectedMillis);
+        assertEquals(result.toString(), "2014-02-12T16:07:00.000-08:00");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/JsonUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/JsonUtilsTest.java
@@ -1,13 +1,18 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
@@ -55,7 +60,7 @@ public class JsonUtilsTest {
         // Success case
         DateTime dateTime = JsonUtils.asDateTime(node, "success-with-time-zone");
         assertNotNull(dateTime);
-        assertEquals(expectedDateTimeStr, dateTime.toString());
+        assertEquals(dateTime.toString(), expectedDateTimeStr);
     }
 
     @Test
@@ -64,7 +69,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asText(node, null));
         assertNull(JsonUtils.asText(node, "badProp"));
-        assertEquals("value", JsonUtils.asText(node, "key"));
+        assertEquals(JsonUtils.asText(node, "key"), "value");
     }
 
     @Test
@@ -73,16 +78,16 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asLong(node, null));
         assertNull(JsonUtils.asLong(node, "badProp"));
-        assertEquals(new Long(3), JsonUtils.asLong(node, "key"));
+        assertEquals(JsonUtils.asLong(node, "key"), new Long(3));
     }
 
     @Test
     public void asLongPrimitive() throws Exception {
         JsonNode node = mapper.readTree(esc("{'key':3}"));
         
-        assertEquals(0L, JsonUtils.asLongPrimitive(node, null));
-        assertEquals(0L, JsonUtils.asLongPrimitive(node, "badProp"));
-        assertEquals(3L, JsonUtils.asLongPrimitive(node, "key"));
+        assertEquals(JsonUtils.asLongPrimitive(node, null), 0L);
+        assertEquals(JsonUtils.asLongPrimitive(node, "badProp"), 0L);
+        assertEquals(JsonUtils.asLongPrimitive(node, "key"), 3L);
     }
 
     @Test
@@ -91,25 +96,25 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asInt(node, null));
         assertNull(JsonUtils.asInt(node, "badProp"));
-        assertEquals(new Integer(3), JsonUtils.asInt(node, "key"));
+        assertEquals(JsonUtils.asInt(node, "key"), new Integer(3));
     }
 
     @Test
     public void asIntPrimitive() throws Exception {
         JsonNode node = mapper.readTree(esc("{'key':3}"));
         
-        assertEquals(0, JsonUtils.asIntPrimitive(node, null));
-        assertEquals(0, JsonUtils.asIntPrimitive(node, "badProp"));
-        assertEquals(3, JsonUtils.asIntPrimitive(node, "key"));
+        assertEquals(JsonUtils.asIntPrimitive(node, null), 0);
+        assertEquals(JsonUtils.asIntPrimitive(node, "badProp"), 0);
+        assertEquals(JsonUtils.asIntPrimitive(node, "key"), 3);
     }
 
     @Test
     public void asMillisDuration() throws Exception {
         JsonNode node = mapper.readTree(esc("{'key':'PT1H'}"));
         
-        assertEquals(0L, JsonUtils.asMillisDuration(node, null));
-        assertEquals(0L, JsonUtils.asMillisDuration(node, "badProp"));
-        assertEquals(1*60*60*1000, JsonUtils.asMillisDuration(node, "key"));
+        assertEquals(JsonUtils.asMillisDuration(node, null), 0L);
+        assertEquals(JsonUtils.asMillisDuration(node, "badProp"), 0L);
+        assertEquals(JsonUtils.asMillisDuration(node, "key"), 1*60*60*1000);
     }
 
     @Test
@@ -118,9 +123,9 @@ public class JsonUtilsTest {
         
         JsonNode node = mapper.readTree(esc("{'key':'2015-03-23T10:00:00.000-07:00'}"));
         
-        assertEquals(0L, JsonUtils.asMillisSinceEpoch(node, null));
-        assertEquals(0L, JsonUtils.asMillisSinceEpoch(node, "badProp"));
-        assertEquals(time.getMillis(), JsonUtils.asMillisSinceEpoch(node, "key"));
+        assertEquals(JsonUtils.asMillisSinceEpoch(node, null), 0L);
+        assertEquals(JsonUtils.asMillisSinceEpoch(node, "badProp"), 0L);
+        assertEquals(JsonUtils.asMillisSinceEpoch(node, "key"), time.getMillis());
     }
 
     @Test
@@ -131,7 +136,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asJsonNode(node, null));
         assertNull(JsonUtils.asJsonNode(node, "badProp"));
-        assertEquals(node2, JsonUtils.asJsonNode(node, "key"));
+        assertEquals(JsonUtils.asJsonNode(node, "key"), node2);
     }
 
     @Test
@@ -145,9 +150,9 @@ public class JsonUtilsTest {
         assertNull(JsonUtils.asConstraints(node, "badProp"));
         
         IntegerConstraints copy = (IntegerConstraints)JsonUtils.asConstraints(node, "key");
-        assertEquals(c.getType(), copy.getType());
-        assertEquals(c.getMinValue(), copy.getMinValue());
-        assertEquals(c.getMaxValue(), copy.getMaxValue());
+        assertEquals(copy.getType(), c.getType());
+        assertEquals(copy.getMinValue(), c.getMinValue());
+        assertEquals(copy.getMaxValue(), c.getMaxValue());
     }
 
     @Test
@@ -157,7 +162,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asObjectNode(node, null));
         assertNull(JsonUtils.asObjectNode(node, "badProp"));
-        assertEquals(subNode, JsonUtils.asObjectNode(node, "key"));
+        assertEquals(JsonUtils.asObjectNode(node, "key"), subNode);
     }
 
     @Test
@@ -175,7 +180,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asEntity(node, null, UIHint.class));
         assertNull(JsonUtils.asEntity(node, "badProp", UIHint.class));
-        assertEquals(UIHint.LIST, JsonUtils.asEntity(node, "key", UIHint.class));
+        assertEquals(JsonUtils.asEntity(node, "key", UIHint.class), UIHint.LIST);
     }
     
     @Test
@@ -184,7 +189,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asEntity(node, null, ActivityType.class));
         assertNull(JsonUtils.asEntity(node, "badProp", ActivityType.class));
-        assertEquals(ActivityType.SURVEY, JsonUtils.asEntity(node, "key", ActivityType.class));
+        assertEquals(JsonUtils.asEntity(node, "key", ActivityType.class), ActivityType.SURVEY);
     }
 
     @Test
@@ -193,7 +198,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asEntity(node, null, ScheduleType.class));
         assertNull(JsonUtils.asEntity(node, "badProp", ScheduleType.class));
-        assertEquals(ScheduleType.ONCE, JsonUtils.asEntity(node, "key", ScheduleType.class));
+        assertEquals(JsonUtils.asEntity(node, "key", ScheduleType.class), ScheduleType.ONCE);
     }
     
     @Test
@@ -203,7 +208,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asEntity(node, null, Image.class));
         assertNull(JsonUtils.asEntity(node, "badProp", Image.class));
-        assertEquals(image, JsonUtils.asEntity(node, "key", Image.class));
+        assertEquals(JsonUtils.asEntity(node, "key", Image.class), image);
     }
     
     @Test
@@ -213,7 +218,7 @@ public class JsonUtilsTest {
         
         assertNull(JsonUtils.asArrayNode(node, null));
         assertNull(JsonUtils.asArrayNode(node, "badProp"));
-        assertEquals(subNode, JsonUtils.asArrayNode(node, "key"));
+        assertEquals(JsonUtils.asArrayNode(node, "key"), subNode);
     }
 
     @Test
@@ -222,9 +227,9 @@ public class JsonUtilsTest {
         
         JsonNode node = mapper.readTree(esc("{'key':['A','B','C']}"));
         
-        assertEquals(Sets.newHashSet(), JsonUtils.asStringSet(node, null));
-        assertEquals(Sets.newHashSet(), JsonUtils.asStringSet(node, "badProp"));
-        assertEquals(set, JsonUtils.asStringSet(node, "key"));
+        assertEquals(JsonUtils.asStringSet(node, null), Sets.newHashSet());
+        assertEquals(JsonUtils.asStringSet(node, "badProp"), Sets.newHashSet());
+        assertEquals(JsonUtils.asStringSet(node, "key"), set);
     }
 
     @Test
@@ -233,9 +238,9 @@ public class JsonUtilsTest {
         
         JsonNode node = mapper.readTree(esc("{'key':['admin','researcher']}"));
 
-        assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, null));
-        assertEquals(Sets.newHashSet(), JsonUtils.asRolesSet(node, "badProp"));
-        assertEquals(set, JsonUtils.asRolesSet(node, "key"));
+        assertEquals(JsonUtils.asRolesSet(node, null), Sets.newHashSet());
+        assertEquals(JsonUtils.asRolesSet(node, "badProp"), Sets.newHashSet());
+        assertEquals(JsonUtils.asRolesSet(node, "key"), set);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/LocalDateToStringSerializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/LocalDateToStringSerializerTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.joda.time.LocalDate;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 public class LocalDateToStringSerializerTest {
     @Test
@@ -19,6 +19,6 @@ public class LocalDateToStringSerializerTest {
         new LocalDateToStringSerializer().serialize(new LocalDate(2014, 2, 12), mockJGen, null);
         ArgumentCaptor<String> arg = ArgumentCaptor.forClass(String.class);
         verify(mockJGen).writeString(arg.capture());
-        assertEquals("2014-02-12", arg.getValue());
+        assertEquals(arg.getValue(), "2014-02-12");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
@@ -7,7 +7,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/MimeTypeSerializerTest.java
@@ -1,20 +1,20 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.studies.MimeType;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 
-@RunWith(MockitoJUnitRunner.class)
 public class MimeTypeSerializerTest {
     
     @Mock
@@ -23,10 +23,15 @@ public class MimeTypeSerializerTest {
     @Captor
     ArgumentCaptor<String> stringCaptor;
     
+    @BeforeMethod
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
     @Test
     public void test() throws Exception {
         new MimeTypeSerializer().serialize(MimeType.TEXT, mockJGen, null);
         verify(mockJGen).writeString(stringCaptor.capture());
-        assertEquals("text/plain", stringCaptor.getValue());
+        assertEquals(stringCaptor.getValue(), "text/plain");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/json/SubpopulationGuidDeserializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/json/SubpopulationGuidDeserializerTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
@@ -38,7 +38,7 @@ public class SubpopulationGuidDeserializerTest {
 
         JsonNode consentNode = node.get("foo5");
         ConsentStatus consent5 = mapper.readValue(consentNode.toString(), ConsentStatus.class);
-        assertEquals(TestConstants.REQUIRED_UNSIGNED, consent5);
+        assertEquals(consent5, TestConstants.REQUIRED_UNSIGNED);
         
         // Test deserialization in a class that has the annotation to restore the SubpopulationGuid key
         MapTest mapTest = new MapTest();
@@ -46,7 +46,7 @@ public class SubpopulationGuidDeserializerTest {
         
         MapTest deserializedMapTest = mapper.readValue(mapper.writeValueAsString(mapTest), MapTest.class);
         
-        assertEquals(map, deserializedMapTest.getConsentStatuses());
+        assertEquals(deserializedMapTest.getConsentStatuses(), map);
     }
     
     private static class MapTest {

--- a/src/test/java/org/sagebionetworks/bridge/models/AccountSummarySearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AccountSummarySearchTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +51,7 @@ public class AccountSummarySearchTest {
         String json = mapper.writeValueAsString(search1);
         AccountSummarySearch search2 = mapper.readValue(json, AccountSummarySearch.class);
         
-        assertEquals(search1, search2);
+        assertEquals(search2, search1);
     }
     
     @Test
@@ -75,24 +76,24 @@ public class AccountSummarySearchTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         // The one JSON property with no analogue in the object itself, verify it's correct
-        assertEquals("AccountSummarySearch", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "AccountSummarySearch");
         
         AccountSummarySearch deser = BridgeObjectMapper.get().readValue(json, AccountSummarySearch.class);
         
-        assertEquals(10, deser.getOffsetBy());
-        assertEquals(100, deser.getPageSize());
-        assertEquals("email", deser.getEmailFilter());
-        assertEquals("phone", deser.getPhoneFilter());
-        assertEquals(Sets.newHashSet("group1"), deser.getAllOfGroups());
-        assertEquals(Sets.newHashSet("group2"), deser.getNoneOfGroups());
-        assertEquals("en", deser.getLanguage());
-        assertEquals(startTime, deser.getStartTime());
-        assertEquals(endTime, deser.getEndTime());
+        assertEquals(deser.getOffsetBy(), 10);
+        assertEquals(deser.getPageSize(), 100);
+        assertEquals(deser.getEmailFilter(), "email");
+        assertEquals(deser.getPhoneFilter(), "phone");
+        assertEquals(deser.getAllOfGroups(), Sets.newHashSet("group1"));
+        assertEquals(deser.getNoneOfGroups(), Sets.newHashSet("group2"));
+        assertEquals(deser.getLanguage(), "en");
+        assertEquals(deser.getStartTime(), startTime);
+        assertEquals(deser.getEndTime(), endTime);
     }
     
     @Test
     public void setsDefaults() {
-        assertEquals(0, AccountSummarySearch.EMPTY_SEARCH.getOffsetBy());
-        assertEquals(BridgeConstants.API_DEFAULT_PAGE_SIZE, AccountSummarySearch.EMPTY_SEARCH.getPageSize());
+        assertEquals(AccountSummarySearch.EMPTY_SEARCH.getOffsetBy(), 0);
+        assertEquals(AccountSummarySearch.EMPTY_SEARCH.getPageSize(), BridgeConstants.API_DEFAULT_PAGE_SIZE);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/AndroidAppSiteAssociationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AndroidAppSiteAssociationTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.models.studies.AndroidAppLink;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,11 +19,11 @@ public class AndroidAppSiteAssociationTest {
         AndroidAppSiteAssociation assoc = new AndroidAppSiteAssociation(link);
         
         JsonNode node = new ObjectMapper().valueToTree(assoc);
-        assertEquals(AndroidAppSiteAssociation.RELATION, node.get("relation").get(0).textValue());
+        assertEquals(node.get("relation").get(0).textValue(), AndroidAppSiteAssociation.RELATION);
         JsonNode target = node.get("target");
-        assertEquals("namespace", target.get("namespace").textValue());
-        assertEquals("package", target.get("package_name").textValue());
-        assertEquals("fingerprint", target.get("sha256_cert_fingerprints").get(0).textValue());
+        assertEquals(target.get("namespace").textValue(), "namespace");
+        assertEquals(target.get("package_name").textValue(), "package");
+        assertEquals(target.get("sha256_cert_fingerprints").get(0).textValue(), "fingerprint");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/AppleAppSiteAssociationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AppleAppSiteAssociationTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.models.studies.AppleAppLink;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,19 +24,19 @@ public class AppleAppSiteAssociationTest {
         
         JsonNode applinks = node.get("applinks"); // It's all under this property for some reason.
         
-        assertEquals(0, ((ArrayNode)applinks.get("apps")).size());
+        assertEquals(((ArrayNode)applinks.get("apps")).size(), 0);
         
         JsonNode details = applinks.get("details");
         
         JsonNode node1 = details.get(0);
-        assertEquals("appId1", node1.get("appID").textValue());
-        assertEquals("/appId1/", node1.get("paths").get(0).textValue());
-        assertEquals("/appId1/*", node1.get("paths").get(1).textValue());
+        assertEquals(node1.get("appID").textValue(), "appId1");
+        assertEquals(node1.get("paths").get(0).textValue(), "/appId1/");
+        assertEquals(node1.get("paths").get(1).textValue(), "/appId1/*");
         
         JsonNode node2 = details.get(1);
-        assertEquals("appId2", node2.get("appID").textValue());
-        assertEquals("/appId2/", node2.get("paths").get(0).textValue());
-        assertEquals("/appId2/*", node2.get("paths").get(1).textValue());
+        assertEquals(node2.get("appID").textValue(), "appId2");
+        assertEquals(node2.get("paths").get(0).textValue(), "/appId2/");
+        assertEquals(node2.get("paths").get(1).textValue(), "/appId2/*");
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -146,13 +146,13 @@ public class ClientInfoTest {
     private void assertClientInfo(String userAgentString, String appName, Integer appVersion, String deviceName,
             String osName, String osVersion, String sdkName, Integer sdkVersion) {
         ClientInfo info = ClientInfo.parseUserAgentString(userAgentString);
-        assertEquals(appName, info.getAppName());
-        assertEquals(appVersion, info.getAppVersion());
-        assertEquals(deviceName, info.getDeviceName());
-        assertEquals(osName, info.getOsName());
-        assertEquals(osVersion, info.getOsVersion());
-        assertEquals(sdkName, info.getSdkName());
-        assertEquals(sdkVersion, info.getSdkVersion());
+        assertEquals(info.getAppName(), appName);
+        assertEquals(info.getAppVersion(), appVersion);
+        assertEquals(info.getDeviceName(), deviceName);
+        assertEquals(info.getOsName(), osName);
+        assertEquals(info.getOsVersion(), osVersion);
+        assertEquals(info.getSdkName(), sdkName);
+        assertEquals(info.getSdkVersion(), sdkVersion);
     }
 
     @Test
@@ -160,13 +160,13 @@ public class ClientInfoTest {
         ClientInfo info1 = ClientInfo.fromUserAgentCache(UA);
         ClientInfo info2 = ClientInfo.fromUserAgentCache(UA);
         
-        assertSame(info1, info2);
+        assertSame(info2, info1);
     }
     
     @Test
     public void cacheWorksWithBadValues() {
-        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache(null));
-        assertSame(ClientInfo.UNKNOWN_CLIENT, ClientInfo.fromUserAgentCache("   \n"));
+        assertSame(ClientInfo.fromUserAgentCache(null), ClientInfo.UNKNOWN_CLIENT);
+        assertSame(ClientInfo.fromUserAgentCache("   \n"), ClientInfo.UNKNOWN_CLIENT);
     }
     
     @Test
@@ -195,7 +195,7 @@ public class ClientInfoTest {
     @Test
     public void returnsUknownClient() {
         ClientInfo info = ClientInfo.parseUserAgentString("/7.1.1.");
-        assertSame(ClientInfo.UNKNOWN_CLIENT, info);
+        assertSame(info, ClientInfo.UNKNOWN_CLIENT);
     }
     
     @Test
@@ -208,11 +208,11 @@ public class ClientInfoTest {
                 .withOsVersion("Version1")
                 .withSdkName("BridgeSDK")
                 .withSdkVersion(4).build();
-        assertEquals("AppName", info.getAppName());
-        assertEquals(1, info.getAppVersion().intValue());
-        assertEquals(IOS, info.getOsName());
-        assertEquals("Version1", info.getOsVersion());
-        assertEquals(4, info.getSdkVersion().intValue());
+        assertEquals(info.getAppName(), "AppName");
+        assertEquals(info.getAppVersion().intValue(), 1);
+        assertEquals(info.getOsName(), IOS);
+        assertEquals(info.getOsVersion(), "Version1");
+        assertEquals(info.getSdkVersion().intValue(), 4);
     }
     
  }

--- a/src/test/java/org/sagebionetworks/bridge/models/CriteriaContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/CriteriaContextTest.java
@@ -1,15 +1,13 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 
+import static org.testng.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -28,13 +26,13 @@ public class CriteriaContextTest {
         CriteriaContext context = new CriteriaContext.Builder()
                 .withUserId(USER_ID)
                 .withStudyIdentifier(TestConstants.TEST_STUDY).build();
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, context.getClientInfo());
-        assertEquals(ImmutableList.of(), context.getLanguages());
-        assertEquals(ImmutableSet.of(), context.getUserDataGroups());
-        assertEquals(ImmutableSet.of(), context.getUserSubstudyIds());
+        assertEquals(context.getClientInfo(), ClientInfo.UNKNOWN_CLIENT);
+        assertEquals(context.getLanguages(), ImmutableList.of());
+        assertEquals(context.getUserDataGroups(), ImmutableList.of());
+        assertEquals(context.getUserSubstudyIds(), ImmutableList.of());
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void requiresStudyIdentifier() {
         new CriteriaContext.Builder().withUserId(USER_ID).build();
     }
@@ -49,16 +47,16 @@ public class CriteriaContextTest {
                 .withUserSubstudyIds(TestConstants.USER_SUBSTUDY_IDS).build();
         
         // There are defaults
-        assertEquals(CLIENT_INFO, context.getClientInfo());
-        assertEquals(TestConstants.USER_DATA_GROUPS, context.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, context.getUserSubstudyIds());
+        assertEquals(context.getClientInfo(), CLIENT_INFO);
+        assertEquals(context.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(context.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
         
         CriteriaContext copy = new CriteriaContext.Builder().withContext(context).build();
-        assertEquals(CLIENT_INFO, copy.getClientInfo());
-        assertEquals(TestConstants.TEST_STUDY, copy.getStudyIdentifier());
-        assertEquals(USER_ID, copy.getUserId());
-        assertEquals(TestConstants.USER_DATA_GROUPS, copy.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, copy.getUserSubstudyIds());
+        assertEquals(copy.getClientInfo(), CLIENT_INFO);
+        assertEquals(copy.getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(copy.getUserId(), USER_ID);
+        assertEquals(copy.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(copy.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
     }
     
     @Test
@@ -68,7 +66,7 @@ public class CriteriaContextTest {
                 .withUserId(USER_ID).build();
         
         AccountId accountId = context.getAccountId();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
-        assertEquals(USER_ID, accountId.getId());
+        assertEquals(accountId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountId.getId(), USER_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/CriteriaUtilsTest.java
@@ -1,18 +1,18 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.validation.Errors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.validators.Validate;
@@ -33,7 +33,7 @@ public class CriteriaUtilsTest {
     
     private Criteria criteria;
     
-    @Before
+    @BeforeMethod
     public void before() {
         criteria = Criteria.create();
         criteria.setKey(KEY);
@@ -178,7 +178,8 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, EMPTY_SET, errors);
-        assertEquals("cannot be less than minAppVersions.iphone_os", errors.getFieldErrors("maxAppVersions.iphone_os").get(0).getCode());
+        assertEquals(errors.getFieldErrors("maxAppVersions.iphone_os").get(0).getCode(),
+                "cannot be less than minAppVersions.iphone_os");
     }
     
     @Test
@@ -187,7 +188,7 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, EMPTY_SET, errors);
-        assertEquals("cannot be negative", errors.getFieldErrors("minAppVersions.iphone_os").get(0).getCode());
+        assertEquals(errors.getFieldErrors("minAppVersions.iphone_os").get(0).getCode(), "cannot be negative");
     }
     
     // Try these again with a different os name. If two different values work, any value should work.
@@ -207,7 +208,8 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, EMPTY_SET, errors);
-        assertEquals("cannot be less than minAppVersions.android", errors.getFieldErrors("maxAppVersions.android").get(0).getCode());
+        assertEquals(errors.getFieldErrors("maxAppVersions.android").get(0).getCode(),
+                "cannot be less than minAppVersions.android");
     }
     
     @Test
@@ -216,7 +218,7 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, EMPTY_SET, errors);
-        assertEquals("cannot be negative", errors.getFieldErrors("minAppVersions.android").get(0).getCode());
+        assertEquals(errors.getFieldErrors("minAppVersions.android").get(0).getCode(), "cannot be negative");
     }
     
     @Test
@@ -253,10 +255,10 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, EMPTY_SET, errors);
-        assertEquals("cannot be null", errors.getFieldErrors("allOfGroups").get(0).getCode());
-        assertEquals("cannot be null", errors.getFieldErrors("noneOfGroups").get(0).getCode());
-        assertEquals("cannot be null", errors.getFieldErrors("allOfSubstudyIds").get(0).getCode());
-        assertEquals("cannot be null", errors.getFieldErrors("noneOfSubstudyIds").get(0).getCode());
+        assertEquals(errors.getFieldErrors("allOfGroups").get(0).getCode(), "cannot be null");
+        assertEquals(errors.getFieldErrors("noneOfGroups").get(0).getCode(), "cannot be null");
+        assertEquals(errors.getFieldErrors("allOfSubstudyIds").get(0).getCode(), "cannot be null");
+        assertEquals(errors.getFieldErrors("noneOfSubstudyIds").get(0).getCode(), "cannot be null");
     }
     
     @Test
@@ -264,8 +266,8 @@ public class CriteriaUtilsTest {
         Criteria criteria = getCriteria(ImmutableSet.of("group1"), ImmutableSet.of("group2"), null, null, null);
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, ImmutableSet.of("group3"), EMPTY_SET, errors);
-        assertEquals("'group1' is not in enumeration: group3", errors.getFieldErrors("allOfGroups").get(0).getCode());
-        assertEquals("'group2' is not in enumeration: group3", errors.getFieldErrors("noneOfGroups").get(0).getCode());
+        assertEquals(errors.getFieldErrors("allOfGroups").get(0).getCode(), "'group1' is not in enumeration: group3");
+        assertEquals(errors.getFieldErrors("noneOfGroups").get(0).getCode(), "'group2' is not in enumeration: group3");
     }
     
     @Test
@@ -287,8 +289,8 @@ public class CriteriaUtilsTest {
         
         Errors errors = Validate.getErrorsFor(criteria);
         CriteriaUtils.validate(criteria, EMPTY_SET, ImmutableSet.of("substudyC"), errors);
-        assertEquals("'substudyA' is not in enumeration: substudyC", errors.getFieldErrors("allOfSubstudyIds").get(0).getCode());
-        assertEquals("'substudyB' is not in enumeration: substudyC", errors.getFieldErrors("noneOfSubstudyIds").get(0).getCode());
+        assertEquals(errors.getFieldErrors("allOfSubstudyIds").get(0).getCode(), "'substudyA' is not in enumeration: substudyC");
+        assertEquals(errors.getFieldErrors("noneOfSubstudyIds").get(0).getCode(), "'substudyB' is not in enumeration: substudyC");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/DateRangeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/DateRangeResourceListTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.ResourceList.START_DATE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.ResourceList.END_DATE;
 
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -26,29 +26,29 @@ public class DateRangeResourceListTest {
                 .withRequestParam(END_DATE, LocalDate.parse("2016-02-23"));
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals("2016-02-03", node.get("startDate").asText());
-        assertEquals("2016-02-23", node.get("endDate").asText());
-        assertEquals("2016-02-03", node.get("requestParams").get("startDate").asText());
-        assertEquals("2016-02-23", node.get("requestParams").get("endDate").asText());
-        assertEquals(ResourceList.REQUEST_PARAMS, node.get("requestParams").get(ResourceList.TYPE).asText());
-        assertEquals("DateRangeResourceList", node.get("type").asText());
-        assertEquals(3, node.get("items").size());
-        assertEquals("1", node.get("items").get(0).asText());
-        assertEquals("2", node.get("items").get(1).asText());
-        assertEquals("3", node.get("items").get(2).asText());
-        assertEquals(6, node.size());
+        assertEquals(node.get("startDate").asText(), "2016-02-03");
+        assertEquals(node.get("endDate").asText(), "2016-02-23");
+        assertEquals(node.get("requestParams").get("startDate").asText(), "2016-02-03");
+        assertEquals(node.get("requestParams").get("endDate").asText(), "2016-02-23");
+        assertEquals(node.get("requestParams").get(ResourceList.TYPE).asText(), ResourceList.REQUEST_PARAMS);
+        assertEquals(node.get("type").asText(), "DateRangeResourceList");
+        assertEquals(node.get("items").size(), 3);
+        assertEquals(node.get("items").get(0).asText(), "1");
+        assertEquals(node.get("items").get(1).asText(), "2");
+        assertEquals(node.get("items").get(2).asText(), "3");
+        assertEquals(node.size(), 6);
         
         list = BridgeObjectMapper.get().readValue(node.toString(), 
                 new TypeReference<DateRangeResourceList<String>>() {});
-        assertEquals(LocalDate.parse("2016-02-03"), list.getStartDate());
-        assertEquals(LocalDate.parse("2016-02-23"), list.getEndDate());
-        assertEquals(3, list.getItems().size());
-        assertEquals("1", list.getItems().get(0));
-        assertEquals("2", list.getItems().get(1));
-        assertEquals("3", list.getItems().get(2));
-        assertEquals("2016-02-03", list.getRequestParams().get("startDate"));
-        assertEquals("2016-02-23", list.getRequestParams().get("endDate"));
-        assertEquals(ResourceList.REQUEST_PARAMS, list.getRequestParams().get(ResourceList.TYPE));
+        assertEquals(list.getStartDate(), LocalDate.parse("2016-02-03"));
+        assertEquals(list.getEndDate(), LocalDate.parse("2016-02-23"));
+        assertEquals(list.getItems().size(), 3);
+        assertEquals(list.getItems().get(0), "1");
+        assertEquals(list.getItems().get(1), "2");
+        assertEquals(list.getItems().get(2), "3");
+        assertEquals(list.getRequestParams().get("startDate"), "2016-02-03");
+        assertEquals(list.getRequestParams().get("endDate"), "2016-02-23");
+        assertEquals(list.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
     
     @SuppressWarnings("deprecation")
@@ -57,14 +57,14 @@ public class DateRangeResourceListTest {
         DateRangeResourceList<String> list = new DateRangeResourceList<>(
                 Lists.newArrayList("1", "2", "3"));
         
-        assertEquals((Integer)3, list.getTotal());
+        assertEquals(list.getTotal(), (Integer)3);
         assertNull(list.getRequestParams().get("total")); // not a request parameter
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals(3, node.get("total").intValue());
+        assertEquals(node.get("total").intValue(), 3);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullList() {
         new DateRangeResourceList<>(null);
     }
@@ -78,6 +78,6 @@ public class DateRangeResourceListTest {
         // We are carrying over an exceptional behavior into this deprecated method where this 
         // list returns 0 instead of null, to keep integration tests and any potential clients
         // working. This value is going away as it is entirely redundent with the list size.
-        assertEquals((Integer)0, list.getTotal());
+        assertEquals(list.getTotal(), (Integer)0);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/DateRangeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/DateRangeTest.java
@@ -1,23 +1,23 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
 
 public class DateRangeTest {
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullStartDate() {
         new DateRange(null, LocalDate.parse("2015-08-19"));
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullEndDate() {
         new DateRange(LocalDate.parse("2015-08-15"), null);
     }
@@ -25,18 +25,18 @@ public class DateRangeTest {
     @Test
     public void startDateBeforeEndDate() {
         DateRange dateRange = new DateRange(LocalDate.parse("2015-08-15"), LocalDate.parse("2015-08-19"));
-        assertEquals("2015-08-15", dateRange.getStartDate().toString());
-        assertEquals("2015-08-19", dateRange.getEndDate().toString());
+        assertEquals(dateRange.getStartDate().toString(), "2015-08-15");
+        assertEquals(dateRange.getEndDate().toString(), "2015-08-19");
     }
 
     @Test
     public void startDateSameAsEndDate() {
         DateRange dateRange = new DateRange(LocalDate.parse("2015-08-17"), LocalDate.parse("2015-08-17"));
-        assertEquals("2015-08-17", dateRange.getStartDate().toString());
-        assertEquals("2015-08-17", dateRange.getEndDate().toString());
+        assertEquals(dateRange.getStartDate().toString(), "2015-08-17");
+        assertEquals(dateRange.getEndDate().toString(), "2015-08-17");
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void startDateAfterEndDate() {
         new DateRange(LocalDate.parse("2015-08-19"), LocalDate.parse("2015-08-15"));
     }
@@ -51,17 +51,17 @@ public class DateRangeTest {
 
         // convert to POJO
         DateRange dateRange = BridgeObjectMapper.get().readValue(jsonText, DateRange.class);
-        assertEquals("2015-08-03", dateRange.getStartDate().toString());
-        assertEquals("2015-08-07", dateRange.getEndDate().toString());
+        assertEquals(dateRange.getStartDate().toString(), "2015-08-03");
+        assertEquals(dateRange.getEndDate().toString(), "2015-08-07");
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(dateRange);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(3, jsonMap.size());
-        assertEquals("2015-08-03", jsonMap.get("startDate"));
-        assertEquals("2015-08-07", jsonMap.get("endDate"));
-        assertEquals("DateRange", jsonMap.get("type"));
+        assertEquals(jsonMap.size(), 3);
+        assertEquals(jsonMap.get("startDate"), "2015-08-03");
+        assertEquals(jsonMap.get("endDate"), "2015-08-07");
+        assertEquals(jsonMap.get("type"), "DateRange");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -24,21 +24,21 @@ public class DateTimeRangeResourceListTest {
                 .withRequestParam(ResourceList.START_TIME, startTime)
                 .withRequestParam(ResourceList.END_TIME, endTime);
         
-        assertEquals(startTime, list.getStartTime());
-        assertEquals(endTime, list.getEndTime());
+        assertEquals(list.getStartTime(), startTime);
+        assertEquals(list.getEndTime(), endTime);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals("2016-02-03T10:10:10.000-08:00", node.get("startTime").asText());
-        assertEquals("2016-02-23T14:14:14.000-08:00", node.get("endTime").asText());
-        assertEquals(3, node.get("items").size());
-        assertEquals("DateTimeRangeResourceList", node.get("type").asText());
-        assertEquals("1", node.get("items").get(0).asText());
-        assertEquals("2", node.get("items").get(1).asText());
-        assertEquals("3", node.get("items").get(2).asText());
-        assertEquals(6, node.size());
-        assertEquals("2016-02-03T10:10:10.000-08:00", node.get("requestParams").get("startTime").asText());
-        assertEquals("2016-02-23T14:14:14.000-08:00", node.get("requestParams").get("endTime").asText());
-        assertEquals(ResourceList.REQUEST_PARAMS, node.get("requestParams").get(ResourceList.TYPE).asText());
+        assertEquals(node.get("startTime").asText(), "2016-02-03T10:10:10.000-08:00");
+        assertEquals(node.get("endTime").asText(), "2016-02-23T14:14:14.000-08:00");
+        assertEquals(node.get("items").size(), 3);
+        assertEquals(node.get("type").asText(), "DateTimeRangeResourceList");
+        assertEquals(node.get("items").get(0).asText(), "1");
+        assertEquals(node.get("items").get(1).asText(), "2");
+        assertEquals(node.get("items").get(2).asText(), "3");
+        assertEquals(node.size(), 6);
+        assertEquals(node.get("requestParams").get("startTime").asText(), "2016-02-03T10:10:10.000-08:00");
+        assertEquals(node.get("requestParams").get("endTime").asText(), "2016-02-23T14:14:14.000-08:00");
+        assertEquals(node.get("requestParams").get(ResourceList.TYPE).asText(), ResourceList.REQUEST_PARAMS);
         
         // We never deserialize this on the server side (only in the SDK).
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -48,59 +48,59 @@ public class ForwardCursorPagedResourceListTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(page);
         
-        assertEquals("nextOffsetKey", node.get("offsetKey").asText());
-        assertEquals("nextOffsetKey", node.get("nextPageOffsetKey").asText());
-        assertEquals(startTime.toString(), node.get("startTime").asText());
-        assertEquals(endTime.toString(), node.get("endTime").asText());
-        assertEquals(startTime.toString(), node.get("scheduledOnStart").asText());
-        assertEquals(endTime.toString(), node.get("scheduledOnEnd").asText());
-        assertEquals(100, node.get("pageSize").intValue());
-        assertEquals(2, node.get("total").intValue());
-        assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
+        assertEquals(node.get("offsetKey").asText(), "nextOffsetKey");
+        assertEquals(node.get("nextPageOffsetKey").asText(), "nextOffsetKey");
+        assertEquals(node.get("startTime").asText(), startTime.toString());
+        assertEquals(node.get("endTime").asText(), endTime.toString());
+        assertEquals(node.get("scheduledOnStart").asText(), startTime.toString());
+        assertEquals(node.get("scheduledOnEnd").asText(), endTime.toString());
+        assertEquals(node.get("pageSize").intValue(), 100);
+        assertEquals(node.get("total").intValue(), 2);
+        assertEquals(node.get("type").asText(), "ForwardCursorPagedResourceList");
         
         JsonNode rp = node.get("requestParams");
-        assertEquals(startTime.toString(), rp.get("startTime").asText());
-        assertEquals(endTime.toString(), rp.get("endTime").asText());
-        assertEquals(startTime.toString(), rp.get("scheduledOnStart").asText());
-        assertEquals(endTime.toString(), rp.get("scheduledOnEnd").asText());
-        assertEquals("filterString", rp.get("emailFilter").asText());
-        assertEquals(100, rp.get("pageSize").intValue());
-        assertEquals("offsetKey", rp.get("offsetKey").asText());
-        assertEquals(ResourceList.REQUEST_PARAMS, rp.get(ResourceList.TYPE).textValue());
+        assertEquals(rp.get("startTime").asText(), startTime.toString());
+        assertEquals(rp.get("endTime").asText(), endTime.toString());
+        assertEquals(rp.get("scheduledOnStart").asText(), startTime.toString());
+        assertEquals(rp.get("scheduledOnEnd").asText(), endTime.toString());
+        assertEquals(rp.get("emailFilter").asText(), "filterString");
+        assertEquals(rp.get("pageSize").intValue(), 100);
+        assertEquals(rp.get("offsetKey").asText(), "offsetKey");
+        assertEquals(rp.get(ResourceList.TYPE).textValue(), ResourceList.REQUEST_PARAMS);
         
         ArrayNode items = (ArrayNode)node.get("items");
-        assertEquals(2, items.size());
+        assertEquals(items.size(), 2);
         
         JsonNode child1 = items.get(0);
-        assertEquals("firstName1", child1.get("firstName").asText());
-        assertEquals("lastName1", child1.get("lastName").asText());
-        assertEquals("email1@email.com", child1.get("email").asText());
-        assertEquals("id", child1.get("id").asText());
-        assertEquals("disabled", child1.get("status").asText());
+        assertEquals(child1.get("firstName").asText(), "firstName1");
+        assertEquals(child1.get("lastName").asText(), "lastName1");
+        assertEquals(child1.get("email").asText(), "email1@email.com");
+        assertEquals(child1.get("id").asText(), "id");
+        assertEquals(child1.get("status").asText(), "disabled");
         
         ForwardCursorPagedResourceList<AccountSummary> serPage = BridgeObjectMapper.get().readValue(node.toString(),
                 new TypeReference<ForwardCursorPagedResourceList<AccountSummary>>() {
                 });
         
-        assertEquals("nextOffsetKey", serPage.getNextPageOffsetKey());
-        assertEquals("nextOffsetKey", serPage.getOffsetKey());
-        assertEquals(startTime, serPage.getStartTime());
-        assertEquals(endTime, serPage.getEndTime());
-        assertEquals(startTime, serPage.getScheduledOnStart());
-        assertEquals(endTime, serPage.getScheduledOnEnd());
-        assertEquals((Integer)100, serPage.getPageSize());
-        assertEquals((Integer)2, serPage.getTotal());
+        assertEquals(serPage.getNextPageOffsetKey(), "nextOffsetKey");
+        assertEquals(serPage.getOffsetKey(), "nextOffsetKey");
+        assertEquals(serPage.getStartTime(), startTime);
+        assertEquals(serPage.getEndTime(), endTime);
+        assertEquals(serPage.getScheduledOnStart(), startTime);
+        assertEquals(serPage.getScheduledOnEnd(), endTime);
+        assertEquals(serPage.getPageSize(), (Integer)100);
+        assertEquals(serPage.getTotal(), (Integer)2);
         
         Map<String,Object> params = serPage.getRequestParams();
-        assertEquals(startTime.toString(), params.get("startTime"));
-        assertEquals(endTime.toString(), params.get("endTime"));
-        assertEquals(startTime.toString(), params.get("scheduledOnStart"));
-        assertEquals(endTime.toString(), params.get("scheduledOnEnd"));
-        assertEquals(100, params.get("pageSize"));
-        assertEquals("filterString", params.get("emailFilter"));
-        assertEquals("offsetKey", params.get("offsetKey"));
+        assertEquals(params.get("startTime"), startTime.toString());
+        assertEquals(params.get("endTime"), endTime.toString());
+        assertEquals(params.get("scheduledOnStart"), startTime.toString());
+        assertEquals(params.get("scheduledOnEnd"), endTime.toString());
+        assertEquals(params.get("pageSize"), 100);
+        assertEquals(params.get("emailFilter"), "filterString");
+        assertEquals(params.get("offsetKey"), "offsetKey");
         
-        assertEquals(page.getItems(), serPage.getItems());
+        assertEquals(serPage.getItems(), page.getItems());
     }
     
     @Test
@@ -119,8 +119,8 @@ public class ForwardCursorPagedResourceListTest {
         assertTrue(list.hasNext());
         node = BridgeObjectMapper.get().valueToTree(list);
         assertTrue(node.get("hasNext").booleanValue());
-        assertEquals("nextPageKey", node.get("offsetKey").asText());
-        assertEquals("nextPageKey", node.get("nextPageOffsetKey").asText());
+        assertEquals(node.get("offsetKey").asText(), "nextPageKey");
+        assertEquals(node.get("nextPageOffsetKey").asText(), "nextPageKey");
     }
     
     // This test was moved from another class that implemented PagedResourceList for
@@ -137,24 +137,24 @@ public class ForwardCursorPagedResourceListTest {
                 .withRequestParam(ResourceList.ID_FILTER, "foo")
                 .withRequestParam(ResourceList.ASSIGNMENT_FILTER, "bar");
         JsonNode node = BridgeObjectMapper.get().valueToTree(page);
-        assertEquals(100, node.get("pageSize").intValue());
-        assertEquals("foo", node.get("requestParams").get("idFilter").asText());
-        assertEquals("bar", node.get("requestParams").get("assignmentFilter").asText());
-        assertEquals("ForwardCursorPagedResourceList", node.get("type").asText());
+        assertEquals(node.get("pageSize").intValue(), 100);
+        assertEquals(node.get("requestParams").get("idFilter").asText(), "foo");
+        assertEquals(node.get("requestParams").get("assignmentFilter").asText(), "bar");
+        assertEquals(node.get("type").asText(), "ForwardCursorPagedResourceList");
         
         ArrayNode items = (ArrayNode)node.get("items");
-        assertEquals(2, items.size());
-        assertEquals("value1", items.get(0).asText());
-        assertEquals("value2", items.get(1).asText());
+        assertEquals(items.size(), 2);
+        assertEquals(items.get(0).asText(), "value1");
+        assertEquals(items.get(1).asText(), "value2");
         
         // We don't deserialize this, but let's verify for the SDK
         ForwardCursorPagedResourceList<String> serPage = BridgeObjectMapper.get().readValue(node.toString(), 
                 new TypeReference<ForwardCursorPagedResourceList<String>>() {});
         
-        assertEquals(page.getNextPageOffsetKey(), serPage.getNextPageOffsetKey());
-        assertEquals(page.getRequestParams().get("pageSize"), serPage.getRequestParams().get("pageSize"));
-        assertEquals(page.getRequestParams().get("idFilter"), serPage.getRequestParams().get("idFilter"));
-        assertEquals(page.getRequestParams().get("assignmentFilter"), serPage.getRequestParams().get("assignmentFilter"));
-        assertEquals(page.getItems(), serPage.getItems());
+        assertEquals(serPage.getNextPageOffsetKey(), page.getNextPageOffsetKey());
+        assertEquals(serPage.getRequestParams().get("pageSize"), page.getRequestParams().get("pageSize"));
+        assertEquals(serPage.getRequestParams().get("idFilter"), page.getRequestParams().get("idFilter"));
+        assertEquals(serPage.getRequestParams().get("assignmentFilter"), page.getRequestParams().get("assignmentFilter"));
+        assertEquals(serPage.getItems(), page.getItems());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/GuidCreatedOnVersionHolderImplTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/GuidCreatedOnVersionHolderImplTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.models;
 
+import org.testng.annotations.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.Test;
 
 public class GuidCreatedOnVersionHolderImplTest {
 

--- a/src/test/java/org/sagebionetworks/bridge/models/MetricsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/MetricsTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -31,8 +31,8 @@ public class MetricsTest {
         assertNotNull(metrics);
 
         // Validate cache key.
-        assertEquals("12345:Metrics", metrics.getCacheKey());
-        assertEquals("12345:Metrics", Metrics.getCacheKey(requestId));
+        assertEquals(metrics.getCacheKey(), "12345:Metrics");
+        assertEquals(Metrics.getCacheKey(requestId), "12345:Metrics");
 
         // Apply setters.
         metrics.setRecordId("test-record");
@@ -41,10 +41,10 @@ public class MetricsTest {
         final String json = metrics.toJsonString();
         assertNotNull(json);
         JsonNode metricsNode = BridgeObjectMapper.get().readTree(json);
-        assertEquals("test-record", metricsNode.get("record_id").textValue());
-        assertEquals(requestId, metricsNode.get("request_id").textValue());
+        assertEquals(metricsNode.get("record_id").textValue(), "test-record");
+        assertEquals(metricsNode.get("request_id").textValue(), requestId);
         assertTrue(metricsNode.hasNonNull("start"));
-        assertEquals(1, metricsNode.get("version").intValue());
+        assertEquals(metricsNode.get("version").intValue(), 1);
     }
 
     @Test
@@ -52,13 +52,13 @@ public class MetricsTest {
         // Mock start and test.
         DateTimeUtils.setCurrentMillisFixed(START_TIME.getMillis());
         Metrics metrics = new Metrics("12345");
-        assertEquals(START_TIME.toString(), metrics.getJson().get("start").textValue());
+        assertEquals(metrics.getJson().get("start").textValue(), START_TIME.toString());
 
         // Mock end and test.
         DateTimeUtils.setCurrentMillisFixed(END_TIME.getMillis());
         metrics.end();
-        assertEquals(END_TIME.toString(), metrics.getJson().get("end").textValue());
-        assertEquals(EXPECTED_ELAPSED_MILLIS, metrics.getJson().get("elapsedMillis").longValue());
+        assertEquals(metrics.getJson().get("end").textValue(), END_TIME.toString());
+        assertEquals(metrics.getJson().get("elapsedMillis").longValue(), EXPECTED_ELAPSED_MILLIS);
     }
 
     @Test
@@ -115,22 +115,22 @@ public class MetricsTest {
         assertTrue(json.contains("\"session_id\":\"d839fe\""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConstructorRequestIdMustNotBeNull() {
         new Metrics(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConstructorRequestIdMustNotBeEmpty() {
         new Metrics(" ");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGetCacheKeyRequestIdMustNotBeNull() {
         Metrics.getCacheKey(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGetCacheKeyRequestIdMustNotBeEmpty() {
         Metrics.getCacheKey(" ");
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -42,50 +42,50 @@ public class PagedResourceListTest {
                 .withRequestParam("emailFilter", "filterString");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(page);
-        assertEquals(123, node.get("offsetBy").intValue());
-        assertEquals(2, node.get("total").intValue());
-        assertEquals(100, node.get("pageSize").intValue());
-        assertEquals("filterString", node.get("emailFilter").asText());
-        assertEquals(startTime.toString(), node.get("startTime").asText());
-        assertEquals(endTime.toString(), node.get("endTime").asText());
-        assertEquals("PagedResourceList", node.get("type").asText());
+        assertEquals(node.get("offsetBy").intValue(), 123);
+        assertEquals(node.get("total").intValue(), 2);
+        assertEquals(node.get("pageSize").intValue(), 100);
+        assertEquals(node.get("emailFilter").asText(), "filterString");
+        assertEquals(node.get("startTime").asText(), startTime.toString());
+        assertEquals(node.get("endTime").asText(), endTime.toString());
+        assertEquals(node.get("type").asText(), "PagedResourceList");
         
         JsonNode rp = node.get("requestParams");
-        assertEquals(123, rp.get("offsetBy").intValue());
-        assertEquals(100, rp.get("pageSize").intValue());
-        assertEquals(startTime.toString(), rp.get("startTime").asText());
-        assertEquals(endTime.toString(), rp.get("endTime").asText());
-        assertEquals("filterString", rp.get("emailFilter").asText());
-        assertEquals(ResourceList.REQUEST_PARAMS, rp.get(ResourceList.TYPE).textValue());
+        assertEquals(rp.get("offsetBy").intValue(), 123);
+        assertEquals(rp.get("pageSize").intValue(), 100);
+        assertEquals(rp.get("startTime").asText(), startTime.toString());
+        assertEquals(rp.get("endTime").asText(), endTime.toString());
+        assertEquals(rp.get("emailFilter").asText(), "filterString");
+        assertEquals(rp.get(ResourceList.TYPE).textValue(), ResourceList.REQUEST_PARAMS);
                 
         ArrayNode items = (ArrayNode)node.get("items");
-        assertEquals(2, items.size());
+        assertEquals(items.size(), 2);
         
         JsonNode child1 = items.get(0);
-        assertEquals("firstName1", child1.get("firstName").asText());
-        assertEquals("lastName1", child1.get("lastName").asText());
-        assertEquals("email1@email.com", child1.get("email").asText());
-        assertEquals("id", child1.get("id").asText());
-        assertEquals("disabled", child1.get("status").asText());
+        assertEquals(child1.get("firstName").asText(), "firstName1");
+        assertEquals(child1.get("lastName").asText(), "lastName1");
+        assertEquals(child1.get("email").asText(), "email1@email.com");
+        assertEquals(child1.get("id").asText(), "id");
+        assertEquals(child1.get("status").asText(), "disabled");
         
         PagedResourceList<AccountSummary> serPage = BridgeObjectMapper.get().readValue(node.toString(), 
                 new TypeReference<PagedResourceList<AccountSummary>>() {});
 
-        assertEquals(page.getTotal(), serPage.getTotal());
-        assertEquals(100, serPage.getPageSize());
-        assertEquals((Integer)123, serPage.getOffsetBy());
-        assertEquals(startTime, serPage.getStartTime());
-        assertEquals(endTime, serPage.getEndTime());
-        assertEquals("filterString", serPage.getEmailFilter());
+        assertEquals(serPage.getTotal(), page.getTotal());
+        assertEquals(serPage.getPageSize(), 100);
+        assertEquals(serPage.getOffsetBy(), (Integer)123);
+        assertEquals(serPage.getStartTime(), startTime);
+        assertEquals(serPage.getEndTime(), endTime);
+        assertEquals(serPage.getEmailFilter(), "filterString");
         
         Map<String,Object> params = page.getRequestParams();
         Map<String,Object> serParams = serPage.getRequestParams();
-        assertEquals(params, serParams);
+        assertEquals(serParams, params);
         
-        assertEquals(page.getItems(), serPage.getItems());
+        assertEquals(serPage.getItems(), page.getItems());
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void totalCannotBeNull() throws Exception {
         List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
         new PagedResourceList<AccountSummary>(accounts, null);

--- a/src/test/java/org/sagebionetworks/bridge/models/RangeTupleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/RangeTupleTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class RangeTupleTest {
 
@@ -11,8 +11,8 @@ public class RangeTupleTest {
     public void test() {
         RangeTuple<String> tuple = new RangeTuple<>("startValue", "endValue");
         
-        assertEquals("startValue", tuple.getStart());
-        assertEquals("endValue", tuple.getEnd());
+        assertEquals(tuple.getStart(), "startValue");
+        assertEquals(tuple.getEnd(), "endValue");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
@@ -30,19 +30,19 @@ public class ReportTypeResourceListTest {
         ReportTypeResourceList<ReportIndex> list = new ReportTypeResourceList<>(
                 Lists.newArrayList(index1, index2)).withRequestParam(ResourceList.REPORT_TYPE, ReportType.PARTICIPANT);
         
-        assertEquals(ReportType.PARTICIPANT, list.getReportType());
+        assertEquals(list.getReportType(), ReportType.PARTICIPANT);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals("participant", node.get("reportType").asText());
-        assertEquals(2, node.get("items").size());
-        assertEquals("participant", node.get("requestParams").get("reportType").asText());
-        assertEquals(ResourceList.REQUEST_PARAMS, node.get("requestParams").get(ResourceList.TYPE).textValue());
-        assertEquals("ReportTypeResourceList", node.get("type").asText());
-        assertEquals("foo", node.get("items").get(0).get("identifier").asText());
+        assertEquals(node.get("reportType").asText(), "participant");
+        assertEquals(node.get("items").size(), 2);
+        assertEquals(node.get("requestParams").get("reportType").asText(), "participant");
+        assertEquals(node.get("requestParams").get(ResourceList.TYPE).textValue(), ResourceList.REQUEST_PARAMS);
+        assertEquals(node.get("type").asText(), "ReportTypeResourceList");
+        assertEquals(node.get("items").get(0).get("identifier").asText(), "foo");
         assertFalse(node.get("items").get(0).get("public").asBoolean());
-        assertEquals("bar", node.get("items").get(1).get("identifier").asText());
+        assertEquals(node.get("items").get(1).get("identifier").asText(), "bar");
         assertTrue(node.get("items").get(1).get("public").asBoolean());
-        assertEquals(5, node.size());
+        assertEquals(node.size(), 5);
         
         // We never deserialize this on the server side (only in the SDK).
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -45,39 +45,39 @@ public class RequestInfoTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(requestInfo);
 
-        assertEquals("userId", node.get("userId").textValue());
-        assertEquals(ACTIVITIES_REQUESTED_ON.withZone(MST).toString(), node.get("activitiesAccessedOn").textValue());
-        assertEquals(UPLOADED_ON.withZone(MST).toString(), node.get("uploadedOn").textValue());
-        assertEquals("en", node.get("languages").get(0).textValue());
-        assertEquals("fr", node.get("languages").get(1).textValue());
+        assertEquals(node.get("userId").textValue(), "userId");
+        assertEquals(node.get("activitiesAccessedOn").textValue(), ACTIVITIES_REQUESTED_ON.withZone(MST).toString());
+        assertEquals(node.get("uploadedOn").textValue(), UPLOADED_ON.withZone(MST).toString());
+        assertEquals(node.get("languages").get(0).textValue(), "en");
+        assertEquals(node.get("languages").get(1).textValue(), "fr");
         Set<String> groups = Sets.newHashSet(
             node.get("userDataGroups").get(0).textValue(),
             node.get("userDataGroups").get(1).textValue()
         );
-        assertEquals(TestConstants.USER_DATA_GROUPS, groups);
+        assertEquals(groups, TestConstants.USER_DATA_GROUPS);
         
         Set<String> substudyIds = Sets.newHashSet(
             node.get("userSubstudyIds").get(0).textValue(),
             node.get("userSubstudyIds").get(1).textValue()
         );
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, substudyIds);
-        assertEquals(SIGNED_IN_ON.withZone(MST).toString(), node.get("signedInOn").textValue());
-        assertEquals("+03:00", node.get("timeZone").textValue());
-        assertEquals("RequestInfo", node.get("type").textValue());
-        assertEquals(USER_AGENT_STRING, node.get("userAgent").textValue());
-        assertEquals(12, node.size());
+        assertEquals(substudyIds, TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(node.get("signedInOn").textValue(), SIGNED_IN_ON.withZone(MST).toString());
+        assertEquals(node.get("timeZone").textValue(), "+03:00");
+        assertEquals(node.get("type").textValue(), "RequestInfo");
+        assertEquals(node.get("userAgent").textValue(), USER_AGENT_STRING);
+        assertEquals(node.size(), 12);
         
         JsonNode studyIdNode = node.get("studyIdentifier");
-        assertEquals("test-study", studyIdNode.get("identifier").textValue());
-        assertEquals("StudyIdentifier", studyIdNode.get("type").textValue());
-        assertEquals(2, studyIdNode.size());
+        assertEquals(studyIdNode.get("identifier").textValue(), "test-study");
+        assertEquals(studyIdNode.get("type").textValue(), "StudyIdentifier");
+        assertEquals(studyIdNode.size(), 2);
         
         JsonNode clientInfoNode = node.get("clientInfo");
-        assertEquals("app", clientInfoNode.get("appName").textValue());
-        assertEquals(20, clientInfoNode.get("appVersion").asInt());
+        assertEquals(clientInfoNode.get("appName").textValue(), "app");
+        assertEquals(clientInfoNode.get("appVersion").asInt(), 20);
         
         RequestInfo deserClientInfo = BridgeObjectMapper.get().readValue(node.toString(), RequestInfo.class);
-        assertEquals(requestInfo, deserClientInfo);
+        assertEquals(deserClientInfo, requestInfo);
     }
     
     @Test
@@ -90,10 +90,8 @@ public class RequestInfoTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(requestInfo);
         
-        assertEquals(ACTIVITIES_REQUESTED_ON.withZone(DateTimeZone.UTC).toString(),
-                node.get("activitiesAccessedOn").textValue());
-        assertEquals(SIGNED_IN_ON.withZone(DateTimeZone.UTC).toString(), 
-                node.get("signedInOn").textValue());
+        assertEquals(node.get("activitiesAccessedOn").textValue(), ACTIVITIES_REQUESTED_ON.withZone(DateTimeZone.UTC).toString());
+        assertEquals(node.get("signedInOn").textValue(), SIGNED_IN_ON.withZone(DateTimeZone.UTC).toString());
     }
     
     @Test
@@ -101,17 +99,17 @@ public class RequestInfoTest {
         RequestInfo requestInfo = createRequestInfo();
         
         RequestInfo copy = new RequestInfo.Builder().copyOf(requestInfo).build();
-        assertEquals(STUDY_ID, copy.getStudyIdentifier());
-        assertEquals(CLIENT_INFO, copy.getClientInfo());
-        assertEquals(USER_AGENT_STRING, copy.getUserAgent());
-        assertEquals(TestConstants.USER_DATA_GROUPS, copy.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, copy.getUserSubstudyIds());
-        assertEquals(LANGUAGES, copy.getLanguages());
-        assertEquals(USER_ID, copy.getUserId());
-        assertEquals(MST, copy.getTimeZone());
-        assertEquals(ACTIVITIES_REQUESTED_ON.withZone(copy.getTimeZone()), copy.getActivitiesAccessedOn());
-        assertEquals(UPLOADED_ON.withZone(copy.getTimeZone()), copy.getUploadedOn());
-        assertEquals(SIGNED_IN_ON.withZone(copy.getTimeZone()), copy.getSignedInOn());
+        assertEquals(copy.getStudyIdentifier(), STUDY_ID);
+        assertEquals(copy.getClientInfo(), CLIENT_INFO);
+        assertEquals(copy.getUserAgent(), USER_AGENT_STRING);
+        assertEquals(copy.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(copy.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(copy.getLanguages(), LANGUAGES);
+        assertEquals(copy.getUserId(), USER_ID);
+        assertEquals(copy.getTimeZone(), MST);
+        assertEquals(copy.getActivitiesAccessedOn(), ACTIVITIES_REQUESTED_ON.withZone(copy.getTimeZone()));
+        assertEquals(copy.getUploadedOn(), UPLOADED_ON.withZone(copy.getTimeZone()));
+        assertEquals(copy.getSignedInOn(), SIGNED_IN_ON.withZone(copy.getTimeZone()));
     }
 
     private RequestInfo createRequestInfo() {

--- a/src/test/java/org/sagebionetworks/bridge/models/ResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ResourceListTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -31,22 +31,22 @@ public class ResourceListTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
         
-        assertEquals(4, node.size());
-        assertEquals(3, node.get("total").intValue());
-        assertEquals(13, node.get("requestParams").get("test").intValue());
-        assertEquals(ResourceList.REQUEST_PARAMS, node.get("requestParams").get(ResourceList.TYPE).textValue());
-        assertEquals(3, node.get("items").size());
-        assertEquals("ResourceList", node.get("type").asText());
+        assertEquals(node.size(), 4);
+        assertEquals(node.get("total").intValue(), 3);
+        assertEquals(node.get("requestParams").get("test").intValue(), 13);
+        assertEquals(node.get("requestParams").get(ResourceList.TYPE).textValue(), ResourceList.REQUEST_PARAMS);
+        assertEquals(node.get("items").size(), 3);
+        assertEquals(node.get("type").asText(), "ResourceList");
         
         ResourceList<String> deser = BridgeObjectMapper.get().readValue(node.toString(), new TypeReference<ResourceList<String>>() {});
         
-        assertEquals("A", deser.getItems().get(0));
-        assertEquals("B", deser.getItems().get(1));
-        assertEquals("C", deser.getItems().get(2));
+        assertEquals(deser.getItems().get(0), "A");
+        assertEquals(deser.getItems().get(1), "B");
+        assertEquals(deser.getItems().get(2), "C");
         // This is deserialized as an integer, not a long, that is a property of the library. Looks the same in JSON.
-        assertEquals((Integer)13, (Integer)deser.getRequestParams().get("test"));
-        assertEquals((Integer)3, deser.getTotal());
-        assertEquals(ResourceList.REQUEST_PARAMS, deser.getRequestParams().get(ResourceList.TYPE));
+        assertEquals((Integer)deser.getRequestParams().get("test"), (Integer)13);
+        assertEquals(deser.getTotal(), (Integer)3);
+        assertEquals(deser.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
     
     @Test
@@ -60,7 +60,7 @@ public class ResourceListTest {
     public void requestParams() {
         ResourceList<String> list = makeResourceList();
         
-        assertEquals("bar", list.getRequestParams().get("foo"));
+        assertEquals(list.getRequestParams().get("foo"), "bar");
         assertNull(list.getRequestParams().get("baz"));
     }
     
@@ -92,8 +92,8 @@ public class ResourceListTest {
         list.withRequestParam("localDate1", localDate);
         list.withRequestParam("localDate2", localDate.toString());
         
-        assertEquals(localDate, list.getLocalDate("localDate1"));
-        assertEquals(localDate, list.getLocalDate("localDate2"));
+        assertEquals(list.getLocalDate("localDate1"), localDate);
+        assertEquals(list.getLocalDate("localDate2"), localDate);
     }
     
     @Test
@@ -108,10 +108,10 @@ public class ResourceListTest {
     public void getTotal() {
         ResourceList<String> list = makeResourceList();
         
-        assertEquals((Integer)3, list.getTotal());
+        assertEquals(list.getTotal(), (Integer)3);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullList() {
         new ResourceList<>(null);
     }
@@ -134,8 +134,8 @@ public class ResourceListTest {
         list.withRequestParam("", "a");
         list.withRequestParam("  ", "a");
         
-        assertEquals(1, list.getRequestParams().size());
-        assertEquals(ResourceList.REQUEST_PARAMS, list.getRequestParams().get(ResourceList.TYPE));
+        assertEquals(list.getRequestParams().size(), 1);
+        assertEquals(list.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
 
     @Test
@@ -144,8 +144,8 @@ public class ResourceListTest {
         ResourceList<String> list = new ResourceList<>(items);
         list.withRequestParam("a valid key", null);
         
-        assertEquals(1, list.getRequestParams().size());
-        assertEquals(ResourceList.REQUEST_PARAMS, list.getRequestParams().get(ResourceList.TYPE));
+        assertEquals(list.getRequestParams().size(), 1);
+        assertEquals(list.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
     
     @Test
@@ -153,7 +153,7 @@ public class ResourceListTest {
         List<String> items = Lists.newArrayList("A","B","C");
         ResourceList<String> list = new ResourceList<>(items);
         list.withRequestParam("type", "not the right type");
-        assertEquals(ResourceList.REQUEST_PARAMS, list.getRequestParams().get(ResourceList.TYPE));
+        assertEquals(list.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
     
     private ResourceList<String> makeResourceList() {

--- a/src/test/java/org/sagebionetworks/bridge/models/TupleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/TupleTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -23,7 +24,7 @@ public class TupleTest {
         String json = BridgeObjectMapper.get().writeValueAsString(tuple);
         
         Tuple<String> deser = BridgeObjectMapper.get().readValue(json, new TypeReference<Tuple<String>>() {});
-        assertEquals(tuple, deser);
+        assertEquals(deser, tuple);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -40,93 +41,93 @@ public class AccountIdTest {
     
     @Test
     public void testToString() {
-        assertEquals("AccountId [studyId=api, credential=user-id]", AccountId.forId(TEST_STUDY_IDENTIFIER, "user-id").toString());
+        assertEquals(AccountId.forId(TEST_STUDY_IDENTIFIER, "user-id").toString(), "AccountId [studyId=api, credential=user-id]");
         
-        assertEquals("AccountId [studyId=api, credential=Phone [regionCode=US, number=9712486796]]", AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE).toString());
+        assertEquals(AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE).toString(), "AccountId [studyId=api, credential=Phone [regionCode=US, number=9712486796]]");
         
-        assertEquals("AccountId [studyId=api, credential=email]", AccountId.forEmail(TEST_STUDY_IDENTIFIER, "email").toString());
+        assertEquals(AccountId.forEmail(TEST_STUDY_IDENTIFIER, "email").toString(), "AccountId [studyId=api, credential=email]");
         
-        assertEquals("AccountId [studyId=api, credential=HEALTH_CODE]", AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, "DEF-GHI").toString());
+        assertEquals(AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, "DEF-GHI").toString(), "AccountId [studyId=api, credential=HEALTH_CODE]");
         
-        assertEquals("AccountId [studyId=api, credential=EXTID]", AccountId.forExternalId(TEST_STUDY_IDENTIFIER, "EXTID").toString());
+        assertEquals(AccountId.forExternalId(TEST_STUDY_IDENTIFIER, "EXTID").toString(), "AccountId [studyId=api, credential=EXTID]");
     }
     
     @Test
     public void factoryMethodsWork() {
         String number = PHONE.getNumber();
-        assertEquals("one", AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getId());
-        assertEquals("one", AccountId.forEmail(TEST_STUDY_IDENTIFIER, "one").getEmail());
-        assertEquals(number, AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE).getPhone().getNumber());
-        assertEquals("ABC-DEF", AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, "ABC-DEF").getHealthCode());
-        assertEquals("EXTID", AccountId.forExternalId(TEST_STUDY_IDENTIFIER, "EXTID").getExternalId());
+        assertEquals(AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getId(), "one");
+        assertEquals(AccountId.forEmail(TEST_STUDY_IDENTIFIER, "one").getEmail(), "one");
+        assertEquals(AccountId.forPhone(TEST_STUDY_IDENTIFIER, PHONE).getPhone().getNumber(), number);
+        assertEquals(AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, "ABC-DEF").getHealthCode(), "ABC-DEF");
+        assertEquals(AccountId.forExternalId(TEST_STUDY_IDENTIFIER, "EXTID").getExternalId(), "EXTID");
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void idAccessorThrows() {
         AccountId.forEmail(TEST_STUDY_IDENTIFIER, "one").getId();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void emailAccessorThrows() {
         AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getEmail();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void phoneAccessorThrows() {
         AccountId.forId(TEST_STUDY_IDENTIFIER, "one").getPhone();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void healthCodeAccessorThrows() {
         AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, "one").getEmail();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void externalIdAccessorThrows() {
         AccountId.forExternalId(TEST_STUDY_IDENTIFIER, "one").getEmail();
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoEmail() {
         AccountId.forEmail(TEST_STUDY_IDENTIFIER, null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoId() {
         AccountId.forId(TEST_STUDY_IDENTIFIER, null);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoPhone() {
         AccountId.forPhone(TEST_STUDY_IDENTIFIER, null);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoHealthCode() {
         AccountId.forHealthCode(TEST_STUDY_IDENTIFIER, null);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoExternalId() {
         AccountId.forExternalId(TEST_STUDY_IDENTIFIER, null);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoStudy() {
         AccountId.forId(null, "id");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoStudyOrEmail() {
         AccountId.forEmail(null, null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoStudyOrId() {
         AccountId.forId(null, null);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoStudyOrPhone() {
         AccountId.forPhone(null, null);
     }
@@ -136,8 +137,8 @@ public class AccountIdTest {
         AccountId id = AccountId.forId("test-study", "id");
         
         AccountId accountId = id.getUnguardedAccountId();
-        assertEquals("test-study", accountId.getStudyId());
-        assertEquals("id", accountId.getId());
+        assertEquals(accountId.getStudyId(), "test-study");
+        assertEquals(accountId.getId(), "id");
         assertNull(accountId.getEmail());
         assertNull(accountId.getPhone());
         assertNull(accountId.getHealthCode());
@@ -156,12 +157,12 @@ public class AccountIdTest {
         
         AccountId identifier = BridgeObjectMapper.get().readValue(json, AccountId.class);
         
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, identifier.getStudyId());
-        assertEquals(TestConstants.EMAIL, identifier.getEmail());
-        assertEquals("someExternalId", identifier.getExternalId());
-        assertEquals("someHealthCode", identifier.getHealthCode());
-        assertEquals(TestConstants.PHONE.getNumber(), identifier.getPhone().getNumber());
-        assertEquals(TestConstants.PHONE.getRegionCode(), identifier.getPhone().getRegionCode());
+        assertEquals(identifier.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(identifier.getEmail(), TestConstants.EMAIL);
+        assertEquals(identifier.getExternalId(), "someExternalId");
+        assertEquals(identifier.getHealthCode(), "someHealthCode");
+        assertEquals(identifier.getPhone().getNumber(), TestConstants.PHONE.getNumber());
+        assertEquals(identifier.getPhone().getRegionCode(), TestConstants.PHONE.getRegionCode());
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSecretIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSecretIdTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -18,7 +18,7 @@ public class AccountSecretIdTest {
     @Test
     public void create() { 
         AccountSecretId key = new AccountSecretId("accountId", "hash");
-        assertEquals("accountId", key.getAccountId());
-        assertEquals("hash", key.getHash());
+        assertEquals(key.getAccountId(), "accountId");
+        assertEquals(key.getHash(), "hash");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
@@ -32,23 +32,23 @@ public class AccountSummaryTest {
                 TestConstants.TEST_STUDY, ImmutableSet.of("sub1", "sub2"));
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(summary);
-        assertEquals("firstName", node.get("firstName").textValue());
-        assertEquals("lastName", node.get("lastName").textValue());
-        assertEquals("email@email.com", node.get("email").textValue());
-        assertEquals("ABC", node.get("id").textValue());
-        assertEquals(TestConstants.PHONE.getNumber(), node.get("phone").get("number").textValue());
-        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("phone").get("regionCode").textValue());
-        assertEquals(TestConstants.PHONE.getNationalFormat(), node.get("phone").get("nationalFormat").textValue());
-        assertEquals("oldExternalId", node.get("externalId").textValue());
-        assertEquals("externalId", node.get("externalIds").get("sub1").textValue());
-        assertEquals(dateTime.withZone(DateTimeZone.UTC).toString(), node.get("createdOn").textValue());
-        assertEquals("unverified", node.get("status").textValue());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, node.get("studyIdentifier").get("identifier").textValue());
-        assertEquals("sub1", node.get("substudyIds").get(0).textValue());
-        assertEquals("sub2", node.get("substudyIds").get(1).textValue());
-        assertEquals("AccountSummary", node.get("type").textValue());
+        assertEquals(node.get("firstName").textValue(), "firstName");
+        assertEquals(node.get("lastName").textValue(), "lastName");
+        assertEquals(node.get("email").textValue(), "email@email.com");
+        assertEquals(node.get("id").textValue(), "ABC");
+        assertEquals(node.get("phone").get("number").textValue(), TestConstants.PHONE.getNumber());
+        assertEquals(node.get("phone").get("regionCode").textValue(), TestConstants.PHONE.getRegionCode());
+        assertEquals(node.get("phone").get("nationalFormat").textValue(), TestConstants.PHONE.getNationalFormat());
+        assertEquals(node.get("externalId").textValue(), "oldExternalId");
+        assertEquals(node.get("externalIds").get("sub1").textValue(), "externalId");
+        assertEquals(node.get("createdOn").textValue(), dateTime.withZone(DateTimeZone.UTC).toString());
+        assertEquals(node.get("status").textValue(), "unverified");
+        assertEquals(node.get("studyIdentifier").get("identifier").textValue(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(node.get("substudyIds").get(0).textValue(), "sub1");
+        assertEquals(node.get("substudyIds").get(1).textValue(), "sub2");
+        assertEquals(node.get("type").textValue(), "AccountSummary");
         
         AccountSummary newSummary = BridgeObjectMapper.get().treeToValue(node, AccountSummary.class);
-        assertEquals(summary, newSummary);
+        assertEquals(newSummary, summary);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/ConsentStatusTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/ConsentStatusTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -27,7 +27,7 @@ public class ConsentStatusTest {
     private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
     private Map<SubpopulationGuid,ConsentStatus> statuses;
     
-    @Before
+    @BeforeMethod
     public void before() {
         statuses = Maps.newHashMap();
     }
@@ -47,16 +47,16 @@ public class ConsentStatusTest {
         String json = BridgeObjectMapper.get().writeValueAsString(status);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("Name", node.get("name").textValue());
-        assertEquals("GUID", node.get("subpopulationGuid").textValue());
+        assertEquals(node.get("name").textValue(), "Name");
+        assertEquals(node.get("subpopulationGuid").textValue(), "GUID");
         assertTrue(node.get("required").booleanValue());
         assertTrue(node.get("consented").booleanValue());
         assertTrue(node.get("signedMostRecentConsent").booleanValue());
-        assertEquals(TIMESTAMP.toString(), node.get("signedOn").textValue());
-        assertEquals("ConsentStatus", node.get("type").textValue());
+        assertEquals(node.get("signedOn").textValue(), TIMESTAMP.toString());
+        assertEquals(node.get("type").textValue(), "ConsentStatus");
         
         ConsentStatus status2 = BridgeObjectMapper.get().readValue(json, ConsentStatus.class);
-        assertEquals(status, status2);
+        assertEquals(status2, status);
     }
     
     @Test
@@ -81,7 +81,7 @@ public class ConsentStatusTest {
         statuses.put(subpop.getGuid(), status1);
         statuses.put(subpop.getGuid(), status2);
         
-        assertEquals(status2, statuses.get(subpop.getGuid()));
+        assertEquals(statuses.get(subpop.getGuid()), status2);
     }
     
     private void add(ConsentStatus status) {

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierInfoTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,13 +22,13 @@ public class ExternalIdentifierInfoTest {
         ExternalIdentifierInfo info = new ExternalIdentifierInfo("AAA", null, true);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(info);
-        assertEquals("AAA", node.get("identifier").textValue());
-        assertEquals(true, node.get("assigned").booleanValue());
-        assertEquals("ExternalIdentifier", node.get("type").textValue());
-        assertEquals(3, node.size());
+        assertEquals(node.get("identifier").textValue(), "AAA");
+        assertEquals(node.get("assigned").booleanValue(), true);
+        assertEquals(node.get("type").textValue(), "ExternalIdentifier");
+        assertEquals(node.size(), 3);
         
         ExternalIdentifierInfo resInfo = BridgeObjectMapper.get().treeToValue(node, ExternalIdentifierInfo.class);
-        assertEquals(info, resInfo);
+        assertEquals(resInfo, info);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoExternalIdentifier;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -25,15 +26,15 @@ public class ExternalIdentifierTest {
         String json = TestUtils.createJson("{'identifier':'AAA','substudyId':'sub-study-id'}");
         
         ExternalIdentifier identifier = BridgeObjectMapper.get().readValue(json, ExternalIdentifier.class);
-        assertEquals("AAA", identifier.getIdentifier());
-        assertEquals("sub-study-id", identifier.getSubstudyId());
+        assertEquals(identifier.getIdentifier(), "AAA");
+        assertEquals(identifier.getSubstudyId(), "sub-study-id");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(identifier);
         
-        assertEquals(3, node.size());
-        assertEquals("AAA", node.get("identifier").textValue());
-        assertEquals("sub-study-id", node.get("substudyId").textValue());
-        assertEquals("ExternalIdentifier", node.get("type").textValue());
+        assertEquals(node.size(), 3);
+        assertEquals(node.get("identifier").textValue(), "AAA");
+        assertEquals(node.get("substudyId").textValue(), "sub-study-id");
+        assertEquals(node.get("type").textValue(), "ExternalIdentifier");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/FPHSExternalIdentifierTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/FPHSExternalIdentifierTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -18,14 +18,14 @@ public class FPHSExternalIdentifierTest {
         String json = BridgeObjectMapper.get().writeValueAsString(identifier);
         
         JsonNode node = BridgeObjectMapper.get().readTree(json);
-        assertEquals("foo", node.get("externalId").asText());
-        assertEquals(false, node.get("registered").asBoolean());
-        assertEquals("ExternalIdentifier", node.get("type").asText());
-        assertEquals(3, node.size());
+        assertEquals(node.get("externalId").asText(), "foo");
+        assertEquals(node.get("registered").asBoolean(), false);
+        assertEquals(node.get("type").asText(), "ExternalIdentifier");
+        assertEquals(node.size(), 3);
         
         json = json.replace("\"registered\":false", "\"registered\":true");
         FPHSExternalIdentifier externalId = BridgeObjectMapper.get().readValue(json, FPHSExternalIdentifier.class);
-        assertEquals("foo", externalId.getExternalId());
+        assertEquals(externalId.getExternalId(), "foo");
         assertTrue(externalId.isRegistered());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/GeneratedPasswordTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/GeneratedPasswordTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class GeneratedPasswordTest {
     @Test
     public void test() { 
         GeneratedPassword gp = new GeneratedPassword("externalId", "userId", "password");
-        assertEquals("externalId", gp.getExternalId());
-        assertEquals("userId", gp.getUserId());
-        assertEquals("password", gp.getPassword());
+        assertEquals(gp.getExternalId(), "externalId");
+        assertEquals(gp.getUserId(), "userId");
+        assertEquals(gp.getPassword(), "password");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/IdentifierUpdateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/IdentifierUpdateTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -19,23 +20,23 @@ public class IdentifierUpdateTest {
         IdentifierUpdate update = new IdentifierUpdate(signIn, "updated@email.com", TestConstants.PHONE, "updatedExternalId");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(update);
-        assertEquals("updated@email.com", node.get("emailUpdate").textValue());
-        assertEquals("updatedExternalId", node.get("externalIdUpdate").textValue());
-        assertEquals("IdentifierUpdate", node.get("type").textValue());
+        assertEquals(node.get("emailUpdate").textValue(), "updated@email.com");
+        assertEquals(node.get("externalIdUpdate").textValue(), "updatedExternalId");
+        assertEquals(node.get("type").textValue(), "IdentifierUpdate");
         
         JsonNode phoneNode = node.get("phoneUpdate");
-        assertEquals(TestConstants.PHONE.getNationalFormat(), phoneNode.get("nationalFormat").textValue());
+        assertEquals(phoneNode.get("nationalFormat").textValue(), TestConstants.PHONE.getNationalFormat());
         
         JsonNode signInNode = node.get("signIn");
-        assertEquals(TestConstants.EMAIL, signInNode.get("email").textValue());
-        assertEquals(TestConstants.PASSWORD, signInNode.get("password").textValue());
+        assertEquals(signInNode.get("email").textValue(), TestConstants.EMAIL);
+        assertEquals(signInNode.get("password").textValue(), TestConstants.PASSWORD);
         
         IdentifierUpdate deser = BridgeObjectMapper.get().readValue(node.toString(), IdentifierUpdate.class);
-        assertEquals("updated@email.com", deser.getEmailUpdate());
-        assertEquals("updatedExternalId", deser.getExternalIdUpdate());
-        assertEquals(TestConstants.PHONE, deser.getPhoneUpdate());
-        assertEquals(TestConstants.EMAIL, deser.getSignIn().getEmail());
-        assertEquals(TestConstants.PASSWORD, deser.getSignIn().getPassword());
+        assertEquals(deser.getEmailUpdate(), "updated@email.com");
+        assertEquals(deser.getExternalIdUpdate(), "updatedExternalId");
+        assertEquals(deser.getPhoneUpdate(), TestConstants.PHONE);
+        assertEquals(deser.getSignIn().getEmail(), TestConstants.EMAIL);
+        assertEquals(deser.getSignIn().getPassword(), TestConstants.PASSWORD);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordAlgorithmTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordAlgorithmTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class PasswordAlgorithmTest {
     private static final String TEST_PASSWORD = "People use 'password1', which is a bad password.";

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordResetTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordResetTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -14,9 +14,9 @@ public class PasswordResetTest {
         String json = TestUtils.createJson("{'sptoken': '3x9HSBY3vZr5zrx9qkEtLa', 'password': 'pass', 'study': 'api'}");
         
         PasswordReset reset = BridgeObjectMapper.get().readValue(json, PasswordReset.class);
-        assertEquals("3x9HSBY3vZr5zrx9qkEtLa", reset.getSptoken());
-        assertEquals("pass", reset.getPassword());
-        assertEquals("api", reset.getStudyIdentifier());
+        assertEquals(reset.getSptoken(), "3x9HSBY3vZr5zrx9qkEtLa");
+        assertEquals(reset.getPassword(), "pass");
+        assertEquals(reset.getStudyIdentifier(), "api");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -23,24 +24,24 @@ public class PhoneTest {
     @Test
     public void canSerialize() throws Exception {
         Phone phone = new Phone(TestConstants.PHONE.getNationalFormat(), TestConstants.PHONE.getRegionCode());
-        assertEquals(TestConstants.PHONE.getNumber(), phone.getNumber());
+        assertEquals(phone.getNumber(), TestConstants.PHONE.getNumber());
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(phone);
-        assertEquals(TestConstants.PHONE.getNumber(), node.get("number").textValue());
-        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("regionCode").textValue());
-        assertEquals(TestConstants.PHONE.getNationalFormat(), node.get("nationalFormat").textValue());
-        assertEquals("Phone", node.get("type").textValue());
-        assertEquals(4, node.size());
+        assertEquals(node.get("number").textValue(), TestConstants.PHONE.getNumber());
+        assertEquals(node.get("regionCode").textValue(), TestConstants.PHONE.getRegionCode());
+        assertEquals(node.get("nationalFormat").textValue(), TestConstants.PHONE.getNationalFormat());
+        assertEquals(node.get("type").textValue(), "Phone");
+        assertEquals(node.size(), 4);
         
         Phone deser = BridgeObjectMapper.get().readValue(node.toString(), Phone.class);
-        assertEquals(phone.getNumber(), deser.getNumber());
-        assertEquals(phone.getRegionCode(), deser.getRegionCode());
-        assertEquals(TestConstants.PHONE.getNationalFormat(), deser.getNationalFormat());
+        assertEquals(deser.getNumber(), phone.getNumber());
+        assertEquals(deser.getRegionCode(), phone.getRegionCode());
+        assertEquals(deser.getNationalFormat(), TestConstants.PHONE.getNationalFormat());
     }
     
     @Test
     public void testToString() {
-        assertEquals("Phone [regionCode=US, number=9712486796]", TestConstants.PHONE.toString());
+        assertEquals(TestConstants.PHONE.toString(), "Phone [regionCode=US, number=9712486796]");
     }
     
     @Test
@@ -48,9 +49,9 @@ public class PhoneTest {
         // Forbidden planet, game store in London, in a local phone format.
         // Note that it's GB, not UK (!)
         Phone phone = new Phone("020-7420-3666", "GB");
-        assertEquals("+442074203666", phone.getNumber());
-        assertEquals("020 7420 3666", phone.getNationalFormat());
-        assertEquals("GB", phone.getRegionCode());
+        assertEquals(phone.getNumber(), "+442074203666");
+        assertEquals(phone.getNationalFormat(), "020 7420 3666");
+        assertEquals(phone.getRegionCode(), "GB");
     }
     
     @Test
@@ -58,20 +59,20 @@ public class PhoneTest {
         Phone phone = new Phone();
         phone.setNumber(TestConstants.PHONE.getNationalFormat());
         phone.setRegionCode("US");
-        assertEquals(TestConstants.PHONE.getNumber(), phone.getNumber());
-        assertEquals(TestConstants.PHONE.getNationalFormat(), phone.getNationalFormat());
+        assertEquals(phone.getNumber(), TestConstants.PHONE.getNumber());
+        assertEquals(phone.getNationalFormat(), TestConstants.PHONE.getNationalFormat());
     }
     
     @Test
     public void invalidPhoneIsPreserved() {
         Phone phone = new Phone("999-999-9999", "US");
-        assertEquals("999-999-9999", phone.getNumber());
-        assertEquals("US", phone.getRegionCode());
-        assertEquals("999-999-9999", phone.getNationalFormat());
+        assertEquals(phone.getNumber(), "999-999-9999");
+        assertEquals(phone.getRegionCode(), "US");
+        assertEquals(phone.getNationalFormat(), "999-999-9999");
         assertFalse(Phone.isValid(phone));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void phoneIsNull() {
         Phone.isValid(null);
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/SharingOptionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/SharingOptionTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.SharingOption;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -22,10 +23,10 @@ public class SharingOptionTest {
         node.put("scope", "sponsors_and_partners");
 
         SharingOption option = SharingOption.fromJson(node, 1);
-        assertEquals(SharingScope.NO_SHARING, option.getSharingScope());
+        assertEquals(option.getSharingScope(), SharingScope.NO_SHARING);
 
         option = SharingOption.fromJson(node, 2);
-        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, option.getSharingScope());
+        assertEquals(option.getSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
 
         try {
             node = JsonNodeFactory.instance.objectNode();
@@ -40,13 +41,13 @@ public class SharingOptionTest {
         // A test failure wound indicate broken APIs
         node.put("scope", "all_qualified_researchers");
         option = SharingOption.fromJson(node, 2);
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, option.getSharingScope());
+        assertEquals(option.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
     }
 
     @Test
     public void sharingOptionFailsGracefully() {
         SharingOption option = SharingOption.fromJson(null, 1);
-        assertEquals(SharingScope.NO_SHARING, option.getSharingScope());
+        assertEquals(option.getSharingScope(), SharingScope.NO_SHARING);
         
         try {
             option = SharingOption.fromJson(null, 11);

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/SignInTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/SignInTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -18,8 +19,8 @@ public class SignInTest {
 
         SignIn signIn = BridgeObjectMapper.get().readValue(oldJson, SignIn.class);
 
-        assertEquals("aName", signIn.getEmail());
-        assertEquals("password", signIn.getPassword());
+        assertEquals(signIn.getEmail(), "aName");
+        assertEquals(signIn.getPassword(), "password");
     }
     
     @Test
@@ -28,10 +29,10 @@ public class SignInTest {
 
         SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);
 
-        assertEquals("foo", signIn.getStudyId());
-        assertEquals("aName", signIn.getEmail());
-        assertEquals("password", signIn.getPassword());
-        assertEquals("ABC", signIn.getToken());
+        assertEquals(signIn.getStudyId(), "foo");
+        assertEquals(signIn.getEmail(), "aName");
+        assertEquals(signIn.getPassword(), "password");
+        assertEquals(signIn.getToken(), "ABC");
     }
     
     @Test
@@ -42,14 +43,14 @@ public class SignInTest {
                 .withStudy("study-key").withToken("token").build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(signIn);
-        assertEquals("email@email.com", node.get("email").textValue());
-        assertEquals("password", node.get("password").textValue());
-        assertEquals(TestConstants.PHONE.getNumber(), node.get("phone").get("number").textValue());
-        assertEquals(TestConstants.PHONE.getRegionCode(), node.get("phone").get("regionCode").textValue());
-        assertEquals("reauthToken", node.get("reauthToken").textValue());
-        assertEquals("study-key", node.get("study").textValue());
-        assertEquals("external-id", node.get("externalId").textValue());
-        assertEquals("token", node.get("token").textValue());
+        assertEquals(node.get("email").textValue(), "email@email.com");
+        assertEquals(node.get("password").textValue(), "password");
+        assertEquals(node.get("phone").get("number").textValue(), TestConstants.PHONE.getNumber());
+        assertEquals(node.get("phone").get("regionCode").textValue(), TestConstants.PHONE.getRegionCode());
+        assertEquals(node.get("reauthToken").textValue(), "reauthToken");
+        assertEquals(node.get("study").textValue(), "study-key");
+        assertEquals(node.get("externalId").textValue(), "external-id");
+        assertEquals(node.get("token").textValue(), "token");
     }
     
     @Test
@@ -58,8 +59,8 @@ public class SignInTest {
 
         SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);
 
-        assertEquals("aName", signIn.getEmail());
-        assertEquals("password", signIn.getPassword());
+        assertEquals(signIn.getEmail(), "aName");
+        assertEquals(signIn.getPassword(), "password");
     }
     
     @Test
@@ -68,8 +69,8 @@ public class SignInTest {
 
         SignIn signIn = BridgeObjectMapper.get().readValue(json, SignIn.class);
 
-        assertEquals("email@email.com", signIn.getEmail());
-        assertEquals("myReauthToken", signIn.getReauthToken());
+        assertEquals(signIn.getEmail(), "email@email.com");
+        assertEquals(signIn.getReauthToken(), "myReauthToken");
     }
     
     @Test
@@ -86,14 +87,14 @@ public class SignInTest {
                 "}"));
         
         SignIn signIn = BridgeObjectMapper.get().readValue(node.toString(), SignIn.class);
-        assertEquals("emailValue", signIn.getEmail());
-        assertEquals("external-id", signIn.getExternalId());
-        assertEquals("passwordValue", signIn.getPassword());
-        assertEquals("studyValue", signIn.getStudyId());
-        assertEquals("tokenValue", signIn.getToken());
-        assertEquals(TestConstants.PHONE.getNumber(), signIn.getPhone().getNumber());
-        assertEquals(TestConstants.PHONE.getRegionCode(), signIn.getPhone().getRegionCode());
-        assertEquals("reauthTokenValue", signIn.getReauthToken());
+        assertEquals(signIn.getEmail(), "emailValue");
+        assertEquals(signIn.getExternalId(), "external-id");
+        assertEquals(signIn.getPassword(), "passwordValue");
+        assertEquals(signIn.getStudyId(), "studyValue");
+        assertEquals(signIn.getToken(), "tokenValue");
+        assertEquals(signIn.getPhone().getNumber(), TestConstants.PHONE.getNumber());
+        assertEquals(signIn.getPhone().getRegionCode(), TestConstants.PHONE.getRegionCode());
+        assertEquals(signIn.getReauthToken(), "reauthTokenValue");
     }
     
     @Test
@@ -106,11 +107,11 @@ public class SignInTest {
                 "'reauthToken':'reauthTokenValue'"+
                 "}"));
         SignIn signIn = BridgeObjectMapper.get().readValue(node.toString(), SignIn.class);
-        assertEquals("emailValue", signIn.getEmail());
-        assertEquals("passwordValue", signIn.getPassword());
-        assertEquals("studyValue", signIn.getStudyId());
-        assertEquals("tokenValue", signIn.getToken());
-        assertEquals("reauthTokenValue", signIn.getReauthToken());
+        assertEquals(signIn.getEmail(), "emailValue");
+        assertEquals(signIn.getPassword(), "passwordValue");
+        assertEquals(signIn.getStudyId(), "studyValue");
+        assertEquals(signIn.getToken(), "tokenValue");
+        assertEquals(signIn.getReauthToken(), "reauthTokenValue");
     }
     
     @Test
@@ -118,8 +119,8 @@ public class SignInTest {
         SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER).withEmail("email")
                 .withPassword("password").build();
         AccountId accountId = signIn.getAccountId();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
-        assertEquals("email", accountId.getEmail());
+        assertEquals(accountId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountId.getEmail(), "email");
     }
     
     @Test
@@ -127,8 +128,8 @@ public class SignInTest {
         SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
                 .withPhone(TestConstants.PHONE).withPassword("password").build();
         AccountId accountId = signIn.getAccountId();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
-        assertEquals(TestConstants.PHONE.getNumber(), accountId.getPhone().getNumber());
+        assertEquals(accountId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountId.getPhone().getNumber(), TestConstants.PHONE.getNumber());
     }
     
     @Test
@@ -136,8 +137,8 @@ public class SignInTest {
         SignIn signIn = new SignIn.Builder().withStudy(TestConstants.TEST_STUDY_IDENTIFIER)
                 .withExternalId("external-id").withPassword("password").build();
         AccountId accountId = signIn.getAccountId();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountId.getStudyId());
-        assertEquals("external-id", accountId.getExternalId());
+        assertEquals(accountId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountId.getExternalId(), "external-id");
     }
     
     @Test
@@ -150,7 +151,7 @@ public class SignInTest {
             signIn.getAccountId();
             fail("Should have thrown an exception");
         } catch(IllegalArgumentException e) {
-            assertEquals("SignIn not constructed with enough information to retrieve an account", e.getMessage());
+            assertEquals(e.getMessage(), "SignIn not constructed with enough information to retrieve an account");
         }
     }
     
@@ -166,17 +167,17 @@ public class SignInTest {
                 .withReauthToken("reauthToken").build();
         
         SignIn copy = new SignIn.Builder().withSignIn(origin).build();
-        assertEquals(TestConstants.EMAIL, copy.getEmail());
-        assertEquals(TestConstants.PHONE, copy.getPhone());
-        assertEquals("externalId", copy.getExternalId());
-        assertEquals("password", copy.getPassword());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, copy.getStudyId());
-        assertEquals("token", copy.getToken());
-        assertEquals("reauthToken", copy.getReauthToken());
+        assertEquals(copy.getEmail(), TestConstants.EMAIL);
+        assertEquals(copy.getPhone(), TestConstants.PHONE);
+        assertEquals(copy.getExternalId(), "externalId");
+        assertEquals(copy.getPassword(), "password");
+        assertEquals(copy.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(copy.getToken(), "token");
+        assertEquals(copy.getReauthToken(), "reauthToken");
         
         // Also test the straight email-to-email copy as well as the username copy
-        assertEquals("email", new SignIn.Builder().withSignIn(
+        assertEquals(new SignIn.Builder().withSignIn(
                 new SignIn.Builder().withEmail("email").build()
-            ).build().getEmail());
+            ).build().getEmail(), "email");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/StudyParticipantTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
@@ -63,29 +63,29 @@ public class StudyParticipantTest {
         String json = StudyParticipant.CACHE_WRITER.writeValueAsString(participant);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("firstName", node.get("firstName").asText());
-        assertEquals("lastName", node.get("lastName").asText());
-        assertEquals("email@email.com", node.get("email").asText());
-        assertEquals("externalId", node.get("externalId").asText());
-        assertEquals("newUserPassword", node.get("password").asText());
-        assertEquals("sponsors_and_partners", node.get("sharingScope").asText());
+        assertEquals(node.get("firstName").asText(), "firstName");
+        assertEquals(node.get("lastName").asText(), "lastName");
+        assertEquals(node.get("email").asText(), "email@email.com");
+        assertEquals(node.get("externalId").asText(), "externalId");
+        assertEquals(node.get("password").asText(), "newUserPassword");
+        assertEquals(node.get("sharingScope").asText(), "sponsors_and_partners");
         assertTrue(node.get("notifyByEmail").asBoolean());
         assertNull(node.get("healthCode"));
         assertNotNull(node.get("encryptedHealthCode"));
         assertTrue(node.get("consented").booleanValue());
-        assertEquals("enabled", node.get("status").asText());
-        assertEquals(CREATED_ON_UTC.toString(), node.get("createdOn").asText());
-        assertEquals(ACCOUNT_ID, node.get("id").asText());
-        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
-        assertEquals("substudyB", node.get("substudyIds").get(1).textValue());
-        assertEquals("+04:00", node.get("timeZone").asText());
-        assertEquals("externalIdA", node.get("externalIds").get("substudyA").textValue());
-        assertEquals("StudyParticipant", node.get("type").asText());
+        assertEquals(node.get("status").asText(), "enabled");
+        assertEquals(node.get("createdOn").asText(), CREATED_ON_UTC.toString());
+        assertEquals(node.get("id").asText(), ACCOUNT_ID);
+        assertEquals(node.get("substudyIds").get(0).textValue(), "substudyA");
+        assertEquals(node.get("substudyIds").get(1).textValue(), "substudyB");
+        assertEquals(node.get("timeZone").asText(), "+04:00");
+        assertEquals(node.get("externalIds").get("substudyA").textValue(), "externalIdA");
+        assertEquals(node.get("type").asText(), "StudyParticipant");
         
         JsonNode clientData = node.get("clientData");
         assertTrue(clientData.get("booleanFlag").booleanValue());
-        assertEquals("testString", clientData.get("stringValue").asText());
-        assertEquals(4, clientData.get("intValue").intValue());
+        assertEquals(clientData.get("stringValue").asText(), "testString");
+        assertEquals(clientData.get("intValue").intValue(), 4);
 
         Set<String> roleNames = Sets.newHashSet(
                 Roles.ADMIN.name().toLowerCase(), Roles.WORKER.name().toLowerCase());
@@ -95,45 +95,45 @@ public class StudyParticipantTest {
         
         // This array the order is significant, it serializes LinkedHashSet
         ArrayNode langsArray = (ArrayNode)node.get("languages"); 
-        assertEquals("en", langsArray.get(0).asText());
-        assertEquals("fr", langsArray.get(1).asText());
+        assertEquals(langsArray.get(0).asText(), "en");
+        assertEquals(langsArray.get(1).asText(), "fr");
         
         ArrayNode dataGroupsArray = (ArrayNode)node.get("dataGroups");
         assertTrue(DATA_GROUPS.contains(dataGroupsArray.get(0).asText()));
         assertTrue(DATA_GROUPS.contains(dataGroupsArray.get(1).asText()));
 
-        assertEquals("B", node.get("attributes").get("A").asText());
-        assertEquals("D", node.get("attributes").get("C").asText());
-        assertEquals(25, node.size());
+        assertEquals(node.get("attributes").get("A").asText(), "B");
+        assertEquals(node.get("attributes").get("C").asText(), "D");
+        assertEquals(node.size(), 25);
         
         StudyParticipant deserParticipant = BridgeObjectMapper.get().readValue(node.toString(), StudyParticipant.class);
-        assertEquals("firstName", deserParticipant.getFirstName());
-        assertEquals("lastName", deserParticipant.getLastName());
-        assertEquals("email@email.com", deserParticipant.getEmail());
-        assertEquals("externalId", deserParticipant.getExternalId());
-        assertEquals("newUserPassword", deserParticipant.getPassword());
-        assertEquals(TIME_ZONE, deserParticipant.getTimeZone());
-        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, deserParticipant.getSharingScope());
+        assertEquals(deserParticipant.getFirstName(), "firstName");
+        assertEquals(deserParticipant.getLastName(), "lastName");
+        assertEquals(deserParticipant.getEmail(), "email@email.com");
+        assertEquals(deserParticipant.getExternalId(), "externalId");
+        assertEquals(deserParticipant.getPassword(), "newUserPassword");
+        assertEquals(deserParticipant.getTimeZone(), TIME_ZONE);
+        assertEquals(deserParticipant.getSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
         assertTrue(deserParticipant.isNotifyByEmail());
-        assertEquals(DATA_GROUPS, deserParticipant.getDataGroups());
-        assertEquals(SUBSTUDIES, deserParticipant.getSubstudyIds());
-        assertEquals(TestConstants.UNENCRYPTED_HEALTH_CODE, deserParticipant.getHealthCode());
+        assertEquals(deserParticipant.getDataGroups(), DATA_GROUPS);
+        assertEquals(deserParticipant.getSubstudyIds(), SUBSTUDIES);
+        assertEquals(deserParticipant.getHealthCode(), TestConstants.UNENCRYPTED_HEALTH_CODE);
         // This is encrypted with different series of characters each time, so just verify it is there.
         assertNotNull(deserParticipant.getEncryptedHealthCode());
-        assertEquals(ATTRIBUTES, deserParticipant.getAttributes());
+        assertEquals(deserParticipant.getAttributes(), ATTRIBUTES);
         assertTrue(deserParticipant.isConsented());
-        assertEquals(CREATED_ON_UTC, deserParticipant.getCreatedOn());
-        assertEquals(AccountStatus.ENABLED, deserParticipant.getStatus());
-        assertEquals(ACCOUNT_ID, deserParticipant.getId());
-        assertEquals("externalIdA", deserParticipant.getExternalIds().get("substudyA"));
+        assertEquals(deserParticipant.getCreatedOn(), CREATED_ON_UTC);
+        assertEquals(deserParticipant.getStatus(), AccountStatus.ENABLED);
+        assertEquals(deserParticipant.getId(), ACCOUNT_ID);
+        assertEquals(deserParticipant.getExternalIds().get("substudyA"), "externalIdA");
         
         UserConsentHistory deserHistory = deserParticipant.getConsentHistories().get("AAA").get(0);
-        assertEquals("2002-02-02", deserHistory.getBirthdate());
-        assertEquals(1000000L, deserHistory.getConsentCreatedOn());
-        assertEquals(2000000L, deserHistory.getSignedOn());
-        assertEquals("Test User", deserHistory.getName());
-        assertEquals("AAA", deserHistory.getSubpopulationGuid());
-        assertEquals(new Long(3000000L), deserHistory.getWithdrewOn());
+        assertEquals(deserHistory.getBirthdate(), "2002-02-02");
+        assertEquals(deserHistory.getConsentCreatedOn(), 1000000L);
+        assertEquals(deserHistory.getSignedOn(), 2000000L);
+        assertEquals(deserHistory.getName(), "Test User");
+        assertEquals(deserHistory.getSubpopulationGuid(), "AAA");
+        assertEquals(deserHistory.getWithdrewOn(), new Long(3000000L));
     }
     
     @Test
@@ -154,7 +154,7 @@ public class StudyParticipantTest {
         String json = StudyParticipant.API_WITH_HEALTH_CODE_WRITER.writeValueAsString(participant);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals(TestConstants.UNENCRYPTED_HEALTH_CODE, node.get("healthCode").asText());
+        assertEquals(node.get("healthCode").asText(), TestConstants.UNENCRYPTED_HEALTH_CODE);
         assertNull(node.get("encryptedHealthCode"));
     }
 
@@ -163,26 +163,26 @@ public class StudyParticipantTest {
         StudyParticipant participant = makeParticipant().build();
         StudyParticipant copy = new StudyParticipant.Builder().copyOf(participant).build();
         
-        assertEquals("firstName", copy.getFirstName());
-        assertEquals("lastName", copy.getLastName());
-        assertEquals("email@email.com", copy.getEmail());
-        assertEquals(PHONE.getNationalFormat(), copy.getPhone().getNationalFormat());
-        assertEquals(Boolean.TRUE, copy.getEmailVerified());
-        assertEquals(Boolean.TRUE, copy.getPhoneVerified());
-        assertEquals("externalId", copy.getExternalId());
-        assertEquals("newUserPassword", copy.getPassword());
-        assertEquals(TIME_ZONE, copy.getTimeZone());
-        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, copy.getSharingScope());
+        assertEquals(copy.getFirstName(), "firstName");
+        assertEquals(copy.getLastName(), "lastName");
+        assertEquals(copy.getEmail(), "email@email.com");
+        assertEquals(copy.getPhone().getNationalFormat(), PHONE.getNationalFormat());
+        assertEquals(copy.getEmailVerified(), Boolean.TRUE);
+        assertEquals(copy.getPhoneVerified(), Boolean.TRUE);
+        assertEquals(copy.getExternalId(), "externalId");
+        assertEquals(copy.getPassword(), "newUserPassword");
+        assertEquals(copy.getTimeZone(), TIME_ZONE);
+        assertEquals(copy.getSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
         assertTrue(copy.isNotifyByEmail());
-        assertEquals(DATA_GROUPS, copy.getDataGroups());
-        assertEquals("healthCode", copy.getHealthCode());
-        assertEquals(ATTRIBUTES, copy.getAttributes());
+        assertEquals(copy.getDataGroups(), DATA_GROUPS);
+        assertEquals(copy.getHealthCode(), "healthCode");
+        assertEquals(copy.getAttributes(), ATTRIBUTES);
         assertTrue(copy.isConsented());
-        assertEquals(CREATED_ON, copy.getCreatedOn());
-        assertEquals(AccountStatus.ENABLED, copy.getStatus());
-        assertEquals(SUBSTUDIES, copy.getSubstudyIds());
-        assertEquals(ACCOUNT_ID, copy.getId());
-        assertEquals(TestUtils.getClientData(), copy.getClientData());
+        assertEquals(copy.getCreatedOn(), CREATED_ON);
+        assertEquals(copy.getStatus(), AccountStatus.ENABLED);
+        assertEquals(copy.getSubstudyIds(), SUBSTUDIES);
+        assertEquals(copy.getId(), ACCOUNT_ID);
+        assertEquals(copy.getClientData(), TestUtils.getClientData());
         
         // And they are equal in the Java sense
         assertEquals(copy, participant);
@@ -307,24 +307,24 @@ public class StudyParticipantTest {
         String json = "{\"email\":\"email@email.com\",\"username\":\"username@email.com\",\"password\":\"password\",\"roles\":[],\"dataGroups\":[],\"type\":\"SignUp\"}";
         
         StudyParticipant participant = BridgeObjectMapper.get().readValue(json, StudyParticipant.class);
-        assertEquals("email@email.com", participant.getEmail());
-        assertEquals("password", participant.getPassword());
+        assertEquals(participant.getEmail(), "email@email.com");
+        assertEquals(participant.getPassword(), "password");
     }
     
     @Test
     public void legacyAccountsWithoutEmailVerificationAreFixed() {
         StudyParticipant participant = new StudyParticipant.Builder().withStatus(AccountStatus.ENABLED).build();
-        assertEquals(Boolean.TRUE, participant.getEmailVerified());
-        assertEquals(AccountStatus.ENABLED, participant.getStatus());
+        assertEquals(participant.getEmailVerified(), Boolean.TRUE);
+        assertEquals(participant.getStatus(), AccountStatus.ENABLED);
         
         participant = new StudyParticipant.Builder().withStatus(AccountStatus.UNVERIFIED).build();
-        assertEquals(Boolean.FALSE, participant.getEmailVerified());
-        assertEquals(AccountStatus.UNVERIFIED, participant.getStatus());
+        assertEquals(participant.getEmailVerified(), Boolean.FALSE);
+        assertEquals(participant.getStatus(), AccountStatus.UNVERIFIED);
         
         // WHen disabled, we don't absolutely know the status of email verification.
         participant = new StudyParticipant.Builder().withStatus(AccountStatus.DISABLED).build();
         assertNull(participant.getEmailVerified());
-        assertEquals(AccountStatus.DISABLED, participant.getStatus());
+        assertEquals(participant.getStatus(), AccountStatus.DISABLED);
     }
     
     @Test
@@ -333,8 +333,8 @@ public class StudyParticipantTest {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withStatus(AccountStatus.ENABLED)
                 .withEmailVerified(Boolean.FALSE).build();
-        assertEquals(Boolean.FALSE, participant.getEmailVerified());
-        assertEquals(AccountStatus.ENABLED, participant.getStatus());
+        assertEquals(participant.getEmailVerified(), Boolean.FALSE);
+        assertEquals(participant.getStatus(), AccountStatus.ENABLED);
     }
     
 
@@ -405,6 +405,6 @@ public class StudyParticipantTest {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withLanguages(Lists.newArrayList("en", "fr", "en", "de")).build();
         
-        assertEquals(Lists.newArrayList("en","fr","de"), participant.getLanguages());
+        assertEquals(participant.getLanguages(), Lists.newArrayList("en","fr","de"));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserConsentHistoryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserConsentHistoryTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -49,18 +50,18 @@ public class UserConsentHistoryTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertNull(node.get("healthCode"));
-        assertEquals("BBB", node.get("subpopulationGuid").asText());
-        assertEquals("2015-10-29T16:29:24.293Z", node.get("consentCreatedOn").asText());
-        assertEquals("image/png", node.get("imageMimeType").asText());
-        assertEquals("2015-10-29T16:29:42.504Z", node.get("signedOn").asText());
-        assertEquals("2015-10-29T16:29:56.168Z", node.get("withdrewOn").asText());
-        assertEquals(true, node.get("hasSignedActiveConsent").asBoolean());
-        assertEquals("UserConsentHistory", node.get("type").asText());
+        assertEquals(node.get("subpopulationGuid").asText(), "BBB");
+        assertEquals(node.get("consentCreatedOn").asText(), "2015-10-29T16:29:24.293Z");
+        assertEquals(node.get("imageMimeType").asText(), "image/png");
+        assertEquals(node.get("signedOn").asText(), "2015-10-29T16:29:42.504Z");
+        assertEquals(node.get("withdrewOn").asText(), "2015-10-29T16:29:56.168Z");
+        assertEquals(node.get("hasSignedActiveConsent").asBoolean(), true);
+        assertEquals(node.get("type").asText(), "UserConsentHistory");
         
         // This has to be added for the deserialized version to be equal to original
         ((ObjectNode)node).put("healthCode", "AAA");
         
         UserConsentHistory newHistory = BridgeObjectMapper.get().readValue(node.toString(), UserConsentHistory.class);
-        assertEquals(history, newHistory);
+        assertEquals(newHistory, history);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -1,14 +1,17 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.*;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Iterator;
 import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -53,42 +56,42 @@ public class UserSessionInfoTest {
         session.setStudyIdentifier(new StudyIdentifierImpl("study-identifier"));
         
         JsonNode node = UserSessionInfo.toJSON(session);
-        assertEquals("first name", node.get("firstName").textValue());
-        assertEquals("last name", node.get("lastName").textValue());
-        assertEquals(session.isAuthenticated(), node.get("authenticated").booleanValue());
-        assertEquals(ConsentStatus.isConsentCurrent(map), node.get("signedMostRecentConsent").booleanValue());
-        assertEquals(ConsentStatus.isUserConsented(map), node.get("consented").booleanValue());
-        assertEquals(participant.getSharingScope().name(), node.get("sharingScope").textValue().toUpperCase());
-        assertEquals(session.getSessionToken(), node.get("sessionToken").textValue());
-        assertEquals(participant.getEmail(), node.get("username").textValue());
+        assertEquals(node.get("firstName").textValue(), "first name");
+        assertEquals(node.get("lastName").textValue(), "last name");
+        assertEquals(node.get("authenticated").booleanValue(), session.isAuthenticated());
+        assertEquals(node.get("signedMostRecentConsent").booleanValue(), ConsentStatus.isConsentCurrent(map));
+        assertEquals(node.get("consented").booleanValue(), ConsentStatus.isUserConsented(map));
+        assertEquals(node.get("sharingScope").textValue().toUpperCase(), participant.getSharingScope().name());
+        assertEquals(node.get("sessionToken").textValue(), session.getSessionToken());
+        assertEquals(node.get("username").textValue(), participant.getEmail());
         assertEquals(participant.getEmail(), node.get("email").textValue());
-        assertEquals("researcher", node.get("roles").get(0).textValue());
-        assertEquals("foo", node.get("dataGroups").get(0).textValue());
-        assertEquals("staging", node.get("environment").textValue());
-        assertEquals("reauthToken", node.get("reauthToken").textValue());
-        assertEquals(participant.getId(), node.get("id").textValue());
-        assertEquals(1, node.get("substudyIds").size());
-        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
+        assertEquals(node.get("roles").get(0).textValue(), "researcher");
+        assertEquals(node.get("dataGroups").get(0).textValue(), "foo");
+        assertEquals(node.get("environment").textValue(), "staging");
+        assertEquals(node.get("reauthToken").textValue(), "reauthToken");
+        assertEquals(node.get("id").textValue(), participant.getId());
+        assertEquals(node.get("substudyIds").size(), 1);
+        assertEquals(node.get("substudyIds").get(0).textValue(), "substudyA");
         assertFalse(node.get("notifyByEmail").booleanValue());
         assertNull(node.get("healthCode"));
         assertNull(node.get("encryptedHealthCode"));
-        assertEquals("externalIdA", node.get("externalIds").get("substudyA").textValue());
-        assertEquals("UserSessionInfo", node.get("type").asText());
+        assertEquals(node.get("externalIds").get("substudyA").textValue(), "externalIdA");
+        assertEquals(node.get("type").asText(), "UserSessionInfo");
         
         JsonNode consentMap = node.get("consentStatuses");
         
         JsonNode consentStatus = consentMap.get("AAA");
-        assertEquals("Consent", consentStatus.get("name").textValue());
-        assertEquals("AAA", consentStatus.get("subpopulationGuid").textValue());
+        assertEquals(consentStatus.get("name").textValue(), "Consent");
+        assertEquals(consentStatus.get("subpopulationGuid").textValue(), "AAA");
         assertTrue(consentStatus.get("required").booleanValue());
         assertTrue(consentStatus.get("consented").booleanValue());
         assertFalse(consentStatus.get("signedMostRecentConsent").booleanValue());
-        assertEquals(timestamp.toString(), consentStatus.get("signedOn").textValue());
-        assertEquals("ConsentStatus", consentStatus.get("type").textValue());
-        assertEquals(7, consentStatus.size());
+        assertEquals(consentStatus.get("signedOn").textValue(), timestamp.toString());
+        assertEquals(consentStatus.get("type").textValue(), "ConsentStatus");
+        assertEquals(consentStatus.size(), 7);
         
         // ... and no things that shouldn't be there
-        assertEquals(22, node.size());
+        assertEquals(node.size(), 22);
     }
     
     @Test
@@ -96,7 +99,7 @@ public class UserSessionInfoTest {
         JsonNode node = UserSessionInfo.toJSON(new UserSession());
         for (Iterator<String> i = node.fieldNames(); i.hasNext();) {
             String fieldName = i.next();
-            assertFalse(fieldName + " should not be null", node.get(fieldName).isNull());
+            assertFalse(node.get(fieldName).isNull(), fieldName + " should not be null");
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
@@ -62,12 +62,12 @@ public class UserSessionTest {
 
         assertTrue(newSession.isAuthenticated());
         assertNull(newSession.getReauthToken());
-        assertEquals(session.getSessionToken(), newSession.getSessionToken());
-        assertEquals(session.getInternalSessionToken(), newSession.getInternalSessionToken());
-        assertEquals(session.getEnvironment(), newSession.getEnvironment());
-        assertEquals(session.getIpAddress(), newSession.getIpAddress());
-        assertEquals(session.getStudyIdentifier(), newSession.getStudyIdentifier());
-        assertEquals(session.getParticipant(), newSession.getParticipant());
+        assertEquals(newSession.getSessionToken(), session.getSessionToken());
+        assertEquals(newSession.getInternalSessionToken(), session.getInternalSessionToken());
+        assertEquals(newSession.getEnvironment(), session.getEnvironment());
+        assertEquals(newSession.getIpAddress(), session.getIpAddress());
+        assertEquals(newSession.getStudyIdentifier(), session.getStudyIdentifier());
+        assertEquals(newSession.getParticipant(), session.getParticipant());
     }
     
     @Test
@@ -86,12 +86,12 @@ public class UserSessionTest {
                 .withHealthCode("123abc").build());
         String sessionSer = StudyParticipant.CACHE_WRITER.writeValueAsString(session);
         assertNotNull(sessionSer);
-        assertFalse("Health code should have been encrypted in the serialized string.",
-                sessionSer.toLowerCase().contains("123abc"));
+        assertFalse(sessionSer.toLowerCase().contains("123abc"),
+                "Health code should have been encrypted in the serialized string.");
         
         UserSession sessionDe = BridgeObjectMapper.get().readValue(sessionSer, UserSession.class);
         assertNotNull(sessionDe);
-        assertEquals("123abc", sessionDe.getHealthCode());
+        assertEquals(sessionDe.getHealthCode(), "123abc");
     }
     
     @Test
@@ -205,7 +205,7 @@ public class UserSessionTest {
             "'consentStatuses':{}}");
         
         UserSession session = BridgeObjectMapper.get().readValue(json, UserSession.class);
-        assertEquals(AccountStatus.ENABLED, session.getParticipant().getStatus());
-        assertEquals(Boolean.TRUE, session.getParticipant().getEmailVerified());
+        assertEquals(session.getParticipant().getStatus(), AccountStatus.ENABLED);
+        assertEquals(session.getParticipant().getEmailVerified(), Boolean.TRUE);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/WithdrawalTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/WithdrawalTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models.accounts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -19,7 +20,7 @@ public class WithdrawalTest {
     public void canSerialize() throws Exception {
         String json = "{\"reason\":\"reasons\"}";
         Withdrawal withdrawal = BridgeObjectMapper.get().readValue(json, Withdrawal.class);
-        assertEquals("reasons", withdrawal.getReason());
+        assertEquals(withdrawal.getReason(), "reasons");
         
         json = "{\"reason\":null}";
         withdrawal = BridgeObjectMapper.get().readValue(json, Withdrawal.class);

--- a/src/test/java/org/sagebionetworks/bridge/models/activities/ActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/activities/ActivityEventTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models.activities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent.Builder;
@@ -22,33 +22,34 @@ public class ActivityEventTest {
             new DynamoActivityEvent.Builder().build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("timestamp cannot be null", e.getErrors().get("timestamp").get(0));
-            assertEquals("healthCode cannot be null or blank", e.getErrors().get("healthCode").get(0));
+            assertEquals(e.getErrors().get("timestamp").get(0), "timestamp cannot be null");
+            assertEquals(e.getErrors().get("healthCode").get(0), "healthCode cannot be null or blank");
         }
         try {
             new DynamoActivityEvent.Builder().withHealthCode("BBB").build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("timestamp cannot be null", e.getErrors().get("timestamp").get(0));
+            assertEquals(e.getErrors().get("timestamp").get(0), "timestamp cannot be null");
         }
         try {
             new DynamoActivityEvent.Builder().withObjectType(ActivityEventObjectType.QUESTION).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("timestamp cannot be null", e.getErrors().get("timestamp").get(0));
-            assertEquals("healthCode cannot be null or blank", e.getErrors().get("healthCode").get(0));
+            assertEquals(e.getErrors().get("timestamp").get(0), "timestamp cannot be null");
+            assertEquals(e.getErrors().get("healthCode").get(0), "healthCode cannot be null or blank");
         }
         try {
             new DynamoActivityEvent.Builder().withTimestamp(DateTime.now()).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("healthCode cannot be null or blank", e.getErrors().get("healthCode").get(0));
+            assertEquals(e.getErrors().get("healthCode").get(0), "healthCode cannot be null or blank");
         }
         try {
             new DynamoActivityEvent.Builder().withHealthCode("BBB").withTimestamp(DateTime.now()).build();
             fail("Should have thrown an exception");
         } catch(InvalidEntityException e) {
-            assertEquals("eventId cannot be null (may be missing object or event type)", e.getErrors().get("eventId").get(0));
+            assertEquals(e.getErrors().get("eventId").get(0),
+                    "eventId cannot be null (may be missing object or event type)");
         }
         
     }
@@ -59,9 +60,9 @@ public class ActivityEventTest {
         Builder builder = new DynamoActivityEvent.Builder();
         ActivityEvent event = builder.withObjectType(ActivityEventObjectType.ENROLLMENT).withHealthCode("BBB").withTimestamp(now).build();
         
-        assertEquals("BBB", event.getHealthCode());
-        assertEquals(now, new DateTime(event.getTimestamp()));
-        assertEquals("enrollment", event.getEventId());
+        assertEquals(event.getHealthCode(), "BBB");
+        assertEquals(new DateTime(event.getTimestamp()), now);
+        assertEquals(event.getEventId(), "enrollment");
     }
     
     @Test
@@ -70,9 +71,9 @@ public class ActivityEventTest {
         Builder builder = new DynamoActivityEvent.Builder();
         ActivityEvent event = builder.withObjectType(ActivityEventObjectType.ENROLLMENT).withHealthCode("BBB").withTimestamp(now).build();
         
-        assertEquals("BBB", event.getHealthCode());
-        assertEquals(now, new DateTime(event.getTimestamp()));
-        assertEquals("enrollment", event.getEventId());
+        assertEquals(event.getHealthCode(), "BBB");
+        assertEquals(new DateTime(event.getTimestamp()), now);
+        assertEquals(event.getEventId(), "enrollment");
     }
     
     @Test
@@ -81,9 +82,9 @@ public class ActivityEventTest {
         ActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode("BBB")
                 .withObjectType(ActivityEventObjectType.ENROLLMENT).withTimestamp(now).build();
         
-        assertEquals("BBB", event.getHealthCode());
-        assertEquals(now, new DateTime(event.getTimestamp()));
-        assertEquals("enrollment", event.getEventId());
+        assertEquals(event.getHealthCode(), "BBB");
+        assertEquals(new DateTime(event.getTimestamp()), now);
+        assertEquals(event.getEventId(), "enrollment");
     }
     
     @Test
@@ -93,9 +94,9 @@ public class ActivityEventTest {
                 .withObjectType(ActivityEventObjectType.ACTIVITIES_RETRIEVED).withHealthCode("BBB").withTimestamp(now)
                 .build();
         
-        assertEquals("BBB", event.getHealthCode());
-        assertEquals(now, new DateTime(event.getTimestamp()));
-        assertEquals("activities_retrieved", event.getEventId());
+        assertEquals(event.getHealthCode(), "BBB");
+        assertEquals(new DateTime(event.getTimestamp()), now);
+        assertEquals(event.getEventId(), "activities_retrieved");
     }
 
     @Test
@@ -110,27 +111,27 @@ public class ActivityEventTest {
 
         // Convert to POJO.
         ActivityEvent activityEvent = BridgeObjectMapper.get().readValue(jsonText, ActivityEvent.class);
-        assertEquals("test-health-code", activityEvent.getHealthCode());
-        assertEquals("test-event", activityEvent.getEventId());
-        assertEquals("dummy answer", activityEvent.getAnswerValue());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-08-20T16:15:19.913Z"), activityEvent.getTimestamp()
-                .longValue());
+        assertEquals(activityEvent.getHealthCode(), "test-health-code");
+        assertEquals(activityEvent.getEventId(), "test-event");
+        assertEquals(activityEvent.getAnswerValue(), "dummy answer");
+        assertEquals(activityEvent.getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-08-20T16:15:19.913Z"));
 
         // Convert back to JSON.
         JsonNode activityNode = BridgeObjectMapper.get().convertValue(activityEvent, JsonNode.class);
-        assertEquals("test-health-code", activityNode.get("healthCode").textValue());
-        assertEquals("test-event", activityNode.get("eventId").textValue());
-        assertEquals("dummy answer", activityNode.get("answerValue").textValue());
-        assertEquals("2018-08-20T16:15:19.913Z", activityNode.get("timestamp").textValue());
-        assertEquals("ActivityEvent", activityNode.get("type").textValue());
+        assertEquals(activityNode.get("healthCode").textValue(), "test-health-code");
+        assertEquals(activityNode.get("eventId").textValue(), "test-event");
+        assertEquals(activityNode.get("answerValue").textValue(), "dummy answer");
+        assertEquals(activityNode.get("timestamp").textValue(), "2018-08-20T16:15:19.913Z");
+        assertEquals(activityNode.get("type").textValue(), "ActivityEvent");
 
         // Test activity event writer, which filters out health code.
         String filteredJsonText = ActivityEvent.ACTIVITY_EVENT_WRITER.writeValueAsString(activityEvent);
         JsonNode filteredActivityNode = BridgeObjectMapper.get().readTree(filteredJsonText);
         assertNull(filteredActivityNode.get("healthCode"));
-        assertEquals("test-event", filteredActivityNode.get("eventId").textValue());
-        assertEquals("dummy answer", filteredActivityNode.get("answerValue").textValue());
-        assertEquals("2018-08-20T16:15:19.913Z", filteredActivityNode.get("timestamp").textValue());
-        assertEquals("ActivityEvent", filteredActivityNode.get("type").textValue());
+        assertEquals(filteredActivityNode.get("eventId").textValue(), "test-event");
+        assertEquals(filteredActivityNode.get("answerValue").textValue(), "dummy answer");
+        assertEquals(filteredActivityNode.get("timestamp").textValue(), "2018-08-20T16:15:19.913Z");
+        assertEquals(filteredActivityNode.get("type").textValue(), "ActivityEvent");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.activities;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -18,7 +18,7 @@ public class CustomActivityEventRequestTest {
     public void builder() {
         CustomActivityEventRequest req = new CustomActivityEventRequest.Builder().withEventKey(EVENT_KEY)
                 .withTimestamp(EVENT_TIMESTAMP).build();
-        assertEquals(EVENT_KEY, req.getEventKey());
+        assertEquals(req.getEventKey(), EVENT_KEY);
         TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, req.getTimestamp());
     }
 
@@ -33,13 +33,13 @@ public class CustomActivityEventRequestTest {
         // Convert to POJO
         CustomActivityEventRequest req = BridgeObjectMapper.get().readValue(jsonText,
                 CustomActivityEventRequest.class);
-        assertEquals(EVENT_KEY, req.getEventKey());
+        assertEquals(req.getEventKey(), EVENT_KEY);
         TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, req.getTimestamp());
 
         // Convert back to JSON
         JsonNode node = BridgeObjectMapper.get().convertValue(req, JsonNode.class);
-        assertEquals(3, node.size());
-        assertEquals(EVENT_KEY, node.get("eventKey").textValue());
+        assertEquals(node.size(), 3);
+        assertEquals(node.get("eventKey").textValue(), EVENT_KEY);
         TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, DateTime.parse(node.get("timestamp").textValue()));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.healthdata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,8 +20,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
@@ -51,17 +51,17 @@ public class HealthDataRecordTest {
         // validate
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
 
-        assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
-        assertSame(DUMMY_DATA, record.getData());
-        assertEquals("dummy healthcode", record.getHealthCode());
+        assertEquals(record.getCreatedOn().longValue(), CREATED_ON_MILLIS);
+        assertSame(record.getData(), DUMMY_DATA);
+        assertEquals(record.getHealthCode(), "dummy healthcode");
         assertNull(record.getId());
-        assertSame(DUMMY_METADATA, record.getMetadata());
-        assertEquals("dummy schema", record.getSchemaId());
-        assertEquals(3, record.getSchemaRevision());
-        assertEquals("dummy study", record.getStudyId());
-        assertEquals(UPLOAD_DATE, record.getUploadDate());
-        assertEquals(TestConstants.USER_DATA_GROUPS, record.getUserDataGroups());
-        assertEquals(SharingScope.NO_SHARING, record.getUserSharingScope());
+        assertSame(record.getMetadata(), DUMMY_METADATA);
+        assertEquals(record.getSchemaId(), "dummy schema");
+        assertEquals(record.getSchemaRevision(), 3);
+        assertEquals(record.getStudyId(), "dummy study");
+        assertEquals(record.getUploadDate(), UPLOAD_DATE);
+        assertEquals(record.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(record.getUserSharingScope(), SharingScope.NO_SHARING);
     }
 
     @Test
@@ -87,18 +87,18 @@ public class HealthDataRecordTest {
         // validate
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
 
-        assertEquals("optional record ID", record.getId());
-        assertEquals(APP_VERSION, record.getAppVersion());
-        assertEquals("+0900", record.getCreatedOnTimeZone());
-        assertEquals(PHONE_INFO, record.getPhoneInfo());
-        assertEquals("raw.zip", record.getRawDataAttachmentId());
-        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, record.getSynapseExporterStatus());
-        assertEquals("optional upload ID", record.getUploadId());
-        assertEquals(uploadedOn, record.getUploadedOn().longValue());
-        assertEquals("optional external ID", record.getUserExternalId());
-        assertSame(DUMMY_USER_METADATA, record.getUserMetadata());
-        assertEquals("dummy validation errors", record.getValidationErrors());
-        assertEquals(42, record.getVersion().longValue());
+        assertEquals(record.getId(), "optional record ID");
+        assertEquals(record.getAppVersion(), APP_VERSION);
+        assertEquals(record.getCreatedOnTimeZone(), "+0900");
+        assertEquals(record.getPhoneInfo(), PHONE_INFO);
+        assertEquals(record.getRawDataAttachmentId(), "raw.zip");
+        assertEquals(record.getSynapseExporterStatus(), HealthDataRecord.ExporterStatus.NOT_EXPORTED);
+        assertEquals(record.getUploadId(), "optional upload ID");
+        assertEquals(record.getUploadedOn().longValue(), uploadedOn);
+        assertEquals(record.getUserExternalId(), "optional external ID");
+        assertSame(record.getUserMetadata(), DUMMY_USER_METADATA);
+        assertEquals(record.getValidationErrors(), "dummy validation errors");
+        assertEquals(record.getVersion().longValue(), 42);
     }
     
     @Test
@@ -115,7 +115,7 @@ public class HealthDataRecordTest {
         assertNull(record.getUserSubstudyMemberships());
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void jsonNullData() throws Exception {
         JsonNode data = BridgeObjectMapper.get().readTree("null");
         HealthDataRecord record = makeValidRecord();
@@ -123,7 +123,7 @@ public class HealthDataRecordTest {
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void dataIsNotMap() throws Exception {
         JsonNode data = BridgeObjectMapper.get().readTree("\"This is not a map.\"");
         HealthDataRecord record = makeValidRecord();
@@ -131,42 +131,42 @@ public class HealthDataRecordTest {
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validatorWithNullData() {
         HealthDataRecord record = makeValidRecord();
         record.setData(null);
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullHealthCode() {
         HealthDataRecord record = makeValidRecord();
         record.setHealthCode(null);
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void emptyHealthCode() {
         HealthDataRecord record = makeValidRecord();
         record.setHealthCode("");
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void emptyId() {
         HealthDataRecord record = makeValidRecord();
         record.setId("");
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validatorWithNullCreatedOn() {
         HealthDataRecord record = makeValidRecord();
         record.setCreatedOn(null);
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void jsonNullMetadata() throws Exception {
         JsonNode metadata = BridgeObjectMapper.get().readTree("null");
         HealthDataRecord record = makeValidRecord();
@@ -174,7 +174,7 @@ public class HealthDataRecordTest {
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void metadataIsNotMap() throws Exception {
         JsonNode metadata = BridgeObjectMapper.get().readTree("\"This is not a map.\"");
         HealthDataRecord record = makeValidRecord();
@@ -182,28 +182,28 @@ public class HealthDataRecordTest {
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validatorWithNullMetadata() {
         HealthDataRecord record = makeValidRecord();
         record.setMetadata(null);
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullSchemaId() {
         HealthDataRecord record = makeValidRecord();
         record.setSchemaId(null);
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void emptySchemaId() {
         HealthDataRecord record = makeValidRecord();
         record.setSchemaId("");
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validatorWithNullUploadDate() {
         HealthDataRecord record = makeValidRecord();
         record.setUploadDate(null);
@@ -301,82 +301,82 @@ public class HealthDataRecordTest {
 
         // convert to POJO
         HealthDataRecord record = BridgeObjectMapper.get().readValue(jsonText, HealthDataRecord.class);
-        assertEquals(APP_VERSION, record.getAppVersion());
-        assertEquals(measuredTimeMillis, record.getCreatedOn().longValue());
-        assertEquals("-0800", record.getCreatedOnTimeZone());
-        assertEquals("json healthcode", record.getHealthCode());
-        assertEquals("json record ID", record.getId());
-        assertEquals(PHONE_INFO, record.getPhoneInfo());
-        assertEquals("raw.zip", record.getRawDataAttachmentId());
-        assertEquals("json schema", record.getSchemaId());
-        assertEquals(3, record.getSchemaRevision());
-        assertEquals("json study", record.getStudyId());
-        assertEquals(HealthDataRecord.ExporterStatus.NOT_EXPORTED, record.getSynapseExporterStatus());
-        assertEquals("2014-02-12", record.getUploadDate().toString(ISODateTimeFormat.date()));
-        assertEquals("json upload", record.getUploadId());
-        assertEquals(uploadedOn, record.getUploadedOn().longValue());
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, record.getUserSharingScope());
-        assertEquals("ABC-123-XYZ", record.getUserExternalId());
-        assertEquals("dummy validation errors", record.getValidationErrors());
-        assertEquals(42, record.getVersion().longValue());
+        assertEquals(record.getAppVersion(), APP_VERSION);
+        assertEquals(record.getCreatedOn().longValue(), measuredTimeMillis);
+        assertEquals(record.getCreatedOnTimeZone(), "-0800");
+        assertEquals(record.getHealthCode(), "json healthcode");
+        assertEquals(record.getId(), "json record ID");
+        assertEquals(record.getPhoneInfo(), PHONE_INFO);
+        assertEquals(record.getRawDataAttachmentId(), "raw.zip");
+        assertEquals(record.getSchemaId(), "json schema");
+        assertEquals(record.getSchemaRevision(), 3);
+        assertEquals(record.getStudyId(), "json study");
+        assertEquals(record.getSynapseExporterStatus(), HealthDataRecord.ExporterStatus.NOT_EXPORTED);
+        assertEquals(record.getUploadDate().toString(ISODateTimeFormat.date()), "2014-02-12");
+        assertEquals(record.getUploadId(), "json upload");
+        assertEquals(record.getUploadedOn().longValue(), uploadedOn);
+        assertEquals(record.getUserSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        assertEquals(record.getUserExternalId(), "ABC-123-XYZ");
+        assertEquals(record.getValidationErrors(), "dummy validation errors");
+        assertEquals(record.getVersion().longValue(), 42);
 
-        assertEquals(1, record.getData().size());
-        assertEquals("myDataValue", record.getData().get("myData").textValue());
+        assertEquals(record.getData().size(), 1);
+        assertEquals(record.getData().get("myData").textValue(), "myDataValue");
 
-        assertEquals(1, record.getMetadata().size());
-        assertEquals("myMetaValue", record.getMetadata().get("myMetadata").textValue());
+        assertEquals(record.getMetadata().size(), 1);
+        assertEquals(record.getMetadata().get("myMetadata").textValue(), "myMetaValue");
 
-        assertEquals(1, record.getUserMetadata().size());
-        assertEquals("userMetaValue", record.getUserMetadata().get("userMetadata").textValue());
+        assertEquals(record.getUserMetadata().size(), 1);
+        assertEquals(record.getUserMetadata().get("userMetadata").textValue(), "userMetaValue");
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(record);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(22, jsonMap.size());
-        assertEquals(APP_VERSION, jsonMap.get("appVersion"));
-        assertEquals("-0800", jsonMap.get("createdOnTimeZone"));
-        assertEquals("json healthcode", jsonMap.get("healthCode"));
-        assertEquals("json record ID", jsonMap.get("id"));
-        assertEquals(PHONE_INFO, jsonMap.get("phoneInfo"));
-        assertEquals("raw.zip", jsonMap.get("rawDataAttachmentId"));
-        assertEquals("json schema", jsonMap.get("schemaId"));
-        assertEquals(3, jsonMap.get("schemaRevision"));
-        assertEquals("json study", jsonMap.get("studyId"));
-        assertEquals("not_exported", jsonMap.get("synapseExporterStatus"));
-        assertEquals("2014-02-12", jsonMap.get("uploadDate"));
-        assertEquals("json upload", jsonMap.get("uploadId"));
-        assertEquals(uploadedOn, DateTime.parse((String) jsonMap.get("uploadedOn")).getMillis());
-        assertEquals("all_qualified_researchers", jsonMap.get("userSharingScope"));
-        assertEquals("ABC-123-XYZ", jsonMap.get("userExternalId"));
-        assertEquals("dummy validation errors", jsonMap.get("validationErrors"));
-        assertEquals(42, jsonMap.get("version"));
-        assertEquals("HealthData", jsonMap.get("type"));
+        assertEquals(jsonMap.size(), 22);
+        assertEquals(jsonMap.get("appVersion"), APP_VERSION);
+        assertEquals(jsonMap.get("createdOnTimeZone"), "-0800");
+        assertEquals(jsonMap.get("healthCode"), "json healthcode");
+        assertEquals(jsonMap.get("id"), "json record ID");
+        assertEquals(jsonMap.get("phoneInfo"), PHONE_INFO);
+        assertEquals(jsonMap.get("rawDataAttachmentId"), "raw.zip");
+        assertEquals(jsonMap.get("schemaId"), "json schema");
+        assertEquals(jsonMap.get("schemaRevision"), 3);
+        assertEquals(jsonMap.get("studyId"), "json study");
+        assertEquals(jsonMap.get("synapseExporterStatus"), "not_exported");
+        assertEquals(jsonMap.get("uploadDate"), "2014-02-12");
+        assertEquals(jsonMap.get("uploadId"), "json upload");
+        assertEquals(DateTime.parse((String) jsonMap.get("uploadedOn")).getMillis(), uploadedOn);
+        assertEquals(jsonMap.get("userSharingScope"), "all_qualified_researchers");
+        assertEquals(jsonMap.get("userExternalId"), "ABC-123-XYZ");
+        assertEquals(jsonMap.get("validationErrors"), "dummy validation errors");
+        assertEquals(jsonMap.get("version"), 42);
+        assertEquals(jsonMap.get("type"), "HealthData");
 
         DateTime convertedMeasuredTime = DateTime.parse((String) jsonMap.get("createdOn"));
-        assertEquals(measuredTimeMillis, convertedMeasuredTime.getMillis());
+        assertEquals(convertedMeasuredTime.getMillis(), measuredTimeMillis);
 
         Map<String, String> data = (Map<String, String>) jsonMap.get("data");
-        assertEquals(1, data.size());
-        assertEquals("myDataValue", data.get("myData"));
+        assertEquals(data.size(), 1);
+        assertEquals(data.get("myData"), "myDataValue");
 
         Map<String, String> metadata = (Map<String, String>) jsonMap.get("metadata");
-        assertEquals(1, metadata.size());
-        assertEquals("myMetaValue", metadata.get("myMetadata"));
+        assertEquals(metadata.size(), 1);
+        assertEquals(metadata.get("myMetadata"), "myMetaValue");
 
         Map<String, String> userMetadata = (Map<String, String>) jsonMap.get("userMetadata");
-        assertEquals(1, userMetadata.size());
-        assertEquals("userMetaValue", userMetadata.get("userMetadata"));
+        assertEquals(userMetadata.size(), 1);
+        assertEquals(userMetadata.get("userMetadata"), "userMetaValue");
 
         // convert back to JSON with PUBLIC_RECORD_WRITER
         String publicJson = HealthDataRecord.PUBLIC_RECORD_WRITER.writeValueAsString(record);
 
         // Convert back to map again. Only validate a few key fields are present and the filtered fields are absent.
         Map<String, Object> publicJsonMap = BridgeObjectMapper.get().readValue(publicJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(21, publicJsonMap.size());
+        assertEquals(publicJsonMap.size(), 21);
         assertFalse(publicJsonMap.containsKey("healthCode"));
-        assertEquals("json record ID", publicJsonMap.get("id"));
+        assertEquals(publicJsonMap.get("id"), "json record ID");
     }
 
     @Test
@@ -400,13 +400,13 @@ public class HealthDataRecordTest {
         // The formatter only takes in DateTimes, not TimeZones. To test this, create a dummy DateTime with the given
         // TimeZone
         DateTime dateTime = new DateTime(2017, 1, 25, 2, 29, timeZone);
-        assertEquals(expected, HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime));
+        assertEquals(HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime), expected);
     }
 
     private static void testTimeZoneFormatterForString(String expected, String timeZoneStr) {
         // DateTimeZone doesn't have an API to parse an ISO timezone representation, so we have to parse an entire date
         // just to parse the timezone.
         DateTime dateTime = DateTime.parse("2017-01-25T02:29" + timeZoneStr);
-        assertEquals(expected, HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime));
+        assertEquals(HealthDataRecord.TIME_ZONE_FORMATTER.print(dateTime), expected);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmissionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/healthdata/HealthDataSubmissionTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.healthdata;
 
-import static org.junit.Assert.assertEquals;
 import static org.sagebionetworks.bridge.TestUtils.assertDatesWithTimeZoneEqual;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -45,35 +45,35 @@ public class HealthDataSubmissionTest {
         // convert to POJO
         HealthDataSubmission healthDataSubmission = BridgeObjectMapper.get().readValue(jsonText,
                 HealthDataSubmission.class);
-        assertEquals(APP_VERSION, healthDataSubmission.getAppVersion());
+        assertEquals(healthDataSubmission.getAppVersion(), APP_VERSION);
         assertDatesWithTimeZoneEqual(CREATED_ON, healthDataSubmission.getCreatedOn());
-        assertEquals(PHONE_INFO, healthDataSubmission.getPhoneInfo());
-        assertEquals(SCHEMA_ID, healthDataSubmission.getSchemaId());
-        assertEquals(SCHEMA_REV, healthDataSubmission.getSchemaRevision().intValue());
+        assertEquals(healthDataSubmission.getPhoneInfo(), PHONE_INFO);
+        assertEquals(healthDataSubmission.getSchemaId(), SCHEMA_ID);
+        assertEquals(healthDataSubmission.getSchemaRevision().intValue(), SCHEMA_REV);
         assertDatesWithTimeZoneEqual(SURVEY_CREATED_ON, healthDataSubmission.getSurveyCreatedOn());
-        assertEquals(SURVEY_GUID, healthDataSubmission.getSurveyGuid());
+        assertEquals(healthDataSubmission.getSurveyGuid(), SURVEY_GUID);
 
         JsonNode pojoData = healthDataSubmission.getData();
-        assertEquals(2, pojoData.size());
-        assertEquals("foo-value", pojoData.get("foo").textValue());
-        assertEquals(42, pojoData.get("bar").intValue());
+        assertEquals(pojoData.size(), 2);
+        assertEquals(pojoData.get("foo").textValue(), "foo-value");
+        assertEquals(pojoData.get("bar").intValue(), 42);
 
         JsonNode pojoMetadata = healthDataSubmission.getMetadata();
-        assertEquals(1, pojoMetadata.size());
-        assertEquals("sample-metadata-value", pojoMetadata.get("sample-metadata-key").textValue());
+        assertEquals(pojoMetadata.size(), 1);
+        assertEquals(pojoMetadata.get("sample-metadata-key").textValue(), "sample-metadata-value");
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(healthDataSubmission, JsonNode.class);
-        assertEquals(10, jsonNode.size());
-        assertEquals(APP_VERSION, jsonNode.get("appVersion").textValue());
+        assertEquals(jsonNode.size(), 10);
+        assertEquals(jsonNode.get("appVersion").textValue(), APP_VERSION);
         assertDatesWithTimeZoneEqual(CREATED_ON, DateTime.parse(jsonNode.get("createdOn").textValue()));
-        assertEquals(pojoData, jsonNode.get("data"));
-        assertEquals(pojoMetadata, jsonNode.get("metadata"));
-        assertEquals(PHONE_INFO, jsonNode.get("phoneInfo").textValue());
-        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
-        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
+        assertEquals(jsonNode.get("data"), pojoData);
+        assertEquals(jsonNode.get("metadata"), pojoMetadata);
+        assertEquals(jsonNode.get("phoneInfo").textValue(), PHONE_INFO);
+        assertEquals(jsonNode.get("schemaId").textValue(), SCHEMA_ID);
+        assertEquals(jsonNode.get("schemaRevision").intValue(), SCHEMA_REV);
         assertDatesWithTimeZoneEqual(SURVEY_CREATED_ON, DateTime.parse(jsonNode.get("surveyCreatedOn").textValue()));
-        assertEquals(SURVEY_GUID, jsonNode.get("surveyGuid").textValue());
-        assertEquals("HealthDataSubmission", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.get("surveyGuid").textValue(), SURVEY_GUID);
+        assertEquals(jsonNode.get("type").textValue(), "HealthDataSubmission");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/itp/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/itp/IntentToParticipateTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.models.itp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -31,51 +32,51 @@ public class IntentToParticipateTest {
                 .withOsName("iOS").withConsentSignature(consentSignature).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(itp);
-        assertEquals("studyId", node.get("studyId").textValue());
-        assertEquals(EMAIL, node.get("email").textValue());
-        assertEquals("subpopGuid", node.get("subpopGuid").textValue());
-        assertEquals("all_qualified_researchers", node.get("scope").textValue());
-        assertEquals("iPhone OS", node.get("osName").textValue());
-        assertEquals("IntentToParticipate", node.get("type").textValue());
-        assertEquals(8, node.size());
+        assertEquals(node.get("studyId").textValue(), "studyId");
+        assertEquals(node.get("email").textValue(), EMAIL);
+        assertEquals(node.get("subpopGuid").textValue(), "subpopGuid");
+        assertEquals(node.get("scope").textValue(), "all_qualified_researchers");
+        assertEquals(node.get("osName").textValue(), "iPhone OS");
+        assertEquals(node.get("type").textValue(), "IntentToParticipate");
+        assertEquals(node.size(), 8);
         
         JsonNode phoneNode = node.get("phone");
-        assertEquals(PHONE.getNumber(), phoneNode.get("number").textValue());
-        assertEquals("US", phoneNode.get("regionCode").textValue());
-        assertEquals(PHONE.getNationalFormat(), phoneNode.get("nationalFormat").textValue());
-        assertEquals("Phone", phoneNode.get("type").textValue());
-        assertEquals(4, phoneNode.size());
+        assertEquals(phoneNode.get("number").textValue(), PHONE.getNumber());
+        assertEquals(phoneNode.get("regionCode").textValue(), "US");
+        assertEquals(phoneNode.get("nationalFormat").textValue(), PHONE.getNationalFormat());
+        assertEquals(phoneNode.get("type").textValue(), "Phone");
+        assertEquals(phoneNode.size(), 4);
         
         JsonNode consentNode = node.get("consentSignature");
-        assertEquals("Consent Name", consentNode.get("name").textValue());
-        assertEquals("1980-10-10", consentNode.get("birthdate").textValue());
-        assertEquals("image-data", consentNode.get("imageData").textValue());
-        assertEquals("image/png", consentNode.get("imageMimeType").textValue());
-        assertEquals(TIMESTAMP.toString(), consentNode.get("consentCreatedOn").textValue());
-        assertEquals(TIMESTAMP.toString(), consentNode.get("signedOn").textValue());
-        assertEquals("ConsentSignature", consentNode.get("type").textValue());
-        assertEquals(7, consentNode.size());
+        assertEquals(consentNode.get("name").textValue(), "Consent Name");
+        assertEquals(consentNode.get("birthdate").textValue(), "1980-10-10");
+        assertEquals(consentNode.get("imageData").textValue(), "image-data");
+        assertEquals(consentNode.get("imageMimeType").textValue(), "image/png");
+        assertEquals(consentNode.get("consentCreatedOn").textValue(), TIMESTAMP.toString());
+        assertEquals(consentNode.get("signedOn").textValue(), TIMESTAMP.toString());
+        assertEquals(consentNode.get("type").textValue(), "ConsentSignature");
+        assertEquals(consentNode.size(), 7);
         
         IntentToParticipate deser = BridgeObjectMapper.get().readValue(node.toString(), IntentToParticipate.class);
-        assertEquals("studyId", deser.getStudyId());
-        assertEquals(PHONE.getNationalFormat(), deser.getPhone().getNationalFormat());
-        assertEquals(EMAIL, deser.getEmail());
-        assertEquals("subpopGuid", deser.getSubpopGuid());
-        assertEquals("iPhone OS", deser.getOsName());
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, deser.getScope());
+        assertEquals(deser.getStudyId(), "studyId");
+        assertEquals(deser.getPhone().getNationalFormat(), PHONE.getNationalFormat());
+        assertEquals(deser.getEmail(), EMAIL);
+        assertEquals(deser.getSubpopGuid(), "subpopGuid");
+        assertEquals(deser.getOsName(), "iPhone OS");
+        assertEquals(deser.getScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
 
         ConsentSignature consentDeser = deser.getConsentSignature();
-        assertEquals("Consent Name", consentDeser.getName());
-        assertEquals("1980-10-10", consentDeser.getBirthdate());
-        assertEquals("image-data", consentDeser.getImageData());
-        assertEquals("image/png", consentDeser.getImageMimeType());
-        assertEquals(TIMESTAMP.getMillis(), consentDeser.getConsentCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), consentDeser.getSignedOn());
+        assertEquals(consentDeser.getName(), "Consent Name");
+        assertEquals(consentDeser.getBirthdate(), "1980-10-10");
+        assertEquals(consentDeser.getImageData(), "image-data");
+        assertEquals(consentDeser.getImageMimeType(), "image/png");
+        assertEquals(consentDeser.getConsentCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(consentDeser.getSignedOn(), TIMESTAMP.getMillis());
         
         Phone deserPhone = deser.getPhone();
-        assertEquals(PHONE.getNumber(), deserPhone.getNumber());
-        assertEquals("US", deserPhone.getRegionCode());
-        assertEquals(PHONE.getNationalFormat(), deserPhone.getNationalFormat());
+        assertEquals(deserPhone.getNumber(), PHONE.getNumber());
+        assertEquals(deserPhone.getRegionCode(), "US");
+        assertEquals(deserPhone.getNationalFormat(), PHONE.getNationalFormat());
     }
     
     @Test
@@ -89,13 +90,13 @@ public class IntentToParticipateTest {
                 .withOsName("iOS").withConsentSignature(consentSignature).build();
 
         IntentToParticipate copy = new IntentToParticipate.Builder().copyOf(itp).build();
-        assertEquals(itp.getStudyId(), copy.getStudyId());
-        assertEquals(itp.getPhone().getNumber(), copy.getPhone().getNumber());
-        assertEquals(itp.getEmail(), copy.getEmail());
-        assertEquals(itp.getSubpopGuid(), copy.getSubpopGuid());
-        assertEquals(itp.getScope(), copy.getScope());
-        assertEquals(itp.getOsName(), copy.getOsName());
-        assertEquals(itp.getConsentSignature(), copy.getConsentSignature());
+        assertEquals(copy.getStudyId(), itp.getStudyId());
+        assertEquals(copy.getPhone().getNumber(), itp.getPhone().getNumber());
+        assertEquals(copy.getEmail(), itp.getEmail());
+        assertEquals(copy.getSubpopGuid(), itp.getSubpopGuid());
+        assertEquals(copy.getScope(), itp.getScope());
+        assertEquals(copy.getOsName(), itp.getOsName());
+        assertEquals(copy.getConsentSignature(), itp.getConsentSignature());
     }
     
     @Test
@@ -108,7 +109,7 @@ public class IntentToParticipateTest {
                 .withSubpopGuid("subpopGuid").withScope(SharingScope.ALL_QUALIFIED_RESEARCHERS).withOsName("iOS")
                 .withConsentSignature(consentSignature).build();
         
-        assertNotEquals(OperatingSystem.IOS, "iOS"); // iOS is a synonym...
-        assertEquals(OperatingSystem.IOS, itp.getOsName()); // ... it is translated to the standard constant.
+        assertNotEquals("iOS", OperatingSystem.IOS); // iOS is a synonym...
+        assertEquals(itp.getOsName(), OperatingSystem.IOS); // ... it is translated to the standard constant.
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/notifications/NotificationMessageTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/notifications/NotificationMessageTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.notifications;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -23,12 +23,12 @@ public class NotificationMessageTest {
         String json = TestUtils.createJson("{'subject':'The Subject','message':'The Message'}");
 
         NotificationMessage message = BridgeObjectMapper.get().readValue(json, NotificationMessage.class);
-        assertEquals("The Subject", message.getSubject());
-        assertEquals("The Message", message.getMessage());
+        assertEquals(message.getSubject(), "The Subject");
+        assertEquals(message.getMessage(), "The Message");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(message);
-        assertEquals("The Subject", node.get("subject").asText());
-        assertEquals("The Message", node.get("message").asText());
-        assertEquals("NotificationMessage", node.get("type").asText());
+        assertEquals(node.get("subject").asText(), "The Subject");
+        assertEquals(node.get("message").asText(), "The Message");
+        assertEquals(node.get("type").asText(), "NotificationMessage");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/notifications/SubscriptionRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/notifications/SubscriptionRequestTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.notifications;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -22,10 +22,10 @@ public class SubscriptionRequestTest {
         JsonNode node = BridgeObjectMapper.get().valueToTree(request);
         Set<String> serializedTopicGuids = Sets.newHashSet(node.get("topicGuids").get(0).asText(), node.get("topicGuids").get(1).asText());
         
-        assertEquals(topicGuids, serializedTopicGuids);
-        assertEquals("SubscriptionRequest", node.get("type").asText());
+        assertEquals(serializedTopicGuids, topicGuids);
+        assertEquals(node.get("type").asText(), "SubscriptionRequest");
         
         SubscriptionRequest deser = BridgeObjectMapper.get().readValue(node.toString(), SubscriptionRequest.class);
-        assertEquals(topicGuids, deser.getTopicGuids());
+        assertEquals(deser.getTopicGuids(), topicGuids);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/oauth/OAuthAccessTokenTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/oauth/OAuthAccessTokenTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.models.oauth;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -29,19 +30,19 @@ public class OAuthAccessTokenTest {
         OAuthAccessToken token = new OAuthAccessToken(VENDOR_ID, ACCESS_TOKEN, DATE_TIME, PROVIDER_USER_ID);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(token);
-        assertEquals(VENDOR_ID, node.get(VENDOR_ID).textValue());
-        assertEquals(ACCESS_TOKEN, node.get(ACCESS_TOKEN).textValue());
-        assertEquals(DATE_TIME.toString(), node.get("expiresOn").textValue());
-        assertEquals(PROVIDER_USER_ID, node.get(PROVIDER_USER_ID).textValue());
-        assertEquals(TYPE_NAME, node.get("type").textValue());
-        assertEquals(5, node.size());
+        assertEquals(node.get(VENDOR_ID).textValue(), VENDOR_ID);
+        assertEquals(node.get(ACCESS_TOKEN).textValue(), ACCESS_TOKEN);
+        assertEquals(node.get("expiresOn").textValue(), DATE_TIME.toString());
+        assertEquals(node.get(PROVIDER_USER_ID).textValue(), PROVIDER_USER_ID);
+        assertEquals(node.get("type").textValue(), TYPE_NAME);
+        assertEquals(node.size(), 5);
         
         OAuthAccessToken deser = BridgeObjectMapper.get().readValue(node.toString(), OAuthAccessToken.class);
-        assertEquals(VENDOR_ID, deser.getVendorId());
-        assertEquals(ACCESS_TOKEN, deser.getAccessToken());
-        assertEquals(DATE_TIME.toString(), deser.getExpiresOn().toString());
-        assertEquals(PROVIDER_USER_ID, deser.getProviderUserId());
+        assertEquals(deser.getVendorId(), VENDOR_ID);
+        assertEquals(deser.getAccessToken(), ACCESS_TOKEN);
+        assertEquals(deser.getExpiresOn().toString(), DATE_TIME.toString());
+        assertEquals(deser.getProviderUserId(), PROVIDER_USER_ID);
         
-        assertEquals(token, deser);
+        assertEquals(deser, token);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/oauth/OAuthAuthorizationTokenTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/oauth/OAuthAuthorizationTokenTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models.oauth;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -20,15 +21,15 @@ public class OAuthAuthorizationTokenTest {
         OAuthAuthorizationToken token = new OAuthAuthorizationToken("vendorId", "authToken");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(token);
-        assertEquals("vendorId", node.get("vendorId").textValue());
-        assertEquals("authToken", node.get("authToken").textValue());
-        assertEquals("OAuthAuthorizationToken", node.get("type").textValue());
-        assertEquals(3, node.size());
+        assertEquals(node.get("vendorId").textValue(), "vendorId");
+        assertEquals(node.get("authToken").textValue(), "authToken");
+        assertEquals(node.get("type").textValue(), "OAuthAuthorizationToken");
+        assertEquals(node.size(), 3);
         
         OAuthAuthorizationToken deser = BridgeObjectMapper.get().readValue(node.toString(), OAuthAuthorizationToken.class);
-        assertEquals("vendorId", deser.getVendorId());
-        assertEquals("authToken", deser.getAuthToken());
+        assertEquals(deser.getVendorId(), "vendorId");
+        assertEquals(deser.getAuthToken(), "authToken");
         
-        assertEquals(token, deser);
+        assertEquals(deser, token);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/reports/ReportDataKeyTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.reports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -24,11 +24,11 @@ public class ReportDataKeyTest {
         ReportDataKey key = new ReportDataKey.Builder().withHealthCode("healthCode").withStudyIdentifier(TEST_STUDY)
                 .withReportType(ReportType.PARTICIPANT).withIdentifier("report").build();
 
-        assertEquals("healthCode:report:api", key.getKeyString());
-        assertEquals("api:PARTICIPANT", key.getIndexKeyString());
-        assertEquals("healthCode", key.getHealthCode());
-        assertEquals("report", key.getIdentifier());
-        assertEquals(ReportType.PARTICIPANT, key.getReportType());
+        assertEquals(key.getKeyString(), "healthCode:report:api");
+        assertEquals(key.getIndexKeyString(), "api:PARTICIPANT");
+        assertEquals(key.getHealthCode(), "healthCode");
+        assertEquals(key.getIdentifier(), "report");
+        assertEquals(key.getReportType(), ReportType.PARTICIPANT);
     }
     
     @Test
@@ -39,11 +39,11 @@ public class ReportDataKeyTest {
         
         // This was constructed, the date is valid. It's not part of the key, it's validated in the builder
         // so validation errors are combined with key validation errors.
-        assertEquals("report:api", key.getKeyString());
-        assertEquals("api:STUDY", key.getIndexKeyString());
+        assertEquals(key.getKeyString(), "report:api");
+        assertEquals(key.getIndexKeyString(), "api:STUDY");
         assertNull(key.getHealthCode());
-        assertEquals("report", key.getIdentifier());
-        assertEquals(ReportType.STUDY, key.getReportType());
+        assertEquals(key.getIdentifier(), "report");
+        assertEquals(key.getReportType(), ReportType.STUDY);
     }
 
     @Test
@@ -51,11 +51,11 @@ public class ReportDataKeyTest {
         ReportDataKey key = new ReportDataKey.Builder().withReportType(ReportType.PARTICIPANT)
                 .withStudyIdentifier(TEST_STUDY).withHealthCode("AAA").withIdentifier("report").build();
         
-        assertEquals("AAA:report:api", key.getKeyString());
-        assertEquals("api:PARTICIPANT", key.getIndexKeyString());
-        assertEquals("AAA", key.getHealthCode());
-        assertEquals("report", key.getIdentifier());
-        assertEquals(ReportType.PARTICIPANT, key.getReportType());
+        assertEquals(key.getKeyString(), "AAA:report:api");
+        assertEquals(key.getIndexKeyString(), "api:PARTICIPANT");
+        assertEquals(key.getHealthCode(), "AAA");
+        assertEquals(key.getIdentifier(), "report");
+        assertEquals(key.getReportType(), ReportType.PARTICIPANT);
     }
     
     @Test
@@ -66,10 +66,10 @@ public class ReportDataKeyTest {
                 .withReportType(ReportType.PARTICIPANT).withIdentifier("report").build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(key);
-        assertEquals("report", node.get("identifier").asText());
-        assertEquals("participant", node.get("reportType").asText());
-        assertEquals("ReportDataKey", node.get("type").asText());
-        assertEquals(3, node.size()); // no healthCode, no studyId.
+        assertEquals(node.get("identifier").asText(), "report");
+        assertEquals(node.get("reportType").asText(), "participant");
+        assertEquals(node.get("type").asText(), "ReportDataKey");
+        assertEquals(node.size(), 3); // no healthCode, no studyId.
     }
     
     // Validator test verify the key cannot be constructed in an invalid state.

--- a/src/test/java/org/sagebionetworks/bridge/models/reports/ReportIndexTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/reports/ReportIndexTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models.reports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -21,16 +21,16 @@ public class ReportIndexTest {
         index.setSubstudyIds(TestConstants.USER_SUBSTUDY_IDS);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(index);
-        assertEquals("asdf", node.get("identifier").textValue());
-        assertEquals("ReportIndex", node.get("type").textValue());
+        assertEquals(node.get("identifier").textValue(), "asdf");
+        assertEquals(node.get("type").textValue(), "ReportIndex");
         assertTrue(node.get("public").booleanValue());
-        assertEquals("substudyA", node.get("substudyIds").get(0).textValue());
-        assertEquals("substudyB", node.get("substudyIds").get(1).textValue());
-        assertEquals(4, node.size());
+        assertEquals(node.get("substudyIds").get(0).textValue(), "substudyA");
+        assertEquals(node.get("substudyIds").get(1).textValue(), "substudyB");
+        assertEquals(node.size(), 4);
         
         ReportIndex deser = BridgeObjectMapper.get().readValue(node.toString(), ReportIndex.class);
-        assertEquals("asdf", deser.getIdentifier());
+        assertEquals(deser.getIdentifier(), "asdf");
         assertTrue(deser.isPublic());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, deser.getSubstudyIds());
+        assertEquals(deser.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategyTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.validation.Errors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
@@ -42,7 +42,7 @@ public class ABTestScheduleStrategyTest {
     private ArrayList<String> healthCodes;
     private Study study;
 
-    @Before
+    @BeforeMethod
     public void before() {
         study = TestUtils.getValidStudy(ScheduleStrategyTest.class);
         healthCodes = Lists.newArrayList();
@@ -63,10 +63,10 @@ public class ABTestScheduleStrategyTest {
         SchedulePlan plan = TestUtils.getABTestSchedulePlan(studyId);
         
         List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
-        assertEquals(3, schedules.size());
-        assertEquals("Schedule 1", schedules.get(0).getLabel());
-        assertEquals("Schedule 2", schedules.get(1).getLabel());
-        assertEquals("Schedule 3", schedules.get(2).getLabel());
+        assertEquals(schedules.size(), 3);
+        assertEquals(schedules.get(0).getLabel(), "Schedule 1");
+        assertEquals(schedules.get(1).getLabel(), "Schedule 2");
+        assertEquals(schedules.get(2).getLabel(), "Schedule 3");
         assertTrue(schedules instanceof ImmutableList);
     }
     
@@ -79,12 +79,12 @@ public class ABTestScheduleStrategyTest {
         DynamoSchedulePlan newPlan = DynamoSchedulePlan.fromJson(node);
         newPlan.setStudyKey(plan.getStudyKey()); // not serialized.
 
-        assertEquals("Plan with AB testing strategy was serialized/deserialized", plan, newPlan);
+        assertEquals(newPlan, plan, "Plan with AB testing strategy was serialized/deserialized");
 
         ABTestScheduleStrategy strategy = (ABTestScheduleStrategy) plan.getStrategy();
         ABTestScheduleStrategy newStrategy = (ABTestScheduleStrategy) newPlan.getStrategy();
-        assertEquals("Deserialized AB testing strategy is complete", strategy.getScheduleGroups().get(0).getSchedule(),
-                        newStrategy.getScheduleGroups().get(0).getSchedule());
+        assertEquals(newStrategy.getScheduleGroups().get(0).getSchedule(), strategy.getScheduleGroups().get(0).getSchedule(),
+                "Deserialized AB testing strategy is complete");
     }
 
     @Test
@@ -105,9 +105,9 @@ public class ABTestScheduleStrategyTest {
         for (Schedule schedule : schedules) {
             countsByLabel.add(schedule.getLabel());
         }
-        assertTrue("40% users assigned to A", Math.abs(countsByLabel.count("A") - 400) < 50);
-        assertTrue("40% users assigned to B", Math.abs(countsByLabel.count("B") - 400) < 50);
-        assertTrue("20% users assigned to C", Math.abs(countsByLabel.count("C") - 200) < 50);
+        assertTrue(Math.abs(countsByLabel.count("A") - 400) < 50, "40% users assigned to A");
+        assertTrue(Math.abs(countsByLabel.count("B") - 400) < 50, "40% users assigned to B");
+        assertTrue(Math.abs(countsByLabel.count("C") - 200) < 50, "20% users assigned to C");
     }
     
     @Test
@@ -124,9 +124,9 @@ public class ABTestScheduleStrategyTest {
         Map<String,List<String>> map = Validate.convertErrorsToSimpleMap(errors);
         
         List<String> errorMessages = map.get("scheduleGroups");
-        assertEquals("scheduleGroups groups must add up to 100%", errorMessages.get(0));
+        assertEquals(errorMessages.get(0), "scheduleGroups groups must add up to 100%");
         errorMessages = map.get("scheduleGroups[0].schedule.expires");
-        assertEquals("scheduleGroups[0].schedule.expires must be set if schedule repeats", errorMessages.get(0));
+        assertEquals(errorMessages.get(0), "scheduleGroups[0].schedule.expires must be set if schedule repeats");
     }
     
     private DynamoSchedulePlan createABSchedulePlan() {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asLong;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
@@ -20,9 +20,9 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
@@ -49,8 +49,7 @@ public class ActivitySchedulerTest {
     private Map<String,DateTime> events;
     private DynamoSchedulePlan plan = new DynamoSchedulePlan();
     
-    
-    @Before
+    @BeforeMethod
     public void before() {
         plan.setGuid("BBB");
         
@@ -63,7 +62,7 @@ public class ActivitySchedulerTest {
         events.put("survey:event", ENROLLMENT.plusDays(2));
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -84,14 +83,14 @@ public class ActivitySchedulerTest {
             .withEndsOn(NOW.plusWeeks(1))
             .withEvents(empty).build();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         context = new ScheduleContext.Builder()
             .withStudyIdentifier(TEST_STUDY)
             .withInitialTimeZone(PST)
             .withEndsOn(NOW.plusWeeks(1)).build();
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     
     @Test
@@ -106,13 +105,13 @@ public class ActivitySchedulerTest {
         DynamoScheduledActivity schActivity = (DynamoScheduledActivity)scheduledActivities.get(0);
 
         assertNotNull(schActivity.getGuid());
-        assertEquals("Activity3", schActivity.getActivity().getLabel());
-        assertEquals("BBB", schActivity.getSchedulePlanGuid());
+        assertEquals(schActivity.getActivity().getLabel(), "Activity3");
+        assertEquals(schActivity.getSchedulePlanGuid(), "BBB");
         assertNotNull(schActivity.getScheduledOn());
         assertNotNull(schActivity.getExpiresOn());
-        assertEquals("healthCode", schActivity.getHealthCode());
-        assertEquals(PST, schActivity.getTimeZone());
-        assertEquals("tapTest:task:2015-03-23T03:00:00.000", schActivity.getReferentGuid());
+        assertEquals(schActivity.getHealthCode(), "healthCode");
+        assertEquals(schActivity.getTimeZone(), PST);
+        assertEquals(schActivity.getReferentGuid(), "tapTest:task:2015-03-23T03:00:00.000");
     }
     
     /**
@@ -133,10 +132,10 @@ public class ActivitySchedulerTest {
         schedule2.setEventId("task:task1");
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
-        assertEquals(asLong("2015-04-23 10:00"), scheduledActivities.get(0).getScheduledOn().getMillis());
+        assertEquals(scheduledActivities.get(0).getScheduledOn().getMillis(), asLong("2015-04-23 10:00"));
 
         scheduledActivities = schedule2.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         DateTime activity1Event = asDT("2015-04-25 15:32", PST);
         
@@ -145,7 +144,7 @@ public class ActivitySchedulerTest {
         
         // One-time tasks without times specified continue to schedule at midnight.
         scheduledActivities = schedule2.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(2)));
-        assertEquals(activity1Event, scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), activity1Event);
     }
     
     @Test
@@ -161,12 +160,12 @@ public class ActivitySchedulerTest {
         events.put("foo", DateTime.parse("2015-03-25T07:00:00.000-07:00"));
         DateTimeZone zone = DateTimeZone.forOffsetHours(-7);
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(zone, NOW.plusMonths(1)));
-        assertEquals(DateTime.parse("2015-03-27T07:00:00.000-07:00"), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), DateTime.parse("2015-03-27T07:00:00.000-07:00"));
         
         // Add an endsOn value in GMT, it shouldn't matter, it'll prevent event from firing
         schedule.setEndsOn("2015-03-25T13:00:00.000-07:00"); // one hour before the event
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     
     @Test
@@ -215,8 +214,8 @@ public class ActivitySchedulerTest {
         schedule.setScheduleType(ONCE);
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(7)));
-        assertEquals(2, scheduledActivities.size());
-        assertNotEquals(scheduledActivities.get(0), scheduledActivities.get(1));
+        assertEquals(scheduledActivities.size(), 2);
+        assertNotEquals(scheduledActivities.get(1), scheduledActivities.get(0));
     }
     
     /**
@@ -233,11 +232,11 @@ public class ActivitySchedulerTest {
         
         events.put("scheduledOn:task:foo", NOW.minusHours(3));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(NOW.minusHours(3), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), NOW.minusHours(3));
 
         events.put("scheduledOn:task:foo", NOW.plusHours(8));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(NOW.plusHours(8), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), NOW.plusHours(8));
     }
     
     @Test
@@ -248,18 +247,18 @@ public class ActivitySchedulerTest {
         schedule.setScheduleType(ONCE);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(1, scheduledActivities.size());
-        assertEquals(ENROLLMENT.plusDays(2).withZone(PST), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.size(), 1);
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), ENROLLMENT.plusDays(2).withZone(PST));
 
         events.remove("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(1, scheduledActivities.size());
-        assertEquals(ENROLLMENT.withZone(PST), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.size(), 1);
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), ENROLLMENT.withZone(PST));
         
         // BUT this produces nothing because the system doesn't fallback to enrollment if an event has been set
         schedule.setEventId("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     
     @Test
@@ -273,18 +272,18 @@ public class ActivitySchedulerTest {
         schedule.addTimes(localTime);
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(1, scheduledActivities.size());
-        assertEquals(ENROLLMENT.withTime(localTime).plusDays(2).withZoneRetainFields(PST), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.size(), 1);
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), ENROLLMENT.withTime(localTime).plusDays(2).withZoneRetainFields(PST));
 
         events.remove("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(1, scheduledActivities.size());
-        assertEquals(ENROLLMENT.withZone(PST).withTime(localTime), scheduledActivities.get(0).getScheduledOn());
+        assertEquals(scheduledActivities.size(), 1);
+        assertEquals(scheduledActivities.get(0).getScheduledOn(), ENROLLMENT.withZone(PST).withTime(localTime));
         
         // BUT this produces nothing because the system doesn't fallback to enrollment if an event has been set
         schedule.setEventId("survey:event");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
 
     // branch coverage
@@ -310,12 +309,12 @@ public class ActivitySchedulerTest {
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(NOW.plusDays(1)));
         ScheduledActivity activity1 = scheduledActivities.get(0);
-        assertEquals("Foo", activity1.getActivity().getLabel());
+        assertEquals(activity1.getActivity().getLabel(), "Foo");
         assertTrue(activity1.getPersistent());
         assertTrue(activity1.getActivity().isPersistentlyRescheduledBy(schedule));
         
         ScheduledActivity activity2 = scheduledActivities.get(1);
-        assertEquals("Bar", activity2.getActivity().getLabel());
+        assertEquals(activity2.getActivity().getLabel(), "Bar");
         assertFalse(activity2.getPersistent());
         assertFalse(activity2.getActivity().isPersistentlyRescheduledBy(schedule));
         
@@ -345,14 +344,14 @@ public class ActivitySchedulerTest {
         // User is in Moscow, however.
         DateTimeZone zone = DateTimeZone.forOffsetHours(3);
         List<ScheduledActivity> activities = schedule.getScheduler().getScheduledActivities(plan, getContext(zone, NOW.withZone(zone).plusDays(1)));
-        assertEquals("2015-03-26T10:00:00.000+03:00", activities.get(0).getScheduledOn().toString());
-        assertEquals("2015-03-27T10:00:00.000+03:00", activities.get(1).getScheduledOn().toString());
+        assertEquals(activities.get(0).getScheduledOn().toString(), "2015-03-26T10:00:00.000+03:00");
+        assertEquals(activities.get(1).getScheduledOn().toString(), "2015-03-27T10:00:00.000+03:00");
         
         // Now the user flies across the planet, and retrieves the tasks again, they are in the new timezone
         zone = DateTimeZone.forOffsetHours(-7);
         activities = schedule.getScheduler().getScheduledActivities(plan, getContext(zone, NOW.withZone(zone).plusDays(1)));
-        assertEquals("2015-03-26T10:00:00.000-07:00", activities.get(0).getScheduledOn().toString());
-        assertEquals("2015-03-27T10:00:00.000-07:00", activities.get(1).getScheduledOn().toString());
+        assertEquals(activities.get(0).getScheduledOn().toString(), "2015-03-26T10:00:00.000-07:00");
+        assertEquals(activities.get(1).getScheduledOn().toString(), "2015-03-27T10:00:00.000-07:00");
     }
     
     @Test
@@ -370,10 +369,10 @@ public class ActivitySchedulerTest {
         Set<String> allGuids = Sets.newHashSet();
         for (ScheduledActivity schActivity : activities) {
             String activityGuidInScheduledActivity = schActivity.getGuid().split(":")[0];
-            assertEquals(schActivity.getActivity().getGuid(), activityGuidInScheduledActivity);
+            assertEquals(activityGuidInScheduledActivity, schActivity.getActivity().getGuid());
             allGuids.add(schActivity.getGuid());
         }
-        assertEquals(activities.size(), allGuids.size());
+        assertEquals(allGuids.size(), activities.size());
     }
     
     @Test
@@ -416,7 +415,7 @@ public class ActivitySchedulerTest {
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, noMinContext);
 
         // There are none on the monthly schedule
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         // Adjust this to have a minimum of 4
         ScheduleContext context = new ScheduleContext.Builder()
@@ -424,9 +423,9 @@ public class ActivitySchedulerTest {
                 .withMinimumPerSchedule(4).build();
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
-        assertEquals(4, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 4);
         for (int i=0; i < 4; i++) {
-            assertEquals(dates.get(i), scheduledActivities.get(i).getScheduledOn().toString());    
+            assertEquals(scheduledActivities.get(i).getScheduledOn().toString(), dates.get(i));    
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivityTest.java
@@ -1,15 +1,17 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -37,19 +39,19 @@ public class ActivityTest {
 
         // convert to POJO
         Activity activity = BridgeObjectMapper.get().readValue(jsonText, Activity.class);
-        assertEquals("My Activity", activity.getLabel());
-        assertEquals("Description of activity", activity.getLabelDetail());
-        assertEquals("test-guid", activity.getGuid());
-        assertEquals("combo-activity", activity.getCompoundActivity().getTaskIdentifier());
+        assertEquals(activity.getLabel(), "My Activity");
+        assertEquals(activity.getLabelDetail(), "Description of activity");
+        assertEquals(activity.getGuid(), "test-guid");
+        assertEquals(activity.getCompoundActivity().getTaskIdentifier(), "combo-activity");
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(activity, JsonNode.class);
-        assertEquals("My Activity", jsonNode.get("label").textValue());
-        assertEquals("Description of activity", jsonNode.get("labelDetail").textValue());
-        assertEquals("test-guid", jsonNode.get("guid").textValue());
-        assertEquals("combo-activity", jsonNode.get("compoundActivity").get("taskIdentifier").textValue());
-        assertEquals("compound", jsonNode.get("activityType").textValue());
-        assertEquals("Activity", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.get("label").textValue(), "My Activity");
+        assertEquals(jsonNode.get("labelDetail").textValue(), "Description of activity");
+        assertEquals(jsonNode.get("guid").textValue(), "test-guid");
+        assertEquals(jsonNode.get("compoundActivity").get("taskIdentifier").textValue(), "combo-activity");
+        assertEquals(jsonNode.get("activityType").textValue(), "compound");
+        assertEquals(jsonNode.get("type").textValue(), "Activity");
     }
 
     @Test
@@ -61,22 +63,22 @@ public class ActivityTest {
         String json = mapper.writeValueAsString(activity);
         
         JsonNode node = mapper.readTree(json);
-        assertEquals("Label", node.get("label").asText());
-        assertEquals("Label Detail", node.get("labelDetail").asText());
-        assertEquals("task", node.get("activityType").asText());
-        assertEquals("taskId", node.get("task").get("identifier").asText());
-        assertEquals("actGuid", node.get("guid").asText());
-        assertEquals("Activity", node.get("type").asText());
+        assertEquals(node.get("label").asText(), "Label");
+        assertEquals(node.get("labelDetail").asText(), "Label Detail");
+        assertEquals(node.get("activityType").asText(), "task");
+        assertEquals(node.get("task").get("identifier").asText(), "taskId");
+        assertEquals(node.get("guid").asText(), "actGuid");
+        assertEquals(node.get("type").asText(), "Activity");
         
         JsonNode taskRef = node.get("task");
-        assertEquals("taskId", taskRef.get("identifier").asText());
-        assertEquals("TaskReference", taskRef.get("type").asText());
+        assertEquals(taskRef.get("identifier").asText(), "taskId");
+        assertEquals(taskRef.get("type").asText(), "TaskReference");
         
         activity = mapper.readValue(json, Activity.class);
-        assertEquals("Label", activity.getLabel());
-        assertEquals("Label Detail", activity.getLabelDetail());
-        assertEquals(ActivityType.TASK, activity.getActivityType());
-        assertEquals("taskId", activity.getTask().getIdentifier());
+        assertEquals(activity.getLabel(), "Label");
+        assertEquals(activity.getLabelDetail(), "Label Detail");
+        assertEquals(activity.getActivityType(), ActivityType.TASK);
+        assertEquals(activity.getTask().getIdentifier(), "taskId");
     }
     
     @Test
@@ -89,31 +91,31 @@ public class ActivityTest {
         String json = mapper.writeValueAsString(activity);
         
         JsonNode node = mapper.readTree(json);
-        assertEquals("Label", node.get("label").asText());
-        assertEquals("Label Detail", node.get("labelDetail").asText());
-        assertEquals("survey", node.get("activityType").asText());
+        assertEquals(node.get("label").asText(), "Label");
+        assertEquals(node.get("labelDetail").asText(), "Label Detail");
+        assertEquals(node.get("activityType").asText(), "survey");
         String hrefString = node.get("survey").get("href").asText();
         assertTrue(hrefString.matches("http[s]?://.*/v3/surveys/guid/revisions/2015-01-01T10:10:10.000Z"));
-        assertEquals("actGuid", node.get("guid").asText());
-        assertEquals("Activity", node.get("type").asText());
+        assertEquals(node.get("guid").asText(), "actGuid");
+        assertEquals(node.get("type").asText(), "Activity");
         
         JsonNode ref = node.get("survey");
-        assertEquals("identifier", ref.get("identifier").asText());
-        assertEquals("guid", ref.get("guid").asText());
-        assertEquals("2015-01-01T10:10:10.000Z", ref.get("createdOn").asText());
+        assertEquals(ref.get("identifier").asText(), "identifier");
+        assertEquals(ref.get("guid").asText(), "guid");
+        assertEquals(ref.get("createdOn").asText(), "2015-01-01T10:10:10.000Z");
         String href = ref.get("href").asText();
         assertTrue(href.matches("http[s]?://.*/v3/surveys/guid/revisions/2015-01-01T10:10:10.000Z"));
-        assertEquals("SurveyReference", ref.get("type").asText());
+        assertEquals(ref.get("type").asText(), "SurveyReference");
         
         activity = mapper.readValue(json, Activity.class);
-        assertEquals("Label", activity.getLabel());
-        assertEquals("Label Detail", activity.getLabelDetail());
-        assertEquals(ActivityType.SURVEY, activity.getActivityType());
+        assertEquals(activity.getLabel(), "Label");
+        assertEquals(activity.getLabelDetail(), "Label Detail");
+        assertEquals(activity.getActivityType(), ActivityType.SURVEY);
         
         SurveyReference ref1 = activity.getSurvey();
-        assertEquals("identifier", ref1.getIdentifier());
-        assertEquals(DateTime.parse("2015-01-01T10:10:10.000Z"), ref1.getCreatedOn());
-        assertEquals("guid", ref1.getGuid());
+        assertEquals(ref1.getIdentifier(), "identifier");
+        assertEquals(ref1.getCreatedOn(), DateTime.parse("2015-01-01T10:10:10.000Z"));
+        assertEquals(ref1.getGuid(), "guid");
         assertTrue(ref1.getHref().matches("http[s]?://.*/v3/surveys/guid/revisions/2015-01-01T10:10:10.000Z"));
     }
     
@@ -126,30 +128,30 @@ public class ActivityTest {
         String json = mapper.writeValueAsString(activity);
 
         JsonNode node = mapper.readTree(json);
-        assertEquals("Label", node.get("label").asText());
-        assertEquals("Label Detail", node.get("labelDetail").asText());
-        assertEquals("survey", node.get("activityType").asText());
+        assertEquals(node.get("label").asText(), "Label");
+        assertEquals(node.get("labelDetail").asText(), "Label Detail");
+        assertEquals(node.get("activityType").asText(), "survey");
         String hrefString = node.get("survey").get("href").asText();
         assertTrue(hrefString.matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        assertEquals("actGuid", node.get("guid").asText());
-        assertEquals("Activity", node.get("type").asText());
+        assertEquals(node.get("guid").asText(), "actGuid");
+        assertEquals(node.get("type").asText(), "Activity");
         
         JsonNode ref = node.get("survey");
-        assertEquals("identifier", ref.get("identifier").asText());
-        assertEquals("guid", ref.get("guid").asText());
+        assertEquals(ref.get("identifier").asText(), "identifier");
+        assertEquals(ref.get("guid").asText(), "guid");
         String href = ref.get("href").asText();
         assertTrue(href.matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
-        assertEquals("SurveyReference", ref.get("type").asText());
+        assertEquals(ref.get("type").asText(), "SurveyReference");
         
         activity = mapper.readValue(json, Activity.class);
-        assertEquals("Label", activity.getLabel());
-        assertEquals("Label Detail", activity.getLabelDetail());
-        assertEquals(ActivityType.SURVEY, activity.getActivityType());
+        assertEquals(activity.getLabel(), "Label");
+        assertEquals(activity.getLabelDetail(), "Label Detail");
+        assertEquals(activity.getActivityType(), ActivityType.SURVEY);
         
         SurveyReference ref1 = activity.getSurvey();
-        assertEquals("identifier", ref1.getIdentifier());
-        assertNull("createdOn", ref1.getCreatedOn());
-        assertEquals("guid", ref1.getGuid());
+        assertEquals(ref1.getIdentifier(), "identifier");
+        assertNull(ref1.getCreatedOn(), "createdOn");
+        assertEquals(ref1.getGuid(), "guid");
         assertTrue(ref1.getHref().matches("http[s]?://.*/v3/surveys/guid/revisions/published"));
     }
     
@@ -160,13 +162,13 @@ public class ActivityTest {
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         Activity activity = mapper.readValue(oldJson, Activity.class);
         
-        assertEquals("Personal Health Survey", activity.getLabel());
-        assertEquals(ActivityType.SURVEY, activity.getActivityType());
+        assertEquals(activity.getLabel(), "Personal Health Survey");
+        assertEquals(activity.getActivityType(), ActivityType.SURVEY);
         
         SurveyReference ref = activity.getSurvey();
-        assertEquals("identifier", ref.getIdentifier());
-        assertNull("createdOn null", ref.getCreatedOn());
-        assertEquals("guid set", "ac1e57fd-5e8e-473f-b82f-bac7547b6783", ref.getGuid());
+        assertEquals(ref.getIdentifier(), "identifier");
+        assertNull(ref.getCreatedOn(), "createdOn null");
+        assertEquals(ref.getGuid(), "ac1e57fd-5e8e-473f-b82f-bac7547b6783", "guid set");
         assertTrue(ref.getHref().matches("http[s]?://.*/v3/surveys/ac1e57fd-5e8e-473f-b82f-bac7547b6783/revisions/published"));
     }
     
@@ -177,7 +179,7 @@ public class ActivityTest {
         BridgeObjectMapper mapper = BridgeObjectMapper.get();
         Activity activity = mapper.readValue(oldJson, Activity.class);
         
-        assertNotEquals("junk", activity.getSurvey().getHref());
+        assertNotEquals(activity.getSurvey().getHref(), "junk");
     }
     
     @Test
@@ -192,7 +194,7 @@ public class ActivityTest {
         String activityJSON = "{\"label\":\"Label\",\"guid\":\"AAA\",\"task\":{\"identifier\":\"task\",\"type\":\"TaskReference\"},\"activityType\":\"task\",\"ref\":\"task\",\"type\":\"Activity\"}";
         
         Activity activity = BridgeObjectMapper.get().readValue(activityJSON, Activity.class);
-        assertEquals("AAA", activity.getGuid());
+        assertEquals(activity.getGuid(), "AAA");
     }
     
     /**
@@ -229,12 +231,12 @@ public class ActivityTest {
                 .build();
         Activity activity = new Activity.Builder().withLabel("My Label").withLabelDetail("My Label Detail")
                 .withGuid("AAA").withCompoundActivity(compoundActivity).build();
-        assertEquals("My Label", activity.getLabel());
-        assertEquals("My Label Detail", activity.getLabelDetail());
-        assertEquals("AAA", activity.getGuid());
-        assertEquals(compoundActivity, activity.getCompoundActivity());
-        assertEquals(ActivityType.COMPOUND, activity.getActivityType());
-        assertEquals("compound:combo-activity:finished", activity.getSelfFinishedEventId());
+        assertEquals(activity.getLabel(), "My Label");
+        assertEquals(activity.getLabelDetail(), "My Label Detail");
+        assertEquals(activity.getGuid(), "AAA");
+        assertEquals(activity.getCompoundActivity(), compoundActivity);
+        assertEquals(activity.getActivityType(), ActivityType.COMPOUND);
+        assertEquals(activity.getSelfFinishedEventId(), "compound:combo-activity:finished");
 
         // toString() gives a lot of stuff and depends on two other classes. To make the tests robust and resilient to
         // changes in encapsulated classes, just test a few keywords
@@ -247,16 +249,16 @@ public class ActivityTest {
 
         // test copy constructor
         Activity copy = new Activity.Builder().withActivity(activity).build();
-        assertEquals(activity, copy);
+        assertEquals(copy, activity);
     }
 
     @Test
     public void taskActivityByRef() {
         TaskReference task = new TaskReference("my-task", null);
         Activity activity = new Activity.Builder().withTask(task).build();
-        assertEquals(task, activity.getTask());
-        assertEquals(ActivityType.TASK, activity.getActivityType());
-        assertEquals("task:my-task:finished", activity.getSelfFinishedEventId());
+        assertEquals(activity.getTask(), task);
+        assertEquals(activity.getActivityType(), ActivityType.TASK);
+        assertEquals(activity.getSelfFinishedEventId(), "task:my-task:finished");
 
         String activityString = activity.toString();
         assertTrue(activityString.contains("my-task"));
@@ -264,23 +266,23 @@ public class ActivityTest {
 
         // test copy constructor
         Activity copy = new Activity.Builder().withActivity(activity).build();
-        assertEquals(activity, copy);
+        assertEquals(copy, activity);
     }
 
     @Test
     public void taskActivityById() {
         // This is already mostly tested above. Just test passing in task ID sets the task correctly.
         Activity activity = new Activity.Builder().withTask("my-task").build();
-        assertEquals(new TaskReference("my-task", null), activity.getTask());
+        assertEquals(activity.getTask(), new TaskReference("my-task", null));
     }
 
     @Test
     public void surveyActivityByRef() {
         SurveyReference survey = new SurveyReference("my-survey", "BBB", null);
         Activity activity = new Activity.Builder().withSurvey(survey).build();
-        assertEquals(survey, activity.getSurvey());
-        assertEquals(ActivityType.SURVEY, activity.getActivityType());
-        assertEquals("survey:BBB:finished", activity.getSelfFinishedEventId());
+        assertEquals(activity.getSurvey(), survey);
+        assertEquals(activity.getActivityType(), ActivityType.SURVEY);
+        assertEquals(activity.getSelfFinishedEventId(), "survey:BBB:finished");
 
         String activityString = activity.toString();
         assertTrue(activityString.contains("my-survey"));
@@ -289,7 +291,7 @@ public class ActivityTest {
 
         // test copy constructor
         Activity copy = new Activity.Builder().withActivity(activity).build();
-        assertEquals(activity, copy);
+        assertEquals(copy, activity);
     }
 
     @Test
@@ -297,13 +299,13 @@ public class ActivityTest {
         // most of this tested above
         DateTime createdOn = DateTime.now();
         Activity activity = new Activity.Builder().withSurvey("my-survey", "BBB", createdOn).build();
-        assertEquals(new SurveyReference("my-survey", "BBB", createdOn), activity.getSurvey());
+        assertEquals(activity.getSurvey(), new SurveyReference("my-survey", "BBB", createdOn));
     }
 
     @Test
     public void publishedSurveyActivity() {
         // most of this tested above
         Activity activity = new Activity.Builder().withPublishedSurvey("my-published-survey", "CCC").build();
-        assertEquals(new SurveyReference("my-published-survey", "CCC", null), activity.getSurvey());
+        assertEquals(activity.getSurvey(), new SurveyReference("my-published-survey", "CCC", null));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivityTypeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivityTypeTest.java
@@ -1,17 +1,17 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class ActivityTypeTest {
 
     @Test
     public void fromPlural() {
-        assertEquals(ActivityType.TASK, ActivityType.fromPlural("tasks"));
-        assertEquals(ActivityType.SURVEY, ActivityType.fromPlural("surveys"));
-        assertEquals(ActivityType.COMPOUND, ActivityType.fromPlural("compoundactivities"));
+        assertEquals(ActivityType.fromPlural("tasks"), ActivityType.TASK);
+        assertEquals(ActivityType.fromPlural("surveys"), ActivityType.SURVEY);
+        assertEquals(ActivityType.fromPlural("compoundactivities"), ActivityType.COMPOUND);
         assertNull(ActivityType.fromPlural("somenonsense"));
         assertNull(ActivityType.fromPlural(""));
         assertNull(ActivityType.fromPlural(null));

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/CompoundActivityTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/CompoundActivityTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -41,9 +41,9 @@ public class CompoundActivityTest {
 
         CompoundActivity compoundActivity = new CompoundActivity.Builder().withSchemaList(inputSchemaList)
                 .withSurveyList(inputSurveyList).withTaskIdentifier("combo-activity").build();
-        assertEquals(expectedSchemaList, compoundActivity.getSchemaList());
-        assertEquals(expectedSurveyList, compoundActivity.getSurveyList());
-        assertEquals("combo-activity", compoundActivity.getTaskIdentifier());
+        assertEquals(compoundActivity.getSchemaList(), expectedSchemaList);
+        assertEquals(compoundActivity.getSurveyList(), expectedSurveyList);
+        assertEquals(compoundActivity.getTaskIdentifier(), "combo-activity");
 
         // toString() gives a lot of stuff and depends on two other classes. To make the tests robust and resilient to
         // changes in encapsulated classes, just test a few keywords
@@ -56,10 +56,10 @@ public class CompoundActivityTest {
 
         // modify original lists to verify we have a defensive copy
         inputSchemaList.add(new SchemaReference("third-schema", 4));
-        assertEquals(expectedSchemaList, compoundActivity.getSchemaList());
+        assertEquals(compoundActivity.getSchemaList(), expectedSchemaList);
 
         inputSurveyList.add(new SurveyReference("third-survey", "third-survey-guid", null));
-        assertEquals(expectedSurveyList, compoundActivity.getSurveyList());
+        assertEquals(compoundActivity.getSurveyList(), expectedSurveyList);
 
         // attempt to modify output list to verify immutability
         try {
@@ -78,7 +78,7 @@ public class CompoundActivityTest {
 
         // test copy constructor
         CompoundActivity copy = new CompoundActivity.Builder().copyOf(compoundActivity).build();
-        assertEquals(compoundActivity, copy);
+        assertEquals(copy, compoundActivity);
     }
 
     @Test
@@ -169,31 +169,31 @@ public class CompoundActivityTest {
 
         // convert to POJO
         CompoundActivity compoundActivity = BridgeObjectMapper.get().readValue(jsonText, CompoundActivity.class);
-        assertEquals("json-activity", compoundActivity.getTaskIdentifier());
+        assertEquals(compoundActivity.getTaskIdentifier(), "json-activity");
 
         List<SchemaReference> outputSchemaList = compoundActivity.getSchemaList();
-        assertEquals(2, outputSchemaList.size());
-        assertEquals(fooSchema, outputSchemaList.get(0));
-        assertEquals(barSchema, outputSchemaList.get(1));
+        assertEquals(outputSchemaList.size(), 2);
+        assertEquals(outputSchemaList.get(0), fooSchema);
+        assertEquals(outputSchemaList.get(1), barSchema);
 
         List<SurveyReference> outputSurveyList = compoundActivity.getSurveyList();
-        assertEquals(2, outputSurveyList.size());
-        assertEquals(asdfSurvey, outputSurveyList.get(0));
-        assertEquals(jklSurvey, outputSurveyList.get(1));
+        assertEquals(outputSurveyList.size(), 2);
+        assertEquals(outputSurveyList.get(0), asdfSurvey);
+        assertEquals(outputSurveyList.get(1), jklSurvey);
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(compoundActivity, JsonNode.class);
-        assertEquals(4, jsonNode.size());
-        assertEquals("json-activity", jsonNode.get("taskIdentifier").textValue());
-        assertEquals("CompoundActivity", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 4);
+        assertEquals(jsonNode.get("taskIdentifier").textValue(), "json-activity");
+        assertEquals(jsonNode.get("type").textValue(), "CompoundActivity");
 
         // For the lists, this is already tested by the encapsulated classes. Just verify that we have a list of the
         // right size.
         assertTrue(jsonNode.get("schemaList").isArray());
-        assertEquals(2, jsonNode.get("schemaList").size());
+        assertEquals(jsonNode.get("schemaList").size(), 2);
 
         assertTrue(jsonNode.get("surveyList").isArray());
-        assertEquals(2, jsonNode.get("surveyList").size());
+        assertEquals(jsonNode.get("surveyList").size(), 2);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ConfigReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ConfigReferenceTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -21,8 +22,8 @@ public class ConfigReferenceTest {
     @Test
     public void normalCase() {
         ConfigReference configRef = new ConfigReference("config1", 7L);
-        assertEquals("config1", configRef.getId());
-        assertEquals(7, configRef.getRevision().intValue());
+        assertEquals(configRef.getId(), "config1");
+        assertEquals(configRef.getRevision().intValue(), 7);
     }
 
     @Test
@@ -39,14 +40,14 @@ public class ConfigReferenceTest {
 
         // convert to POJO
         ConfigReference configRef = BridgeObjectMapper.get().readValue(jsonText, ConfigReference.class);
-        assertEquals("test-config", configRef.getId());
-        assertEquals(7L, configRef.getRevision().longValue());
+        assertEquals(configRef.getId(), "test-config");
+        assertEquals(configRef.getRevision().longValue(), 7L);
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(configRef, JsonNode.class);
-        assertEquals(3, jsonNode.size());
-        assertEquals("test-config", jsonNode.get("id").textValue());
-        assertEquals(7, jsonNode.get("revision").longValue());
-        assertEquals("ConfigReference", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 3);
+        assertEquals(jsonNode.get("id").textValue(), "test-config");
+        assertEquals(jsonNode.get("revision").longValue(), 7);
+        assertEquals(jsonNode.get("type").textValue(), "ConfigReference");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/CriteriaScheduleStrategyTest.java
@@ -1,17 +1,17 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -60,7 +60,7 @@ public class CriteriaScheduleStrategyTest {
     
     private CriteriaScheduleStrategy strategy;
     
-    @Before
+    @BeforeMethod
     public void before() {
         strategy = new CriteriaScheduleStrategy();
         PLAN.setStrategy(strategy);
@@ -81,19 +81,19 @@ public class CriteriaScheduleStrategyTest {
         String json = mapper.writeValueAsString(strategy);
         JsonNode node = mapper.readTree(json);
 
-        assertEquals("CriteriaScheduleStrategy", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "CriteriaScheduleStrategy");
         assertNotNull(node.get("scheduleCriteria"));
         
         ArrayNode array = (ArrayNode)node.get("scheduleCriteria");
         JsonNode schCriteria1 = array.get(0);
-        assertEquals("ScheduleCriteria", schCriteria1.get("type").asText());
+        assertEquals(schCriteria1.get("type").asText(), "ScheduleCriteria");
         
         JsonNode criteriaNode = schCriteria1.get("criteria");
         
         JsonNode minVersionsNode = criteriaNode.get("minAppVersions");
-        assertEquals(4, minVersionsNode.get(OperatingSystem.IOS).asInt());
+        assertEquals(minVersionsNode.get(OperatingSystem.IOS).asInt(), 4);
         JsonNode maxVersionsNode = criteriaNode.get("maxAppVersions");
-        assertEquals(12, maxVersionsNode.get(OperatingSystem.IOS).asInt());
+        assertEquals(maxVersionsNode.get(OperatingSystem.IOS).asInt(), 12);
         
         assertNotNull(criteriaNode.get("allOfGroups"));
         assertNotNull(criteriaNode.get("noneOfGroups"));
@@ -116,7 +116,7 @@ public class CriteriaScheduleStrategyTest {
         
         // But mostly, if this isn't all serialized, and then deserialized, these won't be equal
         CriteriaScheduleStrategy newStrategy = mapper.readValue(json, CriteriaScheduleStrategy.class);
-        assertEquals(strategy, newStrategy);
+        assertEquals(newStrategy, strategy);
     }
     
     @Test
@@ -126,11 +126,11 @@ public class CriteriaScheduleStrategyTest {
         
         // First returned because context has no version info
         Schedule schedule = getScheduleFromStrategy(ClientInfo.UNKNOWN_CLIENT);
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS);
         
         // Context version info outside minimum range of first criteria, last one returned
         schedule = getScheduleFromStrategy(CLIENT_INFO);
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
     }
     
     @Test
@@ -140,11 +140,11 @@ public class CriteriaScheduleStrategyTest {
         
         // First one is returned because client has no version info
         Schedule schedule = getScheduleFromStrategy(ClientInfo.UNKNOWN_CLIENT);
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS);
         
         // Context version info outside maximum range of first criteria, last one returned
         schedule = getScheduleFromStrategy(CLIENT_INFO);
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
     }
     
     @Test
@@ -154,11 +154,11 @@ public class CriteriaScheduleStrategyTest {
         
         // context has a group required by first group, it's returned
         Schedule schedule = getScheduleFromStrategy(Sets.newHashSet("group1"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_ONE_REQUIRED_DATA_GROUP, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_ONE_REQUIRED_DATA_GROUP);
         
         // context does not have a required group, last one returned
         schedule = getScheduleFromStrategy(Sets.newHashSet("someRandomToken"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
     }
     
     @Test
@@ -168,15 +168,15 @@ public class CriteriaScheduleStrategyTest {
         
         // context has all the required groups so the first one is returned
         Schedule schedule = getScheduleFromStrategy(Sets.newHashSet("group1","group2","group3"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_REQUIRED_DATA_GROUPS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_REQUIRED_DATA_GROUPS);
         
         // context does not have *any* the required groups, last one returned
         schedule = getScheduleFromStrategy(Sets.newHashSet("someRandomToken"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
         
         // context does not have *all* the required groups, last one returned
         schedule = getScheduleFromStrategy(Sets.newHashSet("group1"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
     }
     
     @Test
@@ -186,11 +186,11 @@ public class CriteriaScheduleStrategyTest {
         
         // Group not prohibited so first schedule returned
         Schedule schedule = getScheduleFromStrategy(Sets.newHashSet("groupNotProhibited"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_ONE_PROHIBITED_DATA_GROUP, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_ONE_PROHIBITED_DATA_GROUP);
         
         // this group is prohibited so second schedule is returned
         schedule = getScheduleFromStrategy(Sets.newHashSet("group1"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
     }
     
     @Test
@@ -200,15 +200,15 @@ public class CriteriaScheduleStrategyTest {
         
         // context has a prohibited group, so the last schedule is returned
         Schedule schedule = getScheduleFromStrategy(Sets.newHashSet("group1"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
         
         // context has one of the prohibited groups, same thing
         schedule = getScheduleFromStrategy(Sets.newHashSet("foo","group1"));
-        assertEquals(SCHEDULE_FOR_STRATEGY_NO_CRITERIA, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_NO_CRITERIA);
         
         // context has no prohibited groups, first schedule is returned
         schedule = getScheduleFromStrategy(Sets.newHashSet());
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS);
     }
     
     @Test
@@ -241,7 +241,7 @@ public class CriteriaScheduleStrategyTest {
         // and the second because the user does not have a required data group. The last ScheduleCriteria 
         // matches and returns the last schedule in the list
         Schedule schedule = strategy.getScheduleForUser(PLAN, context);
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS);
     }
     
     @Test
@@ -257,7 +257,7 @@ public class CriteriaScheduleStrategyTest {
         
         // Matches the first schedule, not the second schedule (although it also matches)
         Schedule schedule = strategy.getScheduleForUser(PLAN, context);
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_ALL_REQUIREMENTS, schedule);
+        assertEquals(schedule, SCHEDULE_FOR_STRATEGY_WITH_ALL_REQUIREMENTS);
     }
 
     @Test
@@ -267,10 +267,10 @@ public class CriteriaScheduleStrategyTest {
         setUpStrategyWithProhibitedDataGroups();
 
         List<Schedule> schedules = strategy.getAllPossibleSchedules();
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS, schedules.get(0));
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_ONE_REQUIRED_DATA_GROUP, schedules.get(1));
-        assertEquals(SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS, schedules.get(2));
-        assertEquals(3, schedules.size());
+        assertEquals(schedules.get(0), SCHEDULE_FOR_STRATEGY_WITH_APP_VERSIONS);
+        assertEquals(schedules.get(1), SCHEDULE_FOR_STRATEGY_WITH_ONE_REQUIRED_DATA_GROUP);
+        assertEquals(schedules.get(2), SCHEDULE_FOR_STRATEGY_WITH_PROHIBITED_DATA_GROUPS);
+        assertEquals(schedules.size(), 3);
     }
     
     @Test
@@ -358,7 +358,8 @@ public class CriteriaScheduleStrategyTest {
             Validate.entityThrowingException(VALIDATOR, PLAN);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].schedule is required", e.getErrors().get("strategy.scheduleCriteria[0].schedule").get(0));
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].schedule").get(0),
+                    "strategy.scheduleCriteria[0].schedule is required");
         }
     }
     
@@ -377,12 +378,13 @@ public class CriteriaScheduleStrategyTest {
             Validate.entityThrowingException(VALIDATOR, PLAN);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].criteria is required", e.getErrors().get("strategy.scheduleCriteria[0].criteria").get(0));
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].criteria").get(0),
+                    "strategy.scheduleCriteria[0].criteria is required");
         }
     }
     
     private void assertError(InvalidEntityException e, String fieldName, int index, String errorMsg) {
-        assertEquals(fieldName+errorMsg, e.getErrors().get(fieldName).get(index));
+        assertEquals(e.getErrors().get(fieldName).get(index), fieldName+errorMsg);
     }
     
     private Set<String> arrayToSet(JsonNode array) {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/CronActivitySchedulerTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
@@ -16,8 +16,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -39,7 +39,7 @@ public class CronActivitySchedulerTest {
     private List<ScheduledActivity> scheduledActivities;
     private SchedulePlan plan = new DynamoSchedulePlan();
     
-    @Before
+    @BeforeMethod
     public void before() {
         plan.setGuid("BBB");
         
@@ -134,7 +134,7 @@ public class CronActivitySchedulerTest {
         schedule.setStartsOn(asDT("2015-03-31 00:00"));
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusWeeks(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEndsOnCronScheduleWorks() {
@@ -218,7 +218,7 @@ public class CronActivitySchedulerTest {
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(4)));
         // Ultimate result: It's the 23rd, and right at enrollment, you see this task from the 21st.
         assertDates(scheduledActivities, "2015-03-21 06:00");
-        assertEquals(ScheduledActivityStatus.AVAILABLE, scheduledActivities.get(0).getStatus());
+        assertEquals(scheduledActivities.get(0).getStatus(), ScheduledActivityStatus.AVAILABLE);
         DateTimeUtils.setCurrentMillisSystem();
     }
     @Test
@@ -318,9 +318,9 @@ public class CronActivitySchedulerTest {
         List<DateTime> scheduleDates = scheduledActivities.stream()
                 .map(ScheduledActivity::getScheduledOn)
                 .collect(Collectors.toList());
-        assertEquals("2016-05-12T22:00:00.000-07:00", scheduleDates.get(0).toString());
-        assertEquals("2016-05-13T10:00:00.000-07:00", scheduleDates.get(1).toString());
-        assertEquals("2016-05-13T22:00:00.000-07:00", scheduleDates.get(2).toString());
+        assertEquals(scheduleDates.get(0).toString(), "2016-05-12T22:00:00.000-07:00");
+        assertEquals(scheduleDates.get(1).toString(), "2016-05-13T10:00:00.000-07:00");
+        assertEquals(scheduleDates.get(2).toString(), "2016-05-13T22:00:00.000-07:00");
     }
     
     private ScheduleContext getContext(DateTime endsOn) {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asLong;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.ONCE;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleType.RECURRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
@@ -17,9 +17,10 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 
@@ -35,7 +36,7 @@ public class IntervalActivitySchedulerTest {
     private List<ScheduledActivity> scheduledActivities;
     private SchedulePlan plan = new DynamoSchedulePlan();
     
-    @Before
+    @BeforeMethod
     public void before() {
         plan.setGuid("BBB");
 
@@ -46,7 +47,7 @@ public class IntervalActivitySchedulerTest {
         events.put("enrollment", ENROLLMENT);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -154,7 +155,7 @@ public class IntervalActivitySchedulerTest {
         schedule.setExpires("PT24H");
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         schedule.setExpires("P1M");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
@@ -194,7 +195,7 @@ public class IntervalActivitySchedulerTest {
         schedule.setStartsOn("2015-04-10T09:00:00Z");
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEndsOnScheduleWorks() {
@@ -203,7 +204,7 @@ public class IntervalActivitySchedulerTest {
         
         // In this case the endsOn date is before the enrollment. No activities
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         schedule.setEndsOn("2015-04-23T13:40:00Z");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
@@ -235,7 +236,7 @@ public class IntervalActivitySchedulerTest {
         
         // Again, it happens before the start date, so it doesn't happen.
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(3)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceDelayEndsOnScheduleWorks() {
@@ -249,7 +250,7 @@ public class IntervalActivitySchedulerTest {
         // With a delay *after* the end date, nothing happens
         schedule.setDelay("P2M");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(3)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceDelayStartEndsOnScheduleWorks() {
@@ -265,7 +266,7 @@ public class IntervalActivitySchedulerTest {
         schedule.setDelay("P6M");
         schedule.setStartsOn(asDT("2015-05-01 00:00"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(9)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceDelayExpiresScheduleWorks() {
@@ -274,8 +275,8 @@ public class IntervalActivitySchedulerTest {
         schedule.setDelay("P1M");
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(3)));
-        assertEquals(asLong("2015-04-23 09:40"), scheduledActivities.get(0).getScheduledOn().getMillis());
-        assertEquals(asLong("2015-04-30 09:40"), scheduledActivities.get(0).getExpiresOn().getMillis());
+        assertEquals(scheduledActivities.get(0).getScheduledOn().getMillis(), asLong("2015-04-23 09:40"));
+        assertEquals(scheduledActivities.get(0).getExpiresOn().getMillis(), asLong("2015-04-30 09:40"));
     }
     @Test
     public void onceExpiresScheduleWorks() {
@@ -284,7 +285,7 @@ public class IntervalActivitySchedulerTest {
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(3)));
         // No activities. Created on 3/23, it expired by 3/30, today is 4/6
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEventScheduleWorks() {
@@ -308,7 +309,7 @@ public class IntervalActivitySchedulerTest {
 
         // Goes to the event window day and takes the afternoon slot, after 10am
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEventEndsOnScheduleWorks() {
@@ -319,7 +320,7 @@ public class IntervalActivitySchedulerTest {
         
         // No activity, the event happened after the end of the window
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEventStartEndsOnScheduleWorks() {
@@ -330,7 +331,7 @@ public class IntervalActivitySchedulerTest {
 
         // No event... select the startsOn window
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         events.put("survey:AAA:completedOn", asDT("2015-04-10 00:00"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
@@ -370,7 +371,7 @@ public class IntervalActivitySchedulerTest {
         // This should not return a activity.
         schedule.setStartsOn(asDT("2015-04-15 00:00"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void onceEventDelayEndsOnScheduleWorks() {
@@ -427,13 +428,13 @@ public class IntervalActivitySchedulerTest {
         // Given even, it would be on 4/2 at 12:22, expiring 4/5, today is 4/6
         // It's in the window but still doesn't appear
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         events.put("survey:AAA:completedOn", asDT("2015-04-06 09:22"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(6)));
         
-        assertEquals(asLong("2015-04-06 12:22"), scheduledActivities.get(0).getScheduledOn().getMillis());
-        assertEquals(asLong("2015-04-09 12:22"), scheduledActivities.get(0).getExpiresOn().getMillis());
+        assertEquals(scheduledActivities.get(0).getScheduledOn().getMillis(), asLong("2015-04-06 12:22"));
+        assertEquals(scheduledActivities.get(0).getExpiresOn().getMillis(), asLong("2015-04-09 12:22"));
     }
     @Test
     public void recurringScheduleWorks() {
@@ -506,7 +507,7 @@ public class IntervalActivitySchedulerTest {
         // With a delay *after* the end date, nothing happens
         schedule.setDelay("P2M");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(3)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void recurringDelayStartEndsOnScheduleWorks() {
@@ -524,7 +525,7 @@ public class IntervalActivitySchedulerTest {
         schedule.setDelay("P1M");
         schedule.setStartsOn(asDT("2015-03-30 09:00"));
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(3)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void recurringEventScheduleWorks() {
@@ -554,7 +555,7 @@ public class IntervalActivitySchedulerTest {
         
         // No activity, the event happened after the end of the window
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void recurringEventStartEndsOnScheduleWorks() {
@@ -684,7 +685,7 @@ public class IntervalActivitySchedulerTest {
                 .withMinimumPerSchedule(2).build();
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
-        assertEquals(2, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 2);
         
         // But this will lock out tasks. Scheduling window takes precedence.
         schedule.setEndsOn(ENROLLMENT.plusDays(3)); 
@@ -719,7 +720,7 @@ public class IntervalActivitySchedulerTest {
 
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
         
-        assertEquals(5, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 5);
     }
     
     @Test
@@ -744,7 +745,7 @@ public class IntervalActivitySchedulerTest {
                 .withInitialTimeZone(DateTimeZone.forOffsetHours(-7)).build();
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
-        assertEquals(4, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 4);
     }
 
     private ScheduleContext getContext(DateTime endsOn) {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/PersistentActivitySchedulerTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.asDT;
 import static org.sagebionetworks.bridge.models.schedules.ScheduleTestUtils.assertDates;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
 import java.util.List;
@@ -13,9 +13,9 @@ import java.util.Map;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -32,7 +32,7 @@ public class PersistentActivitySchedulerTest {
     private SchedulePlan plan;
     private Schedule schedule;
     
-    @Before
+    @BeforeMethod
     public void before() {
         DateTimeUtils.setCurrentMillisFixed(1428340210000L);
         
@@ -48,7 +48,7 @@ public class PersistentActivitySchedulerTest {
         schedule.setScheduleType(ScheduleType.PERSISTENT);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -71,7 +71,7 @@ public class PersistentActivitySchedulerTest {
         schedule.setStartsOn("2015-04-10T09:00:00Z");
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusDays(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
     }
     @Test
     public void endsOnScheduleWorks() {
@@ -80,7 +80,7 @@ public class PersistentActivitySchedulerTest {
         
         // In this case the endsOn date is before the enrollment. No activities.
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         schedule.setEndsOn("2015-04-23T13:40:00Z");
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
@@ -103,7 +103,7 @@ public class PersistentActivitySchedulerTest {
         schedule.setEventId("survey:AAA:finished");
         
         scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, getContext(ENROLLMENT.plusMonths(1)));
-        assertEquals(0, scheduledActivities.size());
+        assertEquals(scheduledActivities.size(), 0);
         
         // Once that occurs, a task is issued for "right now"
         events.put("survey:AAA:finished", asDT("2015-04-10 11:40"));

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +14,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.ClientInfo;
@@ -42,16 +42,16 @@ public class ScheduleContextTest {
         assertFalse(context.hasEvents());
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void requiresStudyId() {
         new ScheduleContext.Builder().build();
     }
     
     @Test
     public void defaultsTimeZoneMinimumAndClientInfo() {
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, EMPTY_CONTEXT.getCriteriaContext().getClientInfo());
+        assertEquals(EMPTY_CONTEXT.getCriteriaContext().getClientInfo(), ClientInfo.UNKNOWN_CLIENT);
         assertNotNull(EMPTY_CONTEXT.getStartsOn());
-        assertEquals(0, EMPTY_CONTEXT.getMinimumPerSchedule());
+        assertEquals(EMPTY_CONTEXT.getMinimumPerSchedule(), 0);
     }
     
     @Test
@@ -79,21 +79,21 @@ public class ScheduleContextTest {
                 .withUserDataGroups(TestConstants.USER_DATA_GROUPS)
                 .withUserSubstudyIds(TestConstants.USER_SUBSTUDY_IDS).build();
         
-        assertEquals(TEST_STUDY, context.getCriteriaContext().getStudyIdentifier());
-        assertEquals(clientInfo, context.getCriteriaContext().getClientInfo());
-        assertEquals(PST, context.getInitialTimeZone());
-        assertEquals(endsOn, context.getEndsOn());
-        assertEquals(events.get(ENROLLMENT), context.getEvent(ENROLLMENT));
-        assertEquals(3, context.getMinimumPerSchedule());
-        assertEquals(HEALTH_CODE, context.getCriteriaContext().getHealthCode());
-        assertEquals(TestConstants.USER_DATA_GROUPS, context.getCriteriaContext().getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, context.getCriteriaContext().getUserSubstudyIds());
-        assertEquals(startsOn, context.getStartsOn());
-        assertEquals(accountCreatedOn, context.getAccountCreatedOn());
+        assertEquals(context.getCriteriaContext().getStudyIdentifier(), TEST_STUDY);
+        assertEquals(context.getCriteriaContext().getClientInfo(), clientInfo);
+        assertEquals(context.getInitialTimeZone(), PST);
+        assertEquals(context.getEndsOn(), endsOn);
+        assertEquals(context.getEvent(ENROLLMENT), events.get(ENROLLMENT));
+        assertEquals(context.getMinimumPerSchedule(), 3);
+        assertEquals(context.getCriteriaContext().getHealthCode(), HEALTH_CODE);
+        assertEquals(context.getCriteriaContext().getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(context.getCriteriaContext().getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(context.getStartsOn(), startsOn);
+        assertEquals(context.getAccountCreatedOn(), accountCreatedOn);
 
         // Test the withContext() method.
         ScheduleContext copy = new ScheduleContext.Builder().withContext(context).build();
-        assertEquals(context, copy);
+        assertEquals(copy, context);
     }
     
     @Test
@@ -103,21 +103,21 @@ public class ScheduleContextTest {
         assertFalse(EMPTY_CONTEXT.hasEvents());
         assertNull(EMPTY_CONTEXT.getEvent(ENROLLMENT));
         assertNull(EMPTY_CONTEXT.getEndsOn());
-        assertEquals(0, EMPTY_CONTEXT.getMinimumPerSchedule());
+        assertEquals(EMPTY_CONTEXT.getMinimumPerSchedule(), 0);
         assertNull(EMPTY_CONTEXT.getAccountCreatedOn());
         assertTrue(EMPTY_CONTEXT.getCriteriaContext().getUserDataGroups().isEmpty());
         assertTrue(EMPTY_CONTEXT.getCriteriaContext().getUserSubstudyIds().isEmpty());
         assertTrue(EMPTY_CONTEXT.getCriteriaContext().getLanguages().isEmpty());
         assertNull(EMPTY_CONTEXT.getCriteriaContext().getHealthCode());
         assertNull(EMPTY_CONTEXT.getCriteriaContext().getUserId());
-        assertEquals(TEST_STUDY,EMPTY_CONTEXT.getCriteriaContext().getStudyIdentifier());
-        assertEquals(ClientInfo.UNKNOWN_CLIENT, EMPTY_CONTEXT.getCriteriaContext().getClientInfo());
+        assertEquals(EMPTY_CONTEXT.getCriteriaContext().getStudyIdentifier(), TEST_STUDY);
+        assertEquals(EMPTY_CONTEXT.getCriteriaContext().getClientInfo(), ClientInfo.UNKNOWN_CLIENT);
         // And then there's this, which is not null
         assertNotNull(EMPTY_CONTEXT.getStartsOn());
         
         // Test the withContext() method.
         ScheduleContext copy = new ScheduleContext.Builder().withContext(EMPTY_CONTEXT).build();
-        assertEquals(EMPTY_CONTEXT, copy);
+        assertEquals(copy, EMPTY_CONTEXT);
     }
     
     @Test
@@ -131,7 +131,7 @@ public class ScheduleContextTest {
         DateTime now = DateTime.now(DateTimeZone.UTC);
         context = new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY).withAccountCreatedOn(now).build();
         copy = new ScheduleContext.Builder().withContext(context).build();
-        assertEquals(now, copy.getAccountCreatedOn());
+        assertEquals(copy.getAccountCreatedOn(), now);
     }
     
     @Test
@@ -140,10 +140,10 @@ public class ScheduleContextTest {
                 .withAccountCreatedOn(DateTime.parse("2010-10-10T10:10:10.010+03:00"))
                 .withStudyIdentifier("study-Id")
                 .build();
-        assertEquals("2010-10-10T07:10:10.010Z", context.getAccountCreatedOn().toString());
+        assertEquals(context.getAccountCreatedOn().toString(), "2010-10-10T07:10:10.010Z");
         
         ScheduleContext context2 = new ScheduleContext.Builder().withContext(context).build();
-        assertEquals("2010-10-10T07:10:10.010Z", context2.getAccountCreatedOn().toString());
+        assertEquals(context2.getAccountCreatedOn().toString(), "2010-10-10T07:10:10.010Z");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleCriteriaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleCriteriaTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.Criteria;

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleStrategyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleStrategyTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -21,8 +22,8 @@ public class ScheduleStrategyTest {
         String output = BridgeObjectMapper.get().writeValueAsString(strategy);
         JsonNode node = BridgeObjectMapper.get().readTree(output);
         assertNull(node.get("allPossibleSchedules"));
-        assertEquals("ABTestScheduleStrategy", node.get("type").asText());
-        assertEquals(3, ((ArrayNode)node.get("scheduleGroups")).size());
+        assertEquals(node.get("type").asText(), "ABTestScheduleStrategy");
+        assertEquals(((ArrayNode)node.get("scheduleGroups")).size(), 3);
     }
     
     @Test
@@ -43,7 +44,7 @@ public class ScheduleStrategyTest {
     private ScheduleStrategy serializeAndDeserialize(ScheduleStrategy strategy, String typeName) throws Exception {
         String output = BridgeObjectMapper.get().writeValueAsString(strategy);
         JsonNode node = BridgeObjectMapper.get().readTree(output);
-        assertEquals(typeName, node.get("type").asText());
+        assertEquals(node.get("type").asText(), typeName);
         return BridgeObjectMapper.get().readValue(output, ScheduleStrategy.class);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleTest.java
@@ -1,18 +1,20 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -47,48 +49,48 @@ public class ScheduleTest {
         String string = mapper.writeValueAsString(schedule);
 
         JsonNode node = mapper.readTree(string);
-        assertEquals("label", node.get(Schedule.LABEL_PROPERTY).textValue());
-        assertEquals("recurring", node.get(Schedule.SCHEDULE_TYPE_PROPERTY).textValue());
-        assertEquals("eventId", node.get(Schedule.EVENT_ID_PROPERTY).textValue());
-        assertEquals("0 0 8 ? * TUE *", node.get(Schedule.CRON_TRIGGER_PROPERTY).textValue());
-        assertEquals("P1D", node.get(Schedule.DELAY_PROPERTY).textValue());
-        assertEquals("P3D", node.get(Schedule.INTERVAL_PROPERTY).textValue());
-        assertEquals("P2D", node.get(Schedule.EXPIRES_PROPERTY).textValue());
-        assertEquals("P3W", node.get(Schedule.SEQUENCE_PERIOD_PROPERTY).textValue());
-        assertEquals("2015-02-02T10:10:10.000Z", node.get(Schedule.STARTS_ON_PROPERTY).textValue());
-        assertEquals("2015-01-01T10:10:10.000Z", node.get(Schedule.ENDS_ON_PROPERTY).textValue());
+        assertEquals(node.get(Schedule.LABEL_PROPERTY).textValue(), "label");
+        assertEquals(node.get(Schedule.SCHEDULE_TYPE_PROPERTY).textValue(), "recurring");
+        assertEquals(node.get(Schedule.EVENT_ID_PROPERTY).textValue(), "eventId");
+        assertEquals(node.get(Schedule.CRON_TRIGGER_PROPERTY).textValue(), "0 0 8 ? * TUE *");
+        assertEquals(node.get(Schedule.DELAY_PROPERTY).textValue(), "P1D");
+        assertEquals(node.get(Schedule.INTERVAL_PROPERTY).textValue(), "P3D");
+        assertEquals(node.get(Schedule.EXPIRES_PROPERTY).textValue(), "P2D");
+        assertEquals(node.get(Schedule.SEQUENCE_PERIOD_PROPERTY).textValue(), "P3W");
+        assertEquals(node.get(Schedule.STARTS_ON_PROPERTY).textValue(), "2015-02-02T10:10:10.000Z");
+        assertEquals(node.get(Schedule.ENDS_ON_PROPERTY).textValue(), "2015-01-01T10:10:10.000Z");
         assertFalse(node.get(Schedule.PERSISTENT_PROPERTY).booleanValue());
-        assertEquals("Schedule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "Schedule");
 
         ArrayNode times = (ArrayNode)node.get("times");
-        assertEquals("10:10:00.000", times.get(0).textValue());
-        assertEquals("14:00:00.000", times.get(1).textValue());
+        assertEquals(times.get(0).textValue(), "10:10:00.000");
+        assertEquals(times.get(1).textValue(), "14:00:00.000");
         
         JsonNode actNode = node.get("activities").get(0);
-        assertEquals("label", actNode.get("label").textValue());
-        assertEquals("task", actNode.get("activityType").textValue());
-        assertEquals("Activity", actNode.get("type").textValue());
+        assertEquals(actNode.get("label").textValue(), "label");
+        assertEquals(actNode.get("activityType").textValue(), "task");
+        assertEquals(actNode.get("type").textValue(), "Activity");
 
         JsonNode taskNode = actNode.get("task");
-        assertEquals("ref", taskNode.get("identifier").textValue());
-        assertEquals("TaskReference", taskNode.get("type").textValue());
+        assertEquals(taskNode.get("identifier").textValue(), "ref");
+        assertEquals(taskNode.get("type").textValue(), "TaskReference");
         
         schedule = mapper.readValue(string, Schedule.class);
-        assertEquals("0 0 8 ? * TUE *", schedule.getCronTrigger());
-        assertEquals("P1D", schedule.getDelay().toString());
-        assertEquals("P2D", schedule.getExpires().toString());
-        assertEquals("eventId", schedule.getEventId());
-        assertEquals("label", schedule.getLabel());
-        assertEquals("P3D", schedule.getInterval().toString());
-        assertEquals(ScheduleType.RECURRING, schedule.getScheduleType());
-        assertEquals("2015-02-02T10:10:10.000Z", schedule.getStartsOn().toString());
-        assertEquals("2015-01-01T10:10:10.000Z", schedule.getEndsOn().toString());
-        assertEquals("10:10:00.000", schedule.getTimes().get(0).toString());
-        assertEquals("14:00:00.000", schedule.getTimes().get(1).toString());
-        assertEquals("P3W", schedule.getSequencePeriod().toString());
+        assertEquals(schedule.getCronTrigger(), "0 0 8 ? * TUE *");
+        assertEquals(schedule.getDelay().toString(), "P1D");
+        assertEquals(schedule.getExpires().toString(), "P2D");
+        assertEquals(schedule.getEventId(), "eventId");
+        assertEquals(schedule.getLabel(), "label");
+        assertEquals(schedule.getInterval().toString(), "P3D");
+        assertEquals(schedule.getScheduleType(), ScheduleType.RECURRING);
+        assertEquals(schedule.getStartsOn().toString(), "2015-02-02T10:10:10.000Z");
+        assertEquals(schedule.getEndsOn().toString(), "2015-01-01T10:10:10.000Z");
+        assertEquals(schedule.getTimes().get(0).toString(), "10:10:00.000");
+        assertEquals(schedule.getTimes().get(1).toString(), "14:00:00.000");
+        assertEquals(schedule.getSequencePeriod().toString(), "P3W");
         activity = schedule.getActivities().get(0);
-        assertEquals("label", activity.getLabel());
-        assertEquals("ref", activity.getTask().getIdentifier());
+        assertEquals(activity.getLabel(), "label");
+        assertEquals(activity.getTask().getIdentifier(), "ref");
     }
     
     @Test
@@ -105,13 +107,13 @@ public class ScheduleTest {
         schedule.addTimes("10:10");
         schedule.addTimes("12:10");
         
-        assertEquals(period, schedule.getDelay());
-        assertEquals(date, schedule.getEndsOn());
-        assertEquals(date, schedule.getStartsOn());
-        assertEquals(period, schedule.getExpires());
-        assertEquals(period, schedule.getInterval());
-        assertEquals(period, schedule.getSequencePeriod());
-        assertEquals(Lists.newArrayList(LocalTime.parse("10:10"), LocalTime.parse("12:10")), schedule.getTimes());
+        assertEquals(schedule.getDelay(), period);
+        assertEquals(schedule.getEndsOn(), date);
+        assertEquals(schedule.getStartsOn(), date);
+        assertEquals(schedule.getExpires(), period);
+        assertEquals(schedule.getInterval(), period);
+        assertEquals(schedule.getSequencePeriod(), period);
+        assertEquals(schedule.getTimes(), Lists.newArrayList(LocalTime.parse("10:10"), LocalTime.parse("12:10")));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleTestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleTestUtils.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.List;
 
@@ -44,10 +44,10 @@ public class ScheduleTestUtils {
      * @param output
      */
     public static void assertDates(List<ScheduledActivity> activities, DateTimeZone zone, String... output) {
-        assertEquals(output.length, activities.size());
+        assertEquals(activities.size(), output.length);
         for (int i=0; i < activities.size(); i++) {
             DateTime datetime = asDT(output[i], zone);
-            assertEquals(datetime.toString(), activities.get(i).getScheduledOn().toString());
+            assertEquals(activities.get(i).getScheduledOn().toString(), datetime.toString());
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/SchemaReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/SchemaReferenceTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -14,9 +15,9 @@ public class SchemaReferenceTest {
     @Test
     public void normalCase() {
         SchemaReference schemaRef = new SchemaReference("test-schema", 7);
-        assertEquals("test-schema", schemaRef.getId());
-        assertEquals(7, schemaRef.getRevision().intValue());
-        assertEquals("SchemaReference{id='test-schema', revision=7}", schemaRef.toString());
+        assertEquals(schemaRef.getId(), "test-schema");
+        assertEquals(schemaRef.getRevision().intValue(), 7);
+        assertEquals(schemaRef.toString(), "SchemaReference{id='test-schema', revision=7}");
     }
 
     @Test
@@ -39,15 +40,15 @@ public class SchemaReferenceTest {
 
         // convert to POJO
         SchemaReference schemaRef = BridgeObjectMapper.get().readValue(jsonText, SchemaReference.class);
-        assertEquals("test-schema", schemaRef.getId());
-        assertEquals(7, schemaRef.getRevision().intValue());
+        assertEquals(schemaRef.getId(), "test-schema");
+        assertEquals(schemaRef.getRevision().intValue(), 7);
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(schemaRef, JsonNode.class);
-        assertEquals(3, jsonNode.size());
-        assertEquals("test-schema", jsonNode.get("id").textValue());
-        assertEquals(7, jsonNode.get("revision").intValue());
-        assertEquals("SchemaReference", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 3);
+        assertEquals(jsonNode.get("id").textValue(), "test-schema");
+        assertEquals(jsonNode.get("revision").intValue(), 7);
+        assertEquals(jsonNode.get("type").textValue(), "SchemaReference");
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategyTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.validation.Errors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -35,7 +35,7 @@ public class SimpleScheduleStrategyTest {
     private static final BridgeObjectMapper MAPPER = BridgeObjectMapper.get();
     private Study study;
 
-    @Before
+    @BeforeMethod
     public void before() {
         study = TestUtils.getValidStudy(ScheduleStrategyTest.class);
     }
@@ -62,11 +62,11 @@ public class SimpleScheduleStrategyTest {
         DynamoSchedulePlan newPlan = DynamoSchedulePlan.fromJson(node);
 
         newPlan.setStudyKey(plan.getStudyKey()); // not serialized
-        assertEquals("Plan with simple strategy was serialized/deserialized", plan, newPlan);
+        assertEquals(newPlan, plan, "Plan with simple strategy was serialized/deserialized");
 
         SimpleScheduleStrategy newStrategy = (SimpleScheduleStrategy) newPlan.getStrategy();
-        assertEquals("Deserialized simple testing strategy is complete", strategy.getSchedule(),
-                        newStrategy.getSchedule());
+        assertEquals(newStrategy.getSchedule(), strategy.getSchedule(),
+                "Deserialized simple testing strategy is complete");
     }
     
     @Test
@@ -83,7 +83,7 @@ public class SimpleScheduleStrategyTest {
         Map<String,List<String>> map = Validate.convertErrorsToSimpleMap(errors);
         
         List<String> errorMessages = map.get("schedule.expires");
-        assertEquals("schedule.expires must be set if schedule repeats", errorMessages.get(0));
+        assertEquals(errorMessages.get(0), "schedule.expires must be set if schedule repeats");
     }
     
     @Test
@@ -91,8 +91,8 @@ public class SimpleScheduleStrategyTest {
         SchedulePlan plan = TestUtils.getSimpleSchedulePlan(TEST_STUDY);
         
         List<Schedule> schedules = plan.getStrategy().getAllPossibleSchedules();
-        assertEquals(1, schedules.size());
-        assertEquals("Test label for the user", schedules.get(0).getLabel());
+        assertEquals(schedules.size(), 1);
+        assertEquals(schedules.get(0).getLabel(), "Test label for the user");
         assertTrue(schedules instanceof ImmutableList);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/SurveyReferenceTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolder;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -20,9 +20,9 @@ public class SurveyReferenceTest {
     public void test() {
         SurveyReference ref = new SurveyReference(IDENTIFIER, GUID, CREATED_ON);
         
-        assertEquals(IDENTIFIER, ref.getIdentifier());
-        assertEquals(GUID, ref.getGuid());
-        assertEquals(CREATED_ON, ref.getCreatedOn());
+        assertEquals(ref.getIdentifier(), IDENTIFIER);
+        assertEquals(ref.getGuid(), GUID);
+        assertEquals(ref.getCreatedOn(), CREATED_ON);
         assertTrue(ref.getHref().contains("/v3/surveys/abc/revisions/2017-02-09T20:15:59.558Z"));
         
         GuidCreatedOnVersionHolder keys1 = new GuidCreatedOnVersionHolderImpl(GUID, CREATED_ON.getMillis());

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/TaskReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/TaskReferenceTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.schedules;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -21,7 +22,7 @@ public class TaskReferenceTest {
         // SchemaReference.toString() is already tested elsewhere. Use that string directly so we don't have to depend
         // on another class's implementaiton.
         TaskReference taskRef = new TaskReference("test-task", SCHEMA_REF);
-        assertEquals("TaskReference [identifier=test-task, schema=" + SCHEMA_REF.toString() + "]", taskRef.toString());
+        assertEquals(taskRef.toString(), "TaskReference [identifier=test-task, schema=" + SCHEMA_REF.toString() + "]");
     }
 
     @Test
@@ -35,14 +36,14 @@ public class TaskReferenceTest {
 
         // Convert to POJO and validate.
         TaskReference taskRef = BridgeObjectMapper.get().readValue(jsonText, TaskReference.class);
-        assertEquals("json-task", taskRef.getIdentifier());
-        assertEquals(SCHEMA_REF, taskRef.getSchema());
+        assertEquals(taskRef.getIdentifier(), "json-task");
+        assertEquals(taskRef.getSchema(), SCHEMA_REF);
 
         // Convert back to JSON and validate.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(taskRef, JsonNode.class);
-        assertEquals(3, jsonNode.size());
-        assertEquals("json-task", jsonNode.get("identifier").textValue());
-        assertEquals(BridgeObjectMapper.get().convertValue(SCHEMA_REF, JsonNode.class), jsonNode.get("schema"));
-        assertEquals("TaskReference", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 3);
+        assertEquals(jsonNode.get("identifier").textValue(), "json-task");
+        assertEquals(jsonNode.get("schema"), BridgeObjectMapper.get().convertValue(SCHEMA_REF, JsonNode.class));
+        assertEquals(jsonNode.get("type").textValue(), "TaskReference");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatusTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/sharedmodules/SharedModuleImportStatusTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.sharedmodules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -17,27 +18,27 @@ public class SharedModuleImportStatusTest {
     private static final String SURVEY_CREATED_ON_STRING = "2017-04-05T20:54:53.625Z";
     private static final long SURVEY_CREATED_ON_MILLIS = DateUtils.convertToMillisFromEpoch(SURVEY_CREATED_ON_STRING);
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullSchemaId() {
         new SharedModuleImportStatus(null, SCHEMA_REV);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void emptySchemaId() {
         new SharedModuleImportStatus("", SCHEMA_REV);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void blankSchemaId() {
         new SharedModuleImportStatus("   ", SCHEMA_REV);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void negativeSchemaRev() {
         new SharedModuleImportStatus(SCHEMA_ID, -1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void zeroSchemaRev() {
         new SharedModuleImportStatus(SCHEMA_ID, 0);
     }
@@ -46,43 +47,43 @@ public class SharedModuleImportStatusTest {
     public void schemaModule() {
         // Test constructor and getters.
         SharedModuleImportStatus status = new SharedModuleImportStatus(SCHEMA_ID, SCHEMA_REV);
-        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
-        assertEquals(SCHEMA_ID, status.getSchemaId());
-        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+        assertEquals(status.getModuleType(), SharedModuleType.SCHEMA);
+        assertEquals(status.getSchemaId(), SCHEMA_ID);
+        assertEquals(status.getSchemaRevision().intValue(), SCHEMA_REV);
         assertNull(status.getSurveyCreatedOn());
         assertNull(status.getSurveyGuid());
 
         // Test JSON serialization. We only ever write this to JSON, never read it from JSON, so we only need to test
         // this one way.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(status, JsonNode.class);
-        assertEquals(4, jsonNode.size());
-        assertEquals("schema", jsonNode.get("moduleType").textValue());
-        assertEquals(SCHEMA_ID, jsonNode.get("schemaId").textValue());
-        assertEquals(SCHEMA_REV, jsonNode.get("schemaRevision").intValue());
-        assertEquals("SharedModuleImportStatus", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 4);
+        assertEquals(jsonNode.get("moduleType").textValue(), "schema");
+        assertEquals(jsonNode.get("schemaId").textValue(), SCHEMA_ID);
+        assertEquals(jsonNode.get("schemaRevision").intValue(), SCHEMA_REV);
+        assertEquals(jsonNode.get("type").textValue(), "SharedModuleImportStatus");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullSurveyGuid() {
         new SharedModuleImportStatus(null, SURVEY_CREATED_ON_MILLIS);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void emptySurveyGuid() {
         new SharedModuleImportStatus("", SURVEY_CREATED_ON_MILLIS);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void blankSurveyGuid() {
         new SharedModuleImportStatus("   ", SURVEY_CREATED_ON_MILLIS);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void negativeSurveyCreatedOn() {
         new SharedModuleImportStatus(SURVEY_GUID, -1L);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void zeroSurveyCreatedOn() {
         new SharedModuleImportStatus(SURVEY_GUID, 0L);
     }
@@ -91,18 +92,18 @@ public class SharedModuleImportStatusTest {
     public void surveyModule() {
         // Test constructor and getters.
         SharedModuleImportStatus status = new SharedModuleImportStatus(SURVEY_GUID, SURVEY_CREATED_ON_MILLIS);
-        assertEquals(SharedModuleType.SURVEY, status.getModuleType());
+        assertEquals(status.getModuleType(), SharedModuleType.SURVEY);
         assertNull(status.getSchemaId());
         assertNull(status.getSchemaRevision());
-        assertEquals(SURVEY_GUID, status.getSurveyGuid());
-        assertEquals(SURVEY_CREATED_ON_MILLIS, status.getSurveyCreatedOn().longValue());
+        assertEquals(status.getSurveyGuid(), SURVEY_GUID);
+        assertEquals(status.getSurveyCreatedOn().longValue(), SURVEY_CREATED_ON_MILLIS);
 
         // Test JSON serialization.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(status, JsonNode.class);
-        assertEquals(4, jsonNode.size());
-        assertEquals("survey", jsonNode.get("moduleType").textValue());
-        assertEquals(SURVEY_CREATED_ON_STRING, jsonNode.get("surveyCreatedOn").textValue());
-        assertEquals(SURVEY_GUID, jsonNode.get("surveyGuid").textValue());
-        assertEquals("SharedModuleImportStatus", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 4);
+        assertEquals(jsonNode.get("moduleType").textValue(), "survey");
+        assertEquals(jsonNode.get("surveyCreatedOn").textValue(), SURVEY_CREATED_ON_STRING);
+        assertEquals(jsonNode.get("surveyGuid").textValue(), SURVEY_GUID);
+        assertEquals(jsonNode.get("type").textValue(), "SharedModuleImportStatus");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/sms/SmsTypeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/sms/SmsTypeTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models.sms;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class SmsTypeTest {
     @Test
     public void testGetValue() {
-        assertEquals("Promotional", SmsType.PROMOTIONAL.getValue());
-        assertEquals("Transactional", SmsType.TRANSACTIONAL.getValue());
+        assertEquals(SmsType.PROMOTIONAL.getValue(), "Promotional");
+        assertEquals(SmsType.TRANSACTIONAL.getValue(), "Transactional");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/AndroidAppLinkTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/AndroidAppLinkTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -24,15 +24,16 @@ public class AndroidAppLinkTest {
         AndroidAppLink link = new AndroidAppLink("namespace", "packageName", Lists.newArrayList("fingerprint"));
 
         JsonNode node = MAPPER.valueToTree(link);
-        assertEquals(3, node.size());
-        assertEquals("namespace", node.get("namespace").textValue());
-        assertEquals("packageName", node.get("package_name").textValue());
-        assertEquals("fingerprint", node.get("sha256_cert_fingerprints").get(0).textValue());
+        assertEquals(node.size(), 3);
+        assertEquals(node.get("namespace").textValue(), "namespace");
+        assertEquals(node.get("package_name").textValue(), "packageName");
+        assertEquals(node.get("sha256_cert_fingerprints").get(0).textValue(), "fingerprint");
         
         AndroidAppLink deser = MAPPER.readValue(node.toString(), AndroidAppLink.class);
-        assertEquals("namespace", deser.getNamespace());
-        assertEquals("packageName", deser.getPackageName());
-        assertEquals(1, deser.getFingerprints().size());
-        assertEquals("fingerprint", deser.getFingerprints().get(0));    }
+        assertEquals(deser.getNamespace(), "namespace");
+        assertEquals(deser.getPackageName(), "packageName");
+        assertEquals(deser.getFingerprints().size(), 1);
+        assertEquals(deser.getFingerprints().get(0), "fingerprint");
+    }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/AppleAppLinkTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/AppleAppLinkTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
+
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -26,16 +26,16 @@ public class AppleAppLinkTest {
         // We serialize this without the "type" attribute because we're following a schema handed
         // to us by Apple.
         JsonNode node = MAPPER.valueToTree(link);
-        assertEquals(2, node.size());
-        assertEquals("appId", node.get("appID").textValue());
+        assertEquals(node.size(), 2);
+        assertEquals(node.get("appID").textValue(), "appId");
         ArrayNode array = (ArrayNode)node.get("paths");
-        assertEquals(2, array.size());
-        assertEquals("/appId/", array.get(0).textValue());
-        assertEquals("/appId/*", array.get(1).textValue());
+        assertEquals(array.size(), 2);
+        assertEquals(array.get(0).textValue(), "/appId/");
+        assertEquals(array.get(1).textValue(), "/appId/*");
         
         AppleAppLink deser = MAPPER.readValue(node.toString(), AppleAppLink.class);
-        assertEquals("appId", deser.getAppId());
-        assertEquals("/appId/", deser.getPaths().get(0));
-        assertEquals("/appId/*", deser.getPaths().get(1));
+        assertEquals(deser.getAppId(), "appId");
+        assertEquals(deser.getPaths().get(0), "/appId/");
+        assertEquals(deser.getPaths().get(1), "/appId/*");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EmailTemplateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EmailTemplateTest.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,7 +26,7 @@ public class EmailTemplateTest {
         String json = "{\"subject\":\"${studyName} sign in link\",\"body\":\"<p>${host}/${token}</p>\",\"mimeType\":\"HTML\"}";
         
         EmailTemplate template = new ObjectMapper().readValue(json, EmailTemplate.class);
-        assertEquals(MimeType.HTML, template.getMimeType());
+        assertEquals(template.getMimeType(), MimeType.HTML);
     }
     
     @Test
@@ -34,17 +36,17 @@ public class EmailTemplateTest {
         String json = BridgeObjectMapper.get().writeValueAsString(template);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("Subject", node.get("subject").asText());
-        assertEquals("Body", node.get("body").asText());
-        assertEquals("EmailTemplate", node.get("type").asText());
+        assertEquals(node.get("subject").asText(), "Subject");
+        assertEquals(node.get("body").asText(), "Body");
+        assertEquals(node.get("type").asText(), "EmailTemplate");
         
         EmailTemplate template2 = BridgeObjectMapper.get().readValue(json, EmailTemplate.class);
-        assertEquals(template, template2);
+        assertEquals(template2, template);
     }
 
     @Test
     public void mimeTypeHasDefault() {
         EmailTemplate template = new EmailTemplate("Subject", "Body", null);
-        assertEquals(MimeType.HTML, template.getMimeType());
+        assertEquals(template.getMimeType(), MimeType.HTML);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EmailVerificationStatusHolderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EmailVerificationStatusHolderTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.services.EmailVerificationStatus;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -18,10 +18,10 @@ public class EmailVerificationStatusHolderTest {
         String json = BridgeObjectMapper.get().writeValueAsString(holder);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("EmailVerificationStatus", node.get("type").asText());
-        assertEquals("pending", node.get("status").asText());
+        assertEquals(node.get("type").asText(), "EmailVerificationStatus");
+        assertEquals(node.get("status").asText(), "pending");
         
         EmailVerificationStatusHolder newHolder = BridgeObjectMapper.get().readValue(json, EmailVerificationStatusHolder.class);
-        assertEquals(holder.getStatus(), newHolder.getStatus());
+        assertEquals(newHolder.getStatus(), holder.getStatus());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/MimeTypeTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -16,28 +16,28 @@ public class MimeTypeTest {
         ObjectMapper mapper = BridgeObjectMapper.get();
         
         MimeType deser = mapper.readValue("\"pdf\"", MimeType.class);
-        assertEquals(MimeType.PDF, deser);
+        assertEquals(deser, MimeType.PDF);
         
         deser = mapper.readValue("\"application/pdf\"", MimeType.class);
-        assertEquals(MimeType.PDF, deser);
+        assertEquals(deser, MimeType.PDF);
         
         deser = mapper.readValue("\"HTML\"", MimeType.class);
-        assertEquals(MimeType.HTML, deser);
+        assertEquals(deser, MimeType.HTML);
         
         deser = mapper.readValue("\"text/html\"", MimeType.class);
-        assertEquals(MimeType.HTML, deser);
+        assertEquals(deser, MimeType.HTML);
         
         deser = mapper.readValue("\"TEXT/PLAIN\"", MimeType.class);
-        assertEquals(MimeType.TEXT, deser);
+        assertEquals(deser, MimeType.TEXT);
     }
     
     @Test
     public void serializationUsesMimeTypeValue() throws Exception {
         ObjectMapper mapper = BridgeObjectMapper.get();
         
-        assertEquals("\"text/html\"", mapper.writeValueAsString(MimeType.HTML));
-        assertEquals("\"text/plain\"", mapper.writeValueAsString(MimeType.TEXT));
-        assertEquals("\"application/pdf\"", mapper.writeValueAsString(MimeType.PDF));
+        assertEquals(mapper.writeValueAsString(MimeType.HTML), "\"text/html\"");
+        assertEquals(mapper.writeValueAsString(MimeType.TEXT), "\"text/plain\"");
+        assertEquals(mapper.writeValueAsString(MimeType.PDF), "\"application/pdf\"");
     }
     
     /**
@@ -51,7 +51,7 @@ public class MimeTypeTest {
         
         MimeType type = mapper.readValue(json, MimeType.class);
         
-        assertEquals(MimeType.HTML, type);
+        assertEquals(type, MimeType.HTML);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/OAuthProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/OAuthProviderTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -23,17 +24,17 @@ public class OAuthProviderTest {
         OAuthProvider provider = new OAuthProvider("clientId", "secret", "endpoint", CALLBACK_URL);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(provider);
-        assertEquals("clientId", node.get("clientId").textValue());
-        assertEquals("secret", node.get("secret").textValue());
-        assertEquals("endpoint", node.get("endpoint").textValue());
-        assertEquals(CALLBACK_URL, node.get("callbackUrl").textValue());
-        assertEquals("OAuthProvider", node.get("type").textValue());
-        assertEquals(5, node.size());
+        assertEquals(node.get("clientId").textValue(), "clientId");
+        assertEquals(node.get("secret").textValue(), "secret");
+        assertEquals(node.get("endpoint").textValue(), "endpoint");
+        assertEquals(node.get("callbackUrl").textValue(), CALLBACK_URL);
+        assertEquals(node.get("type").textValue(), "OAuthProvider");
+        assertEquals(node.size(), 5);
         
         OAuthProvider deser = BridgeObjectMapper.get().readValue(node.toString(), OAuthProvider.class);
-        assertEquals("clientId", deser.getClientId());
-        assertEquals("secret", deser.getSecret());
-        assertEquals("endpoint", deser.getEndpoint());
-        assertEquals(CALLBACK_URL, deser.getCallbackUrl());
+        assertEquals(deser.getClientId(), "clientId");
+        assertEquals(deser.getSecret(), "secret");
+        assertEquals(deser.getEndpoint(), "endpoint");
+        assertEquals(deser.getCallbackUrl(), CALLBACK_URL);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/PasswordPolicyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/PasswordPolicyTest.java
@@ -1,10 +1,13 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.*;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,14 +25,14 @@ public class PasswordPolicyTest {
         String json = BridgeObjectMapper.get().writeValueAsString(policy);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals(8, node.get("minLength").asInt());
+        assertEquals(node.get("minLength").asInt(), 8);
         assertTrue(node.get("numericRequired").asBoolean());
         assertTrue(node.get("symbolRequired").asBoolean());
         assertTrue(node.get("lowerCaseRequired").asBoolean());
         assertTrue(node.get("upperCaseRequired").asBoolean());
-        assertEquals("PasswordPolicy", node.get("type").asText());
+        assertEquals(node.get("type").asText(), "PasswordPolicy");
         
         PasswordPolicy policy2 = BridgeObjectMapper.get().readValue(json, PasswordPolicy.class);
-        assertEquals(policy, policy2);
+        assertEquals(policy2, policy);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/SmsTemplateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/SmsTemplateTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,7 +23,7 @@ public class SmsTemplateTest {
         String json = "{\"message\":\"a message\"}";
         
         SmsTemplate template = new ObjectMapper().readValue(json, SmsTemplate.class);
-        assertEquals("a message", template.getMessage());
+        assertEquals(template.getMessage(), "a message");
     }
     
     @Test
@@ -32,9 +33,9 @@ public class SmsTemplateTest {
         String json = BridgeObjectMapper.get().writeValueAsString(template);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("a message", node.get("message").textValue());
+        assertEquals(node.get("message").textValue(), "a message");
         
         SmsTemplate template2 = BridgeObjectMapper.get().readValue(json, SmsTemplate.class);
-        assertEquals(template, template2);
+        assertEquals(template2, template);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/StudyAndUsersTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/StudyAndUsersTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.LinkedHashSet;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -90,8 +91,8 @@ public class StudyAndUsersTest {
         List<StudyParticipant> userList = retStudyAndUsers.getUsers();
 
         // verify
-        assertEquals(adminIds, retAdminIds);
-        assertEquals(study, retStudy);
-        assertEquals(mockUsers, userList);
+        assertEquals(retAdminIds, adminIds);
+        assertEquals(retStudy, study);
+        assertEquals(userList, mockUsers);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/StudyIdentifierImplTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/StudyIdentifierImplTest.java
@@ -3,7 +3,8 @@ package org.sagebionetworks.bridge.models.studies;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 
 public class StudyIdentifierImplTest {
@@ -13,17 +14,17 @@ public class StudyIdentifierImplTest {
         EqualsVerifier.forClass(StudyIdentifierImpl.class).suppress(Warning.NONFINAL_FIELDS).allFieldsShouldBeUsed().verify();
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void throwWithNull() {
         new StudyIdentifierImpl(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void throwWithEmpty() {
         new StudyIdentifierImpl("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void throwWithBlank() {
         new StudyIdentifierImpl(" ");
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/SynapseProjectIdTeamIdHolderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/SynapseProjectIdTeamIdHolderTest.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.models.studies;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import static org.testng.Assert.assertEquals;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 public class SynapseProjectIdTeamIdHolderTest {
     private static final String TEST_PROJECT_ID = "test-project-id";
@@ -17,7 +19,7 @@ public class SynapseProjectIdTeamIdHolderTest {
         String synapseIds = BridgeObjectMapper.get().writeValueAsString(holder);
         JsonNode synapse = BridgeObjectMapper.get().readTree(synapseIds);
 
-        assertEquals(TEST_PROJECT_ID, synapse.get("projectId").asText());
-        assertEquals(TEST_TEAM_ID.longValue(), synapse.get("teamId").asLong());
+        assertEquals(synapse.get("projectId").asText(), TEST_PROJECT_ID);
+        assertEquals(synapse.get("teamId").asLong(), TEST_TEAM_ID.longValue());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/subpopulations/ConsentSignatureTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/subpopulations/ConsentSignatureTest.java
@@ -1,19 +1,19 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,12 +22,12 @@ public class ConsentSignatureTest {
     private static final DateTime SIGNED_ON_TIMESTAMP = DateTime.now(DateTimeZone.UTC);
     private static final DateTime WITHDREW_ON_TIMESTAMP = DateTime.now(DateTimeZone.UTC).plusDays(1);
     
-    @Before
+    @BeforeMethod
     public void before() {
         DateTimeUtils.setCurrentMillisFixed(SIGNED_ON_TIMESTAMP.getMillis());
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -45,17 +45,15 @@ public class ConsentSignatureTest {
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
         assertNull(node.get("consentCreatedOn"));
-        assertEquals(WITHDREW_ON_TIMESTAMP.toString(),
-                node.get("withdrewOn").textValue());
-        assertEquals(SIGNED_ON_TIMESTAMP.toString(), 
-                node.get("signedOn").textValue());
-        assertEquals("ConsentSignature", node.get("type").textValue());
+        assertEquals(node.get("withdrewOn").textValue(), WITHDREW_ON_TIMESTAMP.toString());
+        assertEquals(node.get("signedOn").textValue(), SIGNED_ON_TIMESTAMP.toString());
+        assertEquals(node.get("type").textValue(), "ConsentSignature");
         
         ConsentSignature deser = ConsentSignature.fromJSON(node);
-        assertEquals("Dave Test", deser.getName());
-        assertEquals("1970-01-01", deser.getBirthdate());
-        assertEquals(SIGNED_ON_TIMESTAMP.getMillis(), deser.getSignedOn()); // this is set in the builder
-        assertEquals(0L, deser.getConsentCreatedOn());
+        assertEquals(deser.getName(), "Dave Test");
+        assertEquals(deser.getBirthdate(), "1970-01-01");
+        assertEquals(deser.getSignedOn(), SIGNED_ON_TIMESTAMP.getMillis()); // this is set in the builder
+        assertEquals(deser.getConsentCreatedOn(), 0L);
         assertNull(deser.getWithdrewOn());
     }
     
@@ -64,9 +62,9 @@ public class ConsentSignatureTest {
         ConsentSignature sig = new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
                 .withConsentCreatedOn(CONSENT_CREATED_ON_TIMESTAMP.getMillis())
                 .withSignedOn(SIGNED_ON_TIMESTAMP.getMillis()).build();
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
-        assertEquals(CONSENT_CREATED_ON_TIMESTAMP.getMillis(), sig.getConsentCreatedOn());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
+        assertEquals(sig.getConsentCreatedOn(), CONSENT_CREATED_ON_TIMESTAMP.getMillis());
         assertNull(sig.getImageData());
         assertNull(sig.getImageMimeType());
     }
@@ -76,18 +74,18 @@ public class ConsentSignatureTest {
         ConsentSignature sig = new ConsentSignature.Builder().withName("test name").withBirthdate("1970-01-01")
                 .withImageData(TestConstants.DUMMY_IMAGE_DATA).withImageMimeType("image/fake")
                 .withSignedOn(SIGNED_ON_TIMESTAMP.getMillis()).build();
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
-        assertEquals(TestConstants.DUMMY_IMAGE_DATA, sig.getImageData());
-        assertEquals("image/fake", sig.getImageMimeType());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
+        assertEquals(sig.getImageData(), TestConstants.DUMMY_IMAGE_DATA);
+        assertEquals(sig.getImageMimeType(), "image/fake");
     }
 
     @Test
     public void jsonHappyCase() throws Exception {
         String jsonStr = "{\"name\":\"test name\", \"birthdate\":\"1970-01-01\"}";
         ConsentSignature sig = BridgeObjectMapper.get().readValue(jsonStr, ConsentSignature.class);
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
         assertNull(sig.getImageData());
         assertNull(sig.getImageMimeType());
     }
@@ -101,8 +99,8 @@ public class ConsentSignatureTest {
                 "   \"imageMimeType\":null\n" +
                 "}";
         ConsentSignature sig = BridgeObjectMapper.get().readValue(jsonStr, ConsentSignature.class);
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
         assertNull(sig.getImageData());
         assertNull(sig.getImageMimeType());
     }
@@ -116,20 +114,20 @@ public class ConsentSignatureTest {
                 "   \"imageMimeType\":\"image/fake\"\n" +
                 "}";
         ConsentSignature sig = BridgeObjectMapper.get().readValue(jsonStr, ConsentSignature.class);
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
-        assertEquals(TestConstants.DUMMY_IMAGE_DATA, sig.getImageData());
-        assertEquals("image/fake", sig.getImageMimeType());
-        assertEquals(SIGNED_ON_TIMESTAMP.getMillis(), sig.getSignedOn());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
+        assertEquals(sig.getImageData(), TestConstants.DUMMY_IMAGE_DATA);
+        assertEquals(sig.getImageMimeType(), "image/fake");
+        assertEquals(sig.getSignedOn(), SIGNED_ON_TIMESTAMP.getMillis());
     }
     
     @Test
     public void existingSignatureJsonDeserializesWithoutSignedOn() throws Exception {
         String json = "{\"name\":\"test name\",\"birthdate\":\"1970-01-01\"}";
         ConsentSignature sig = BridgeObjectMapper.get().readValue(json, ConsentSignature.class);
-        assertEquals("test name", sig.getName());
-        assertEquals("1970-01-01", sig.getBirthdate());
-        assertEquals(SIGNED_ON_TIMESTAMP.getMillis(), sig.getSignedOn());
+        assertEquals(sig.getName(), "test name");
+        assertEquals(sig.getBirthdate(), "1970-01-01");
+        assertEquals(sig.getSignedOn(), SIGNED_ON_TIMESTAMP.getMillis());
     }
     
     @Test
@@ -139,14 +137,14 @@ public class ConsentSignatureTest {
 
         ConsentSignature updated = new ConsentSignature.Builder().withConsentSignature(sig)
                 .withSignedOn(SIGNED_ON_TIMESTAMP.getMillis()).build();
-        assertEquals("test name", updated.getName());
-        assertEquals("1970-01-01", updated.getBirthdate());
-        assertEquals(SIGNED_ON_TIMESTAMP.getMillis(), updated.getSignedOn());
+        assertEquals(updated.getName(), "test name");
+        assertEquals(updated.getBirthdate(), "1970-01-01");
+        assertEquals(updated.getSignedOn(), SIGNED_ON_TIMESTAMP.getMillis());
         
         json = "{\"name\":\"test name\",\"birthdate\":\"1970-01-01\",\"signedOn\":\"" + 
                 SIGNED_ON_TIMESTAMP.toString() + "\"}";
         sig = BridgeObjectMapper.get().readValue(json, ConsentSignature.class);
-        assertEquals(SIGNED_ON_TIMESTAMP.getMillis(), sig.getSignedOn());
+        assertEquals(sig.getSignedOn(), SIGNED_ON_TIMESTAMP.getMillis());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/subpopulations/StudyConsentFormTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/subpopulations/StudyConsentFormTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -19,11 +19,11 @@ public class StudyConsentFormTest {
         String json = BridgeObjectMapper.get().writeValueAsString(form);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("<p>This is content</p>", node.get("documentContent").asText());
-        assertEquals("StudyConsent", node.get("type").asText());
+        assertEquals(node.get("documentContent").asText(), "<p>This is content</p>");
+        assertEquals(node.get("type").asText(), "StudyConsent");
         
         StudyConsentForm newForm = BridgeObjectMapper.get().readValue(json, StudyConsentForm.class);
-        assertEquals(form.getDocumentContent(), newForm.getDocumentContent());
+        assertEquals(newForm.getDocumentContent(), form.getDocumentContent());
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/subpopulations/StudyConsentViewTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudyConsent1;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -27,13 +28,13 @@ public class StudyConsentViewTest {
         String json = BridgeObjectMapper.get().writeValueAsString(view);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("<document/>", node.get("documentContent").asText());
-        assertEquals("1970-01-01T00:00:00.200Z", node.get("createdOn").asText());
-        assertEquals("test", node.get("subpopulationGuid").asText());
-        assertEquals("StudyConsent", node.get("type").asText());
+        assertEquals(node.get("documentContent").asText(), "<document/>");
+        assertEquals(node.get("createdOn").asText(), "1970-01-01T00:00:00.200Z");
+        assertEquals(node.get("subpopulationGuid").asText(), "test");
+        assertEquals(node.get("type").asText(), "StudyConsent");
         
         StudyConsentForm form = BridgeObjectMapper.get().readValue(json, StudyConsentForm.class);
-        assertEquals("<document/>", form.getDocumentContent());
+        assertEquals(form.getDocumentContent(), "<document/>");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/subpopulations/SubpopulationGuidTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/subpopulations/SubpopulationGuidTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.subpopulations;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -13,6 +13,6 @@ public class SubpopulationGuidTest {
     }
     @Test
     public void testToString() {
-        assertEquals("ABC", SubpopulationGuid.create("ABC").toString());
+        assertEquals(SubpopulationGuid.create("ABC").toString(), "ABC");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/substudies/AccountSubstudyIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/substudies/AccountSubstudyIdTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.substudies;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -18,9 +18,9 @@ public class AccountSubstudyIdTest {
     @Test
     public void create() { 
         AccountSubstudyId key = new AccountSubstudyId("studyId", "substudyId", "accountId");
-        assertEquals("studyId", key.getStudyId());
-        assertEquals("substudyId", key.getSubstudyId());
-        assertEquals("accountId", key.getAccountId());
+        assertEquals(key.getStudyId(), "studyId");
+        assertEquals(key.getSubstudyId(), "substudyId");
+        assertEquals(key.getAccountId(), "accountId");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/substudies/AccountSubstudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/substudies/AccountSubstudyTest.java
@@ -1,17 +1,17 @@
 package org.sagebionetworks.bridge.models.substudies;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class AccountSubstudyTest {
 
     @Test
     public void create() {
         AccountSubstudy substudy = AccountSubstudy.create("studyId", "substudyId", "accountId");
-        assertEquals("studyId", substudy.getStudyId());
-        assertEquals("substudyId", substudy.getSubstudyId());
-        assertEquals("accountId", substudy.getAccountId());
+        assertEquals(substudy.getStudyId(), "studyId");
+        assertEquals(substudy.getSubstudyId(), "substudyId");
+        assertEquals(substudy.getAccountId(), "accountId");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/substudies/SubstudyIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/substudies/SubstudyIdTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.substudies;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -19,7 +19,7 @@ public class SubstudyIdTest {
     public void test() {
         SubstudyId studyId = new SubstudyId("studyId", "id");
         
-        assertEquals("studyId", studyId.getStudyId());
-        assertEquals("id", studyId.getId());
+        assertEquals(studyId.getStudyId(), "studyId");
+        assertEquals(studyId.getId(), "id");
     }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/ConstraintTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/ConstraintTest.java
@@ -1,8 +1,9 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 public class ConstraintTest {
@@ -18,10 +19,10 @@ public class ConstraintTest {
         String json = BridgeObjectMapper.get().writeValueAsString(c);
         c = BridgeObjectMapper.get().readValue(json, IntegerConstraints.class);
         
-        assertEquals(DataType.INTEGER, c.getDataType());
-        assertEquals(Unit.MILLILITERS, c.getUnit());
-        assertEquals(new Double(1.0d), c.getMinValue());
-        assertEquals(new Double(10000000d), c.getMaxValue());
+        assertEquals(c.getDataType(), DataType.INTEGER);
+        assertEquals(c.getUnit(), Unit.MILLILITERS);
+        assertEquals(c.getMinValue(), new Double(1.0d));
+        assertEquals(c.getMaxValue(), new Double(10000000d));
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/ConstraintsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/ConstraintsTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 public class ConstraintsTest {
@@ -20,7 +21,7 @@ public class ConstraintsTest {
         constraints.setLatestValue(DateTime.parse("2015-12-31T10:10:10-07:00"));
 
         String json = BridgeObjectMapper.get().writeValueAsString(constraints);
-        assertEquals(json.indexOf("\"dataType\""), json.lastIndexOf("\"dataType\""));
+        assertEquals(json.lastIndexOf("\"dataType\""), json.indexOf("\"dataType\""));
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/DateConstraintsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/DateConstraintsTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -19,10 +20,10 @@ public class DateConstraintsTest {
         String json = BridgeObjectMapper.get().writeValueAsString(constraints);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
         
-        assertEquals("2015-01-01", node.get("earliestValue").asText());
-        assertEquals("2015-12-31", node.get("latestValue").asText());
-        assertEquals("date", node.get("dataType").asText());
-        assertEquals("DateConstraints", node.get("type").asText());
+        assertEquals(node.get("earliestValue").asText(), "2015-01-01");
+        assertEquals(node.get("latestValue").asText(), "2015-12-31");
+        assertEquals(node.get("dataType").asText(), "date");
+        assertEquals(node.get("type").asText(), "DateConstraints");
     }
     
     

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/DateTimeConstraintsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/DateTimeConstraintsTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,10 +23,10 @@ public class DateTimeConstraintsTest {
         // The serialization is losing the time zone used by the user initially,
         // and this we don't want. We would need to create custom serializer/deserializers
         // for this.
-        assertEquals("2015-01-01T10:10:10.000-07:00", node.get("earliestValue").asText());
-        assertEquals("2015-12-31T10:10:10.000-07:00", node.get("latestValue").asText());
-        assertEquals("datetime", node.get("dataType").asText());
-        assertEquals("DateTimeConstraints", node.get("type").asText());
+        assertEquals(node.get("earliestValue").asText(), "2015-01-01T10:10:10.000-07:00");
+        assertEquals(node.get("latestValue").asText(), "2015-12-31T10:10:10.000-07:00");
+        assertEquals(node.get("dataType").asText(), "datetime");
+        assertEquals(node.get("type").asText(), "DateTimeConstraints");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/PostalCodeConstraintsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/PostalCodeConstraintsTest.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.Test;
 
-import org.junit.Test;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -16,19 +17,19 @@ public class PostalCodeConstraintsTest {
         pcc.setCountryCode(CountryCode.US);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(pcc);
-        assertEquals("postalcode", node.get("dataType").textValue());
-        assertEquals("us", node.get("countryCode").textValue());
-        assertEquals("PostalCodeConstraints", node.get("type").textValue());
+        assertEquals(node.get("dataType").textValue(), "postalcode");
+        assertEquals(node.get("countryCode").textValue(), "us");
+        assertEquals(node.get("type").textValue(), "PostalCodeConstraints");
         int len = BridgeConstants.SPARSE_ZIP_CODE_PREFIXES.size();
-        assertEquals(len, node.get("sparseZipCodePrefixes").size());
+        assertEquals(node.get("sparseZipCodePrefixes").size(), len);
         for (int i=0; i < len; i++) {
             String zipCodePrefix = BridgeConstants.SPARSE_ZIP_CODE_PREFIXES.get(i);
-            assertEquals(zipCodePrefix, node.get("sparseZipCodePrefixes").get(i).textValue());
+            assertEquals(node.get("sparseZipCodePrefixes").get(i).textValue(), zipCodePrefix);
         }
         
         // Verify that the mapper correctly selects the subclass we want.
         PostalCodeConstraints deser = (PostalCodeConstraints) BridgeObjectMapper
                 .get().readValue(node.toString(), Constraints.class);
-        assertEquals(CountryCode.US, deser.getCountryCode());
+        assertEquals(deser.getCountryCode(), CountryCode.US);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyElementTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurveyInfoScreen;
@@ -44,43 +44,43 @@ public class SurveyElementTest {
         assertNull(question.getConstraints());
         assertNotNull(question.getData());
         assertFalse(question.getFireEvent());
-        assertEquals("test-guid", question.getGuid());
-        assertEquals("test-survey-question", question.getIdentifier());
-        assertEquals(0, question.getOrder());
-        assertEquals("Is this a survey question?", question.getPrompt());
-        assertEquals("Details about question", question.getPromptDetail());
+        assertEquals(question.getGuid(), "test-guid");
+        assertEquals(question.getIdentifier(), "test-survey-question");
+        assertEquals(question.getOrder(), 0);
+        assertEquals(question.getPrompt(), "Is this a survey question?");
+        assertEquals(question.getPromptDetail(), "Details about question");
         assertNull(question.getSurveyCompoundKey());
-        assertEquals("SurveyQuestion", question.getType());
-        assertEquals(UIHint.TEXTFIELD, question.getUiHint());
+        assertEquals(question.getType(), "SurveyQuestion");
+        assertEquals(question.getUiHint(), UIHint.TEXTFIELD);
         
-        assertEquals(BEFORE_RULE, question.getBeforeRules().get(0));
-        assertEquals(AFTER_RULE, question.getAfterRules().get(0));
+        assertEquals(question.getBeforeRules().get(0), BEFORE_RULE);
+        assertEquals(question.getAfterRules().get(0), AFTER_RULE);
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(question);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(9, jsonMap.size());
+        assertEquals(jsonMap.size(), 9);
         assertFalse((boolean) jsonMap.get("fireEvent"));
-        assertEquals("test-guid", jsonMap.get("guid"));
-        assertEquals("test-survey-question", jsonMap.get("identifier"));
-        assertEquals("Is this a survey question?", jsonMap.get("prompt"));
-        assertEquals("Details about question", jsonMap.get("promptDetail"));
-        assertEquals("SurveyQuestion", jsonMap.get("type"));
-        assertEquals("textfield", jsonMap.get("uiHint"));
+        assertEquals(jsonMap.get("guid"), "test-guid");
+        assertEquals(jsonMap.get("identifier"), "test-survey-question");
+        assertEquals(jsonMap.get("prompt"), "Is this a survey question?");
+        assertEquals(jsonMap.get("promptDetail"), "Details about question");
+        assertEquals(jsonMap.get("type"), "SurveyQuestion");
+        assertEquals(jsonMap.get("uiHint"), "textfield");
         
         SurveyQuestion deserQuestion = BridgeObjectMapper.get().readValue(convertedJson, SurveyQuestion.class);
         
         assertFalse(deserQuestion.getFireEvent());
-        assertEquals("test-guid", deserQuestion.getGuid());
-        assertEquals("test-survey-question", deserQuestion.getIdentifier());
-        assertEquals("Is this a survey question?", deserQuestion.getPrompt());
-        assertEquals("Details about question", deserQuestion.getPromptDetail());
-        assertEquals("SurveyQuestion", deserQuestion.getType());
-        assertEquals(UIHint.TEXTFIELD, deserQuestion.getUiHint());
-        assertEquals(BEFORE_RULE, deserQuestion.getBeforeRules().get(0));
-        assertEquals(AFTER_RULE, deserQuestion.getAfterRules().get(0));
+        assertEquals(deserQuestion.getGuid(), "test-guid");
+        assertEquals(deserQuestion.getIdentifier(), "test-survey-question");
+        assertEquals(deserQuestion.getPrompt(), "Is this a survey question?");
+        assertEquals(deserQuestion.getPromptDetail(), "Details about question");
+        assertEquals(deserQuestion.getType(), "SurveyQuestion");
+        assertEquals(deserQuestion.getUiHint(), UIHint.TEXTFIELD);
+        assertEquals(deserQuestion.getBeforeRules().get(0), BEFORE_RULE);
+        assertEquals(deserQuestion.getAfterRules().get(0), AFTER_RULE);
     }
 
     @Test
@@ -104,43 +104,43 @@ public class SurveyElementTest {
         DynamoSurveyInfoScreen infoScreen = (DynamoSurveyInfoScreen) BridgeObjectMapper.get().readValue(jsonText,
                 SurveyElement.class);
         assertNotNull(infoScreen.getData());
-        assertEquals("test-guid", infoScreen.getGuid());
-        assertEquals("test-survey-info-screen", infoScreen.getIdentifier());
-        assertEquals(0, infoScreen.getOrder());
-        assertEquals("This is the survey info", infoScreen.getPrompt());
-        assertEquals("More info", infoScreen.getPromptDetail());
+        assertEquals(infoScreen.getGuid(), "test-guid");
+        assertEquals(infoScreen.getIdentifier(), "test-survey-info-screen");
+        assertEquals(infoScreen.getOrder(), 0);
+        assertEquals(infoScreen.getPrompt(), "This is the survey info");
+        assertEquals(infoScreen.getPromptDetail(), "More info");
         assertNull(infoScreen.getSurveyCompoundKey());
-        assertEquals("Survey Info", infoScreen.getTitle());
-        assertEquals("SurveyInfoScreen", infoScreen.getType());
-        assertEquals(BEFORE_RULE, infoScreen.getBeforeRules().get(0));
-        assertEquals(AFTER_RULE, infoScreen.getAfterRules().get(0));
+        assertEquals(infoScreen.getTitle(), "Survey Info");
+        assertEquals(infoScreen.getType(), "SurveyInfoScreen");
+        assertEquals(infoScreen.getBeforeRules().get(0), BEFORE_RULE);
+        assertEquals(infoScreen.getAfterRules().get(0), AFTER_RULE);
 
-        assertEquals("http://www.example.com/test.png", infoScreen.getImage().getSource());
-        assertEquals(200, infoScreen.getImage().getWidth());
-        assertEquals(150, infoScreen.getImage().getHeight());
+        assertEquals(infoScreen.getImage().getSource(), "http://www.example.com/test.png");
+        assertEquals(infoScreen.getImage().getWidth(), 200);
+        assertEquals(infoScreen.getImage().getHeight(), 150);
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(infoScreen);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(9, jsonMap.size());
-        assertEquals("test-guid", jsonMap.get("guid"));
-        assertEquals("test-survey-info-screen", jsonMap.get("identifier"));
-        assertEquals("This is the survey info", jsonMap.get("prompt"));
-        assertEquals("More info", jsonMap.get("promptDetail"));
-        assertEquals("Survey Info", jsonMap.get("title"));
-        assertEquals("SurveyInfoScreen", jsonMap.get("type"));
+        assertEquals(jsonMap.size(), 9);
+        assertEquals(jsonMap.get("guid"), "test-guid");
+        assertEquals(jsonMap.get("identifier"), "test-survey-info-screen");
+        assertEquals(jsonMap.get("prompt"), "This is the survey info");
+        assertEquals(jsonMap.get("promptDetail"), "More info");
+        assertEquals(jsonMap.get("title"), "Survey Info");
+        assertEquals(jsonMap.get("type"), "SurveyInfoScreen");
 
         Map<String, Object> imageMap = (Map<String, Object>) jsonMap.get("image");
-        assertEquals(4, imageMap.size());
-        assertEquals("http://www.example.com/test.png", imageMap.get("source"));
-        assertEquals(200, imageMap.get("width"));
-        assertEquals(150, imageMap.get("height"));
-        assertEquals("Image", imageMap.get("type"));
+        assertEquals(imageMap.size(), 4);
+        assertEquals(imageMap.get("source"), "http://www.example.com/test.png");
+        assertEquals(imageMap.get("width"), 200);
+        assertEquals(imageMap.get("height"), 150);
+        assertEquals(imageMap.get("type"), "Image");
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void serializeInvalidSurveyElementType() throws Exception {
         // start with JSON
         String jsonText = TestUtils.createJson("{'guid': 'bad-guid'," +

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
 
 public class SurveyQuestionOptionTest {
     private static final Image DUMMY_IMAGE = new Image("dummy-source", 42, 42);
@@ -13,10 +14,10 @@ public class SurveyQuestionOptionTest {
     @Test
     public void allValues() {
         SurveyQuestionOption option = new SurveyQuestionOption("test-label", "test-detail", "test-value", DUMMY_IMAGE);
-        assertEquals("test-label", option.getLabel());
-        assertEquals("test-detail", option.getDetail());
-        assertEquals("test-value", option.getValue());
-        assertEquals(DUMMY_IMAGE, option.getImage());
+        assertEquals(option.getLabel(), "test-label");
+        assertEquals(option.getDetail(), "test-detail");
+        assertEquals(option.getValue(), "test-value");
+        assertEquals(option.getImage(), DUMMY_IMAGE);
 
         String optionString = option.toString();
         assertTrue(optionString.contains(option.getLabel()));
@@ -30,7 +31,7 @@ public class SurveyQuestionOptionTest {
         String[] testCaseArr = { null, "", "   " };
         for (String oneTestCase : testCaseArr) {
             SurveyQuestionOption option = new SurveyQuestionOption("test-label", null, oneTestCase, null);
-            assertEquals("test-label", option.getValue());
+            assertEquals(option.getValue(), "test-label");
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyRuleTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.TreeSet;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -30,9 +30,9 @@ public class SurveyRuleTest {
                 "'skipTo':'theend','endSurvey':false}");
         SurveyRule rule = BridgeObjectMapper.get().readValue(json, SurveyRule.class);
         assertNull(rule.getEndSurvey());
-        assertEquals(Operator.EQ, rule.getOperator());
-        assertEquals("theend", rule.getSkipToTarget());
-        assertEquals("No", rule.getValue());
+        assertEquals(rule.getOperator(), Operator.EQ);
+        assertEquals(rule.getSkipToTarget(), "theend");
+        assertEquals(rule.getValue(), "No");
     }
     
     @Test
@@ -41,14 +41,14 @@ public class SurveyRuleTest {
                 .withSkipToTarget("test").withEndSurvey(Boolean.FALSE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(skipToRule);
-        assertEquals("eq", node.get("operator").textValue());
-        assertEquals("value", node.get("value").textValue());
-        assertEquals("test", node.get("skipTo").textValue());
+        assertEquals(node.get("operator").textValue(), "eq");
+        assertEquals(node.get("value").textValue(), "value");
+        assertEquals(node.get("skipTo").textValue(), "test");
         assertNull(node.get("endSurvey"));
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(skipToRule, deser);
+        assertEquals(deser, skipToRule);
     }
 
     @Test
@@ -57,14 +57,14 @@ public class SurveyRuleTest {
                 .withEndSurvey(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(endRule);
-        assertEquals("eq", node.get("operator").textValue());
-        assertEquals("value", node.get("value").textValue());
+        assertEquals(node.get("operator").textValue(), "eq");
+        assertEquals(node.get("value").textValue(), "value");
         assertNull(node.get("skipTo"));
         assertTrue(node.get("endSurvey").booleanValue());
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(endRule, deser);
+        assertEquals(deser, endRule);
     }
     
     @Test
@@ -72,14 +72,14 @@ public class SurveyRuleTest {
         SurveyRule alwaysRule = new SurveyRule.Builder().withOperator(Operator.ALWAYS).withEndSurvey(true).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(alwaysRule);
-        assertEquals("always", node.get("operator").textValue());
+        assertEquals(node.get("operator").textValue(), "always");
         assertNull(node.get("value"));
         assertNull(node.get("skipTo"));
         assertTrue(node.get("endSurvey").booleanValue());
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(alwaysRule, deser);
+        assertEquals(deser, alwaysRule);
     }
     
     @Test
@@ -88,14 +88,14 @@ public class SurveyRuleTest {
                 .withAssignDataGroup("bar").build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(dataGroupRule);
-        assertEquals("eq", node.get("operator").textValue());
-        assertEquals("foo", node.get("value").textValue());
+        assertEquals(node.get("operator").textValue(), "eq");
+        assertEquals(node.get("value").textValue(), "foo");
         assertNull(node.get("skipTo"));
-        assertEquals("bar", node.get("assignDataGroup").textValue());
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("assignDataGroup").textValue(), "bar");
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(dataGroupRule, deser);
+        assertEquals(deser, dataGroupRule);
     }
     
     @Test
@@ -107,14 +107,14 @@ public class SurveyRuleTest {
                 .withDataGroups(displayGroups).withDisplayIf(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(displayIf);
-        assertEquals("any", node.get("operator").textValue());
-        assertEquals("bar", node.get("dataGroups").get(0).textValue());
-        assertEquals("foo", node.get("dataGroups").get(1).textValue());
+        assertEquals(node.get("operator").textValue(), "any");
+        assertEquals(node.get("dataGroups").get(0).textValue(), "bar");
+        assertEquals(node.get("dataGroups").get(1).textValue(), "foo");
         assertTrue(node.get("displayIf").booleanValue());
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(displayIf, deser);
+        assertEquals(deser, displayIf);
     }
     
     @Test
@@ -123,13 +123,13 @@ public class SurveyRuleTest {
                 .withDataGroups(Sets.newHashSet("foo")).withDisplayUnless(Boolean.TRUE).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(displayIf);
-        assertEquals("any", node.get("operator").textValue());
-        assertEquals("foo", node.get("dataGroups").get(0).textValue());
+        assertEquals(node.get("operator").textValue(), "any");
+        assertEquals(node.get("dataGroups").get(0).textValue(), "foo");
         assertTrue(node.get("displayUnless").booleanValue());
-        assertEquals("SurveyRule", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "SurveyRule");
         
         SurveyRule deser = BridgeObjectMapper.get().treeToValue(node, SurveyRule.class);
-        assertEquals(displayIf, deser);
+        assertEquals(deser, displayIf);
     }
     
     // If the user sends a property set to false, ensure the field is set to null and

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/YearMonthConstraintsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/YearMonthConstraintsTest.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.bridge.models.surveys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.EnumSet;
 
 import org.joda.time.YearMonth;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,19 +23,19 @@ public class YearMonthConstraintsTest {
         String json = BridgeObjectMapper.get().writeValueAsString(constraints);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
 
-        assertEquals("2000-01", node.get("earliestValue").textValue());
-        assertEquals("2009-12", node.get("latestValue").textValue());
-        assertEquals("yearmonth", node.get("dataType").textValue());
+        assertEquals(node.get("earliestValue").textValue(), "2000-01");
+        assertEquals(node.get("latestValue").textValue(), "2009-12");
+        assertEquals(node.get("dataType").textValue(), "yearmonth");
         assertTrue(node.get("allowFuture").booleanValue());
-        assertEquals("YearMonthConstraints", node.get("type").textValue());
+        assertEquals(node.get("type").textValue(), "YearMonthConstraints");
         
         // Deserialize as a Constraints object to verify the right subtype is selected.
         YearMonthConstraints deser = (YearMonthConstraints) BridgeObjectMapper.get()
                 .readValue(node.toString(), Constraints.class);
-        assertEquals(YearMonth.parse("2000-01"), deser.getEarliestValue());
-        assertEquals(YearMonth.parse("2009-12"), deser.getLatestValue());
+        assertEquals(deser.getEarliestValue(), YearMonth.parse("2000-01"));
+        assertEquals(deser.getLatestValue(), YearMonth.parse("2009-12"));
         assertTrue(deser.getAllowFuture());
-        assertEquals(DataType.YEARMONTH, deser.getDataType());
-        assertEquals(EnumSet.of(UIHint.YEARMONTH), deser.getSupportedHints());
+        assertEquals(deser.getDataType(), DataType.YEARMONTH);
+        assertEquals(deser.getSupportedHints(), EnumSet.of(UIHint.YEARMONTH));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadFieldDefinitionTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.models.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +10,8 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.JsonUtils;
@@ -21,27 +22,27 @@ public class UploadFieldDefinitionTest {
     public void testBuilder() {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test-field")
                 .withType(UploadFieldType.ATTACHMENT_BLOB).build();
-        assertEquals("test-field", fieldDef.getName());
+        assertEquals(fieldDef.getName(), "test-field");
         assertTrue(fieldDef.isRequired());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDef.getType());
+        assertEquals(fieldDef.getType(), UploadFieldType.ATTACHMENT_BLOB);
     }
 
     @Test
     public void testRequiredTrue() {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test-field")
                 .withRequired(true).withType(UploadFieldType.ATTACHMENT_BLOB).build();
-        assertEquals("test-field", fieldDef.getName());
+        assertEquals(fieldDef.getName(), "test-field");
         assertTrue(fieldDef.isRequired());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDef.getType());
+        assertEquals(fieldDef.getType(), UploadFieldType.ATTACHMENT_BLOB);
     }
 
     @Test
     public void testRequiredFalse() {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test-field")
                 .withRequired(false).withType(UploadFieldType.ATTACHMENT_BLOB).build();
-        assertEquals("test-field", fieldDef.getName());
+        assertEquals(fieldDef.getName(), "test-field");
         assertFalse(fieldDef.isRequired());
-        assertEquals(UploadFieldType.ATTACHMENT_BLOB, fieldDef.getType());
+        assertEquals(fieldDef.getType(), UploadFieldType.ATTACHMENT_BLOB);
     }
 
     @Test
@@ -55,18 +56,18 @@ public class UploadFieldDefinitionTest {
         List<String> expectedAnswerList = ImmutableList.of("first", "second");
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("multi-choice-field")
                 .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList(originalAnswerList).build();
-        assertEquals(expectedAnswerList, fieldDef.getMultiChoiceAnswerList());
+        assertEquals(fieldDef.getMultiChoiceAnswerList(), expectedAnswerList);
 
         // modify original list, verify that field def stays the same
         originalAnswerList.add("third");
-        assertEquals(expectedAnswerList, fieldDef.getMultiChoiceAnswerList());
+        assertEquals(fieldDef.getMultiChoiceAnswerList(), expectedAnswerList);
     }
 
     @Test
     public void testMultiChoiceAnswerVarargs() {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("multi-choice-field")
                 .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("aa", "bb", "cc").build();
-        assertEquals(ImmutableList.of("aa", "bb", "cc"), fieldDef.getMultiChoiceAnswerList());
+        assertEquals(fieldDef.getMultiChoiceAnswerList(), ImmutableList.of("aa", "bb", "cc"));
     }
 
     @Test
@@ -92,18 +93,18 @@ public class UploadFieldDefinitionTest {
                 .withMaxLength(128).withMultiChoiceAnswerList(multiChoiceAnswerList).withName("optional-stuff")
                 .withRequired(false).withType(UploadFieldType.STRING).withUnboundedText(true).build();
         assertTrue(fieldDef.getAllowOtherChoices());
-        assertEquals(".test", fieldDef.getFileExtension());
-        assertEquals("text/plain", fieldDef.getMimeType());
-        assertEquals(128, fieldDef.getMaxLength().intValue());
-        assertEquals(multiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
-        assertEquals("optional-stuff", fieldDef.getName());
+        assertEquals(fieldDef.getFileExtension(), ".test");
+        assertEquals(fieldDef.getMimeType(), "text/plain");
+        assertEquals(fieldDef.getMaxLength().intValue(), 128);
+        assertEquals(fieldDef.getMultiChoiceAnswerList(), multiChoiceAnswerList);
+        assertEquals(fieldDef.getName(), "optional-stuff");
         assertFalse(fieldDef.isRequired());
-        assertEquals(UploadFieldType.STRING, fieldDef.getType());
+        assertEquals(fieldDef.getType(), UploadFieldType.STRING);
         assertTrue(fieldDef.isUnboundedText());
 
         // Also test copy constructor.
         UploadFieldDefinition copy = new UploadFieldDefinition.Builder().copyOf(fieldDef).build();
-        assertEquals(fieldDef, copy);
+        assertEquals(copy, fieldDef);
     }
 
     @Test
@@ -125,13 +126,13 @@ public class UploadFieldDefinitionTest {
         List<String> expectedMultiChoiceAnswerList = ImmutableList.of("asdf", "jkl");
         UploadFieldDefinition fieldDef = BridgeObjectMapper.get().readValue(jsonText, UploadFieldDefinition.class);
         assertTrue(fieldDef.getAllowOtherChoices());
-        assertEquals(".json", fieldDef.getFileExtension());
-        assertEquals("text/json", fieldDef.getMimeType());
-        assertEquals(24, fieldDef.getMaxLength().intValue());
-        assertEquals(expectedMultiChoiceAnswerList, fieldDef.getMultiChoiceAnswerList());
-        assertEquals("test-field", fieldDef.getName());
+        assertEquals(fieldDef.getFileExtension(), ".json");
+        assertEquals(fieldDef.getMimeType(), "text/json");
+        assertEquals(fieldDef.getMaxLength().intValue(), 24);
+        assertEquals(fieldDef.getMultiChoiceAnswerList(), expectedMultiChoiceAnswerList);
+        assertEquals(fieldDef.getName(), "test-field");
         assertFalse(fieldDef.isRequired());
-        assertEquals(UploadFieldType.INT, fieldDef.getType());
+        assertEquals(fieldDef.getType(), UploadFieldType.INT);
         assertTrue(fieldDef.isUnboundedText());
 
         // convert back to JSON
@@ -139,15 +140,15 @@ public class UploadFieldDefinitionTest {
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(9, jsonMap.size());
+        assertEquals(jsonMap.size(), 9);
         assertTrue((boolean) jsonMap.get("allowOtherChoices"));
-        assertEquals(".json", jsonMap.get("fileExtension"));
-        assertEquals("text/json", jsonMap.get("mimeType"));
-        assertEquals(24, jsonMap.get("maxLength"));
-        assertEquals(expectedMultiChoiceAnswerList, jsonMap.get("multiChoiceAnswerList"));
-        assertEquals("test-field", jsonMap.get("name"));
+        assertEquals(jsonMap.get("fileExtension"), ".json");
+        assertEquals(jsonMap.get("mimeType"), "text/json");
+        assertEquals(jsonMap.get("maxLength"), 24);
+        assertEquals(jsonMap.get("multiChoiceAnswerList"), expectedMultiChoiceAnswerList);
+        assertEquals(jsonMap.get("name"), "test-field");
         assertFalse((boolean) jsonMap.get("required"));
-        assertEquals("int", jsonMap.get("type"));
+        assertEquals(jsonMap.get("type"), "int");
         assertTrue((boolean) jsonMap.get("unboundedText"));
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadSchemaTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,8 +13,10 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.AppVersionHelper;
 import org.sagebionetworks.bridge.dynamodb.DynamoUploadSchema;
@@ -47,16 +49,16 @@ public class UploadSchemaTest {
         assertFieldDefListIsImmutable(schema.getFieldDefinitions());
         {
             List<UploadFieldDefinition> gettedFieldDefList = schema.getFieldDefinitions();
-            assertEquals(1, gettedFieldDefList.size());
-            assertEquals(fieldDef1, gettedFieldDefList.get(0));
+            assertEquals(gettedFieldDefList.size(), 1);
+            assertEquals(gettedFieldDefList.get(0), fieldDef1);
         }
 
         // Modify the original list. getFieldDefinitions() shouldn't reflect this change.
         fieldDefList.add(fieldDef2);
         {
             List<UploadFieldDefinition> gettedFieldDefList = schema.getFieldDefinitions();
-            assertEquals(1, gettedFieldDefList.size());
-            assertEquals(fieldDef1, gettedFieldDefList.get(0));
+            assertEquals(gettedFieldDefList.size(), 1);
+            assertEquals(gettedFieldDefList.get(0), fieldDef1);
         }
 
         // Set field def list to null. It'll come back as empty.
@@ -81,7 +83,7 @@ public class UploadSchemaTest {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setStudyId("api");
         ddbUploadSchema.setSchemaId("test");
-        assertEquals("api:test", ddbUploadSchema.getKey());
+        assertEquals(ddbUploadSchema.getKey(), "api:test");
     }
 
     @Test
@@ -134,35 +136,35 @@ public class UploadSchemaTest {
     public void getStudyAndSchemaFromKey() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey("api:test");
-        assertEquals("api", ddbUploadSchema.getStudyId());
-        assertEquals("test", ddbUploadSchema.getSchemaId());
+        assertEquals(ddbUploadSchema.getStudyId(), "api");
+        assertEquals(ddbUploadSchema.getSchemaId(), "test");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void nullKey() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void emptyKey() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey("");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void keyWithOnePart() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey("keyWithOnePart");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void keyWithEmptyStudy() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey(":test");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void keyWithEmptySchema() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey("api:");
@@ -173,15 +175,15 @@ public class UploadSchemaTest {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setStudyId("api");
         ddbUploadSchema.setSchemaId("test:schema");
-        assertEquals("api:test:schema", ddbUploadSchema.getKey());
+        assertEquals(ddbUploadSchema.getKey(), "api:test:schema");
     }
 
     @Test
     public void setKeyWithColonsInSchema() {
         DynamoUploadSchema ddbUploadSchema = new DynamoUploadSchema();
         ddbUploadSchema.setKey("api:test:schema");
-        assertEquals("api", ddbUploadSchema.getStudyId());
-        assertEquals("test:schema", ddbUploadSchema.getSchemaId());
+        assertEquals(ddbUploadSchema.getStudyId(), "api");
+        assertEquals(ddbUploadSchema.getSchemaId(), "test:schema");
     }
 
     @Test
@@ -195,7 +197,7 @@ public class UploadSchemaTest {
         schema.setStudyId("test-study");
         schema.setSchemaId("test-schema");
         schema.setRevision(7);
-        assertEquals("test-study-test-schema-v7", schema.getSchemaKey().toString());
+        assertEquals(schema.getSchemaKey().toString(), "test-study-test-schema-v7");
     }
 
     @Test
@@ -236,33 +238,33 @@ public class UploadSchemaTest {
 
         // convert to POJO
         UploadSchema uploadSchema = BridgeObjectMapper.get().readValue(jsonText, UploadSchema.class);
-        assertEquals(MODULE_ID, uploadSchema.getModuleId());
-        assertEquals(MODULE_VERSION, uploadSchema.getModuleVersion().intValue());
-        assertEquals("Test Schema", uploadSchema.getName());
-        assertEquals(3, uploadSchema.getRevision());
-        assertEquals("test-schema", uploadSchema.getSchemaId());
-        assertEquals(UploadSchemaType.IOS_SURVEY, uploadSchema.getSchemaType());
-        assertEquals("test-study", uploadSchema.getStudyId());
-        assertEquals("survey-guid", uploadSchema.getSurveyGuid());
-        assertEquals(surveyCreatedOnMillis, uploadSchema.getSurveyCreatedOn().longValue());
+        assertEquals(uploadSchema.getModuleId(), MODULE_ID);
+        assertEquals(uploadSchema.getModuleVersion().intValue(), MODULE_VERSION);
+        assertEquals(uploadSchema.getName(), "Test Schema");
+        assertEquals(uploadSchema.getRevision(), 3);
+        assertEquals(uploadSchema.getSchemaId(), "test-schema");
+        assertEquals(uploadSchema.getSchemaType(), UploadSchemaType.IOS_SURVEY);
+        assertEquals(uploadSchema.getStudyId(), "test-study");
+        assertEquals(uploadSchema.getSurveyGuid(), "survey-guid");
+        assertEquals(uploadSchema.getSurveyCreatedOn().longValue(), surveyCreatedOnMillis);
         assertTrue(uploadSchema.isDeleted());
-        assertEquals(6, ((DynamoUploadSchema) uploadSchema).getVersion().longValue());
+        assertEquals(((DynamoUploadSchema) uploadSchema).getVersion().longValue(), 6);
 
-        assertEquals(ImmutableSet.of("iOS", "Android"), uploadSchema.getAppVersionOperatingSystems());
-        assertEquals(13, uploadSchema.getMinAppVersion("iOS").intValue());
-        assertEquals(37, uploadSchema.getMaxAppVersion("iOS").intValue());
-        assertEquals(23, uploadSchema.getMinAppVersion("Android").intValue());
-        assertEquals(42, uploadSchema.getMaxAppVersion("Android").intValue());
+        assertEquals(uploadSchema.getAppVersionOperatingSystems(), ImmutableSet.of("iOS", "Android"));
+        assertEquals(uploadSchema.getMinAppVersion("iOS").intValue(), 13);
+        assertEquals(uploadSchema.getMaxAppVersion("iOS").intValue(), 37);
+        assertEquals(uploadSchema.getMinAppVersion("Android").intValue(), 23);
+        assertEquals(uploadSchema.getMaxAppVersion("Android").intValue(), 42);
 
         UploadFieldDefinition fooFieldDef = uploadSchema.getFieldDefinitions().get(0);
-        assertEquals("foo", fooFieldDef.getName());
+        assertEquals(fooFieldDef.getName(), "foo");
         assertTrue(fooFieldDef.isRequired());
-        assertEquals(UploadFieldType.INT, fooFieldDef.getType());
+        assertEquals(fooFieldDef.getType(), UploadFieldType.INT);
 
         UploadFieldDefinition barFieldDef = uploadSchema.getFieldDefinitions().get(1);
-        assertEquals("bar", barFieldDef.getName());
+        assertEquals(barFieldDef.getName(), "bar");
         assertFalse(barFieldDef.isRequired());
-        assertEquals(UploadFieldType.STRING, barFieldDef.getType());
+        assertEquals(barFieldDef.getType(), UploadFieldType.STRING);
 
         // Add study ID and verify that it doesn't get leaked into the JSON
         uploadSchema.setStudyId("test-study");
@@ -273,47 +275,47 @@ public class UploadSchemaTest {
         // for consistency in tests, we should do it the same way every time.
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(uploadSchema);
         JsonNode jsonNode = BridgeObjectMapper.get().readTree(convertedJson);
-        assertEquals(15, jsonNode.size());
-        assertEquals(MODULE_ID, jsonNode.get("moduleId").textValue());
-        assertEquals(MODULE_VERSION, jsonNode.get("moduleVersion").intValue());
-        assertEquals("Test Schema", jsonNode.get("name").textValue());
-        assertEquals(3, jsonNode.get("revision").intValue());
-        assertEquals("test-schema", jsonNode.get("schemaId").textValue());
-        assertEquals("ios_survey", jsonNode.get("schemaType").textValue());
-        assertEquals("test-study", jsonNode.get("studyId").textValue());
-        assertEquals("survey-guid", jsonNode.get("surveyGuid").textValue());
-        assertEquals("UploadSchema", jsonNode.get("type").textValue());
+        assertEquals(jsonNode.size(), 15);
+        assertEquals(jsonNode.get("moduleId").textValue(), MODULE_ID);
+        assertEquals(jsonNode.get("moduleVersion").intValue(), MODULE_VERSION);
+        assertEquals(jsonNode.get("name").textValue(), "Test Schema");
+        assertEquals(jsonNode.get("revision").intValue(), 3);
+        assertEquals(jsonNode.get("schemaId").textValue(), "test-schema");
+        assertEquals(jsonNode.get("schemaType").textValue(), "ios_survey");
+        assertEquals(jsonNode.get("studyId").textValue(), "test-study");
+        assertEquals(jsonNode.get("surveyGuid").textValue(), "survey-guid");
+        assertEquals(jsonNode.get("type").textValue(), "UploadSchema");
         assertTrue(jsonNode.get("deleted").booleanValue());
-        assertEquals(6,  jsonNode.get("version").intValue());
+        assertEquals(jsonNode.get("version").intValue(), 6);
         assertTrue(jsonNode.get("deleted").booleanValue());
 
         JsonNode maxAppVersionMap = jsonNode.get("maxAppVersions");
-        assertEquals(2, maxAppVersionMap.size());
-        assertEquals(37, maxAppVersionMap.get("iOS").intValue());
-        assertEquals(42, maxAppVersionMap.get("Android").intValue());
+        assertEquals(maxAppVersionMap.size(), 2);
+        assertEquals(maxAppVersionMap.get("iOS").intValue(), 37);
+        assertEquals(maxAppVersionMap.get("Android").intValue(), 42);
 
         JsonNode minAppVersionMap = jsonNode.get("minAppVersions");
-        assertEquals(2, minAppVersionMap.size());
-        assertEquals(13, minAppVersionMap.get("iOS").intValue());
-        assertEquals(23, minAppVersionMap.get("Android").intValue());
+        assertEquals(minAppVersionMap.size(), 2);
+        assertEquals(minAppVersionMap.get("iOS").intValue(), 13);
+        assertEquals(minAppVersionMap.get("Android").intValue(), 23);
 
         // The createdOn time is converted into ISO timestamp, but might be in a different timezone. Ensure that it
         // still refers to the correct instant in time, down to the millisecond.
         long resultSurveyCreatedOnMillis = DateTime.parse(jsonNode.get("surveyCreatedOn").textValue()).getMillis();
-        assertEquals(surveyCreatedOnMillis, resultSurveyCreatedOnMillis);
+        assertEquals(resultSurveyCreatedOnMillis, surveyCreatedOnMillis);
 
         JsonNode fieldDefJsonList = jsonNode.get("fieldDefinitions");
-        assertEquals(2, fieldDefJsonList.size());
+        assertEquals(fieldDefJsonList.size(), 2);
 
         JsonNode fooJsonMap = fieldDefJsonList.get(0);
-        assertEquals("foo", fooJsonMap.get("name").textValue());
+        assertEquals(fooJsonMap.get("name").textValue(), "foo");
         assertTrue(fooJsonMap.get("required").booleanValue());
-        assertEquals("int", fooJsonMap.get("type").textValue());
+        assertEquals(fooJsonMap.get("type").textValue(), "int");
 
         JsonNode barJsonMap = fieldDefJsonList.get(1);
-        assertEquals("bar", barJsonMap.get("name").textValue());
+        assertEquals(barJsonMap.get("name").textValue(), "bar");
         assertFalse(barJsonMap.get("required").booleanValue());
-        assertEquals("string", barJsonMap.get("type").textValue());
+        assertEquals(barJsonMap.get("type").textValue(), "string");
 
         // Serialize it again using the public writer, which includes all fields except studyId.
         String publicJson = UploadSchema.PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
@@ -322,7 +324,7 @@ public class UploadSchemaTest {
         // Public JSON is missing studyId, but is otherwise identical to the non-public (internal worker) JSON.
         assertFalse(publicJsonNode.has("studyId"));
         ((ObjectNode) publicJsonNode).put("studyId", "test-study");
-        assertEquals(jsonNode, publicJsonNode);
+        assertEquals(Sets.newHashSet(publicJsonNode.fieldNames()), Sets.newHashSet(jsonNode.fieldNames()));
     }
 
     @Test
@@ -349,17 +351,17 @@ public class UploadSchemaTest {
         // there is no way to actually create a class of that type. Fortunately, the unmarshaller never uses that
         // object, so we just pass in null.
         List<UploadFieldDefinition> fieldDefList = fieldDefListMarshaller.unconvert(jsonText);
-        assertEquals(2, fieldDefList.size());
+        assertEquals(fieldDefList.size(), 2);
 
         UploadFieldDefinition fooFieldDef = fieldDefList.get(0);
-        assertEquals("foo", fooFieldDef.getName());
+        assertEquals(fooFieldDef.getName(), "foo");
         assertTrue(fooFieldDef.isRequired());
-        assertEquals(UploadFieldType.INT, fooFieldDef.getType());
+        assertEquals(fooFieldDef.getType(), UploadFieldType.INT);
 
         UploadFieldDefinition barFieldDef = fieldDefList.get(1);
-        assertEquals("bar", barFieldDef.getName());
+        assertEquals(barFieldDef.getName(), "bar");
         assertFalse(barFieldDef.isRequired());
-        assertEquals(UploadFieldType.STRING, barFieldDef.getType());
+        assertEquals(barFieldDef.getType(), UploadFieldType.STRING);
 
         // re-marshall
         String marshalledJson = fieldDefListMarshaller.convert(fieldDefList);
@@ -367,16 +369,16 @@ public class UploadSchemaTest {
         // then convert to a list so we can validate the raw JSON
         List<Map<String, Object>> fieldDefJsonList = BridgeObjectMapper.get().readValue(marshalledJson,
                 List.class);
-        assertEquals(2, fieldDefJsonList.size());
+        assertEquals(fieldDefJsonList.size(), 2);
 
         Map<String, Object> fooJsonMap = fieldDefJsonList.get(0);
-        assertEquals("foo", fooJsonMap.get("name"));
+        assertEquals(fooJsonMap.get("name"), "foo");
         assertTrue((boolean) fooJsonMap.get("required"));
-        assertEquals("int", fooJsonMap.get("type"));
+        assertEquals(fooJsonMap.get("type"), "int");
 
         Map<String, Object> barJsonMap = fieldDefJsonList.get(1);
-        assertEquals("bar", barJsonMap.get("name"));
+        assertEquals(barJsonMap.get("name"), "bar");
         assertFalse((boolean) barJsonMap.get("required"));
-        assertEquals("string", barJsonMap.get("type"));
+        assertEquals(barJsonMap.get("type"), "string");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadValidationStatusTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadValidationStatusTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.models.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,9 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -30,9 +29,9 @@ public class UploadValidationStatusTest {
     public void builder() {
         UploadValidationStatus status = new UploadValidationStatus.Builder().withId("test-upload")
                 .withMessageList(Collections.<String>emptyList()).withStatus(UploadStatus.SUCCEEDED).build();
-        assertEquals("test-upload", status.getId());
+        assertEquals(status.getId(), "test-upload");
         assertTrue(status.getMessageList().isEmpty());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
         assertNull(status.getRecord());
     }
 
@@ -43,15 +42,15 @@ public class UploadValidationStatusTest {
         UploadValidationStatus status = new UploadValidationStatus.Builder().withId("happy-case-2")
                 .withMessageList(ImmutableList.of("foo", "bar", "baz")).withStatus(UploadStatus.VALIDATION_FAILED)
                 .withRecord(dummyRecord).build();
-        assertEquals("happy-case-2", status.getId());
-        assertEquals(UploadStatus.VALIDATION_FAILED, status.getStatus());
-        assertSame(dummyRecord, status.getRecord());
+        assertEquals(status.getId(), "happy-case-2");
+        assertEquals(status.getStatus(), UploadStatus.VALIDATION_FAILED);
+        assertSame(status.getRecord(), dummyRecord);
 
         List<String> messageList = status.getMessageList();
-        assertEquals(3, messageList.size());
-        assertEquals("foo", messageList.get(0));
-        assertEquals("bar", messageList.get(1));
-        assertEquals("baz", messageList.get(2));
+        assertEquals(messageList.size(), 3);
+        assertEquals(messageList.get(0), "foo");
+        assertEquals(messageList.get(1), "bar");
+        assertEquals(messageList.get(2), "baz");
     }
 
     @Test
@@ -64,12 +63,12 @@ public class UploadValidationStatusTest {
 
         // construct and validate
         UploadValidationStatus status = UploadValidationStatus.from(upload2, null);
-        assertEquals("from-upload", status.getId());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
+        assertEquals(status.getId(), "from-upload");
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
         assertNull(status.getRecord());
 
-        assertEquals(1, status.getMessageList().size());
-        assertEquals("foo", status.getMessageList().get(0));
+        assertEquals(status.getMessageList().size(), 1);
+        assertEquals(status.getMessageList().get(0), "foo");
     }
 
     @Test
@@ -84,26 +83,26 @@ public class UploadValidationStatusTest {
 
         // construct and validate
         UploadValidationStatus status = UploadValidationStatus.from(upload2, dummyRecord);
-        assertEquals("from-upload-with-record", status.getId());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
-        assertSame(dummyRecord, status.getRecord());
+        assertEquals(status.getId(), "from-upload-with-record");
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
+        assertSame(status.getRecord(), dummyRecord);
 
-        assertEquals(1, status.getMessageList().size());
-        assertEquals("hasRecord", status.getMessageList().get(0));
+        assertEquals(status.getMessageList().size(), 1);
+        assertEquals(status.getMessageList().get(0), "hasRecord");
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void fromNullUpload() {
         UploadValidationStatus.from(null, null);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullMessageList() {
         new UploadValidationStatus.Builder().withId("test-upload").withMessageList(null)
                 .withStatus(UploadStatus.SUCCEEDED).build();
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void messageListWithNullString() {
         List<String> list = new ArrayList<>();
         list.add(null);
@@ -112,7 +111,7 @@ public class UploadValidationStatusTest {
                 .withStatus(UploadStatus.SUCCEEDED).build();
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void messageListWithEmptyString() {
         List<String> list = new ArrayList<>();
         list.add("");
@@ -121,19 +120,19 @@ public class UploadValidationStatusTest {
                 .withStatus(UploadStatus.SUCCEEDED).build();
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullId() {
         new UploadValidationStatus.Builder().withId(null).withMessageList(Collections.singletonList("foo"))
                 .withStatus(UploadStatus.SUCCEEDED).build();
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void emptyId() {
         new UploadValidationStatus.Builder().withId("").withMessageList(Collections.singletonList("foo"))
                 .withStatus(UploadStatus.SUCCEEDED).build();
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void nullStatus() {
         new UploadValidationStatus.Builder().withId("test-upload").withMessageList(Collections.singletonList("foo"))
                 .withStatus(null).build();
@@ -157,7 +156,7 @@ public class UploadValidationStatusTest {
     public void validateNull() {
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "UploadValidationStatus");
         UploadValidationStatusValidator.INSTANCE.validate(null, errors);
-        Assert.assertTrue(errors.hasErrors());
+        assertTrue(errors.hasErrors());
     }
 
     // branch coverage
@@ -166,7 +165,7 @@ public class UploadValidationStatusTest {
     public void validateWrongClass() {
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "UploadValidationStatus");
         UploadValidationStatusValidator.INSTANCE.validate("this is the wrong class", errors);
-        Assert.assertTrue(errors.hasErrors());
+        assertTrue(errors.hasErrors());
     }
 
     @Test
@@ -184,29 +183,29 @@ public class UploadValidationStatusTest {
 
         // convert to POJO
         UploadValidationStatus status = BridgeObjectMapper.get().readValue(jsonText, UploadValidationStatus.class);
-        assertEquals("json-upload", status.getId());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
+        assertEquals(status.getId(), "json-upload");
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
 
         List<String> messageList = status.getMessageList();
-        assertEquals(3, messageList.size());
-        assertEquals("foo", messageList.get(0));
-        assertEquals("bar", messageList.get(1));
-        assertEquals("baz", messageList.get(2));
+        assertEquals(messageList.size(), 3);
+        assertEquals(messageList.get(0), "foo");
+        assertEquals(messageList.get(1), "bar");
+        assertEquals(messageList.get(2), "baz");
 
         // convert back to JSON
         String convertedJson = BridgeObjectMapper.get().writeValueAsString(status);
 
         // then convert to a map so we can validate the raw JSON
         Map<String, Object> jsonMap = BridgeObjectMapper.get().readValue(convertedJson, JsonUtils.TYPE_REF_RAW_MAP);
-        assertEquals(4, jsonMap.size());
-        assertEquals("UploadValidationStatus", jsonMap.get("type"));
-        assertEquals("json-upload", jsonMap.get("id"));
-        assertEquals("succeeded", jsonMap.get("status"));
+        assertEquals(jsonMap.size(), 4);
+        assertEquals(jsonMap.get("type"), "UploadValidationStatus");
+        assertEquals(jsonMap.get("id"), "json-upload");
+        assertEquals(jsonMap.get("status"), "succeeded");
 
         List<String> messageJsonList = (List<String>) jsonMap.get("messageList");
-        assertEquals(3, messageJsonList.size());
-        assertEquals("foo", messageJsonList.get(0));
-        assertEquals("bar", messageJsonList.get(1));
-        assertEquals("baz", messageJsonList.get(2));
+        assertEquals(messageJsonList.size(), 3);
+        assertEquals(messageJsonList.get(0), "foo");
+        assertEquals(messageJsonList.get(1), "bar");
+        assertEquals(messageJsonList.get(2), "baz");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.models.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -69,44 +70,44 @@ public class UploadViewTest {
 
         JsonNode node = BridgeObjectMapper.get().valueToTree(view);
         
-        assertEquals(1000, node.get("contentLength").intValue());
-        assertEquals("succeeded", node.get("status").textValue());
-        assertEquals("2016-07-25T16:25:32.211Z", node.get("requestedOn").textValue());
-        assertEquals("2016-07-25T16:25:32.277Z", node.get("completedOn").textValue());
-        assertEquals("app", node.get("completedBy").textValue());
-        assertEquals("schema-name", node.get("schemaId").textValue());
-        assertEquals(10, node.get("schemaRevision").intValue());
-        assertEquals("Upload", node.get("type").textValue());
-        assertEquals("succeeded", node.get("healthRecordExporterStatus").textValue());
+        assertEquals(node.get("contentLength").intValue(), 1000);
+        assertEquals(node.get("status").textValue(), "succeeded");
+        assertEquals(node.get("requestedOn").textValue(), "2016-07-25T16:25:32.211Z");
+        assertEquals(node.get("completedOn").textValue(), "2016-07-25T16:25:32.277Z");
+        assertEquals(node.get("completedBy").textValue(), "app");
+        assertEquals(node.get("schemaId").textValue(), "schema-name");
+        assertEquals(node.get("schemaRevision").intValue(), 10);
+        assertEquals(node.get("type").textValue(), "Upload");
+        assertEquals(node.get("healthRecordExporterStatus").textValue(), "succeeded");
         
         JsonNode recordNode = node.get("healthData");
-        assertEquals("appVersion", recordNode.get("appVersion").textValue());
-        assertEquals(COMPLETED_ON.toString(), recordNode.get("createdOn").textValue());
-        assertEquals("+03:00", recordNode.get("createdOnTimeZone").textValue());
-        assertEquals("id", recordNode.get("id").textValue());
-        assertEquals("phoneInfo", recordNode.get("phoneInfo").textValue());
-        assertEquals("schema-id", recordNode.get("schemaId").textValue());
-        assertEquals(5, recordNode.get("schemaRevision").intValue());
-        assertEquals("studyId", recordNode.get("studyId").textValue());
-        assertEquals("2016-10-10", recordNode.get("uploadDate").textValue());
-        assertEquals("upload-id", recordNode.get("uploadId").textValue());
-        assertEquals(REQUESTED_ON.toString(), recordNode.get("uploadedOn").textValue());
-        assertEquals("all_qualified_researchers", recordNode.get("userSharingScope").textValue());
-        assertEquals("external-id", recordNode.get("userExternalId").textValue());
+        assertEquals(recordNode.get("appVersion").textValue(), "appVersion");
+        assertEquals(recordNode.get("createdOn").textValue(), COMPLETED_ON.toString());
+        assertEquals(recordNode.get("createdOnTimeZone").textValue(), "+03:00");
+        assertEquals(recordNode.get("id").textValue(), "id");
+        assertEquals(recordNode.get("phoneInfo").textValue(), "phoneInfo");
+        assertEquals(recordNode.get("schemaId").textValue(), "schema-id");
+        assertEquals(recordNode.get("schemaRevision").intValue(), 5);
+        assertEquals(recordNode.get("studyId").textValue(), "studyId");
+        assertEquals(recordNode.get("uploadDate").textValue(), "2016-10-10");
+        assertEquals(recordNode.get("uploadId").textValue(), "upload-id");
+        assertEquals(recordNode.get("uploadedOn").textValue(), REQUESTED_ON.toString());
+        assertEquals(recordNode.get("userSharingScope").textValue(), "all_qualified_researchers");
+        assertEquals(recordNode.get("userExternalId").textValue(), "external-id");
         assertTrue(TestConstants.USER_DATA_GROUPS.contains(recordNode.get("userDataGroups").get(0).textValue()));
         assertTrue(TestConstants.USER_DATA_GROUPS.contains(recordNode.get("userDataGroups").get(1).textValue()));
-        assertEquals("some errors", recordNode.get("validationErrors").textValue());
-        assertEquals(1L, recordNode.get("version").longValue());
-        assertEquals("succeeded", recordNode.get("synapseExporterStatus").textValue());
-        assertEquals("healthCode", recordNode.get("healthCode").textValue());
+        assertEquals(recordNode.get("validationErrors").textValue(), "some errors");
+        assertEquals(recordNode.get("version").longValue(), 1L);
+        assertEquals(recordNode.get("synapseExporterStatus").textValue(), "succeeded");
+        assertEquals(recordNode.get("healthCode").textValue(), "healthCode");
         
         assertTrue(recordNode.get("data").isObject());
         assertTrue(recordNode.get("metadata").isObject());
         assertTrue(recordNode.get("userMetadata").isObject());
         
         // With recent changes to expose to admin, these should be present in JSON
-        assertEquals("some-content", node.get("contentMd5").textValue());
-        assertEquals("health-code", node.get("healthCode").textValue());
+        assertEquals(node.get("contentMd5").textValue(), "some-content");
+        assertEquals(node.get("healthCode").textValue(), "health-code");
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/s3/S3HelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/s3/S3HelperTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.s3;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -12,7 +12,8 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.google.common.base.Charsets;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 public class S3HelperTest {
     // Test strategy is that given a mock input stream from a mock S3 object, the S3Helper can still turn that
@@ -26,7 +27,7 @@ public class S3HelperTest {
 
         S3Helper testS3Helper = setupWithMockS3(bucket, key, content);
         byte[] retValBytes = testS3Helper.readS3FileAsBytes(bucket, key);
-        assertEquals(content, new String(retValBytes, Charsets.UTF_8));
+        assertEquals(new String(retValBytes, Charsets.UTF_8), content);
     }
 
     @Test
@@ -37,7 +38,7 @@ public class S3HelperTest {
 
         S3Helper testS3Helper = setupWithMockS3(bucket, key, content);
         String retVal = testS3Helper.readS3FileAsString(bucket, key);
-        assertEquals(content, retVal);
+        assertEquals(retVal, content);
     }
 
     @Test
@@ -48,10 +49,10 @@ public class S3HelperTest {
 
         S3Helper testS3Helper = setupWithMockS3(bucket, key, content);
         List<String> lineList = testS3Helper.readS3FileAsLines(bucket, key);
-        assertEquals(3, lineList.size());
-        assertEquals("foo", lineList.get(0));
-        assertEquals("bar", lineList.get(1));
-        assertEquals("baz", lineList.get(2));
+        assertEquals(lineList.size(), 3);
+        assertEquals(lineList.get(0), "foo");
+        assertEquals(lineList.get(1), "bar");
+        assertEquals(lineList.get(2), "baz");
     }
 
     private static S3Helper setupWithMockS3(String bucket, String key, String content) {

--- a/src/test/java/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
@@ -1,9 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -11,6 +7,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -19,9 +18,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDateTime;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.ActivityEventDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent.Builder;
@@ -43,7 +43,7 @@ public class ActivityEventServiceTest {
 
     private ActivityEventDao activityEventDao;
     
-    @Before
+    @BeforeMethod
     public void before() {
         activityEventDao = mock(ActivityEventDao.class);
 
@@ -64,9 +64,9 @@ public class ActivityEventServiceTest {
 
         ActivityEvent activityEvent = activityEventArgumentCaptor.getValue();
 
-        assertEquals("custom:eventKey1", activityEvent.getEventId());
-        assertEquals("healthCode", activityEvent.getHealthCode());
-        assertEquals(timestamp.getMillis(), activityEvent.getTimestamp().longValue());
+        assertEquals(activityEvent.getEventId(), "custom:eventKey1");
+        assertEquals(activityEvent.getHealthCode(), "healthCode");
+        assertEquals(activityEvent.getTimestamp().longValue(), timestamp.getMillis());
     }
 
     @Test
@@ -84,9 +84,9 @@ public class ActivityEventServiceTest {
 
         ActivityEvent activityEvent = activityEventArgumentCaptor.getValue();
 
-        assertEquals("custom:3-days-after-enrollment", activityEvent.getEventId());
-        assertEquals("healthCode", activityEvent.getHealthCode());
-        assertEquals(timestamp.getMillis(), activityEvent.getTimestamp().longValue());
+        assertEquals(activityEvent.getEventId(), "custom:3-days-after-enrollment");
+        assertEquals(activityEvent.getHealthCode(), "healthCode");
+        assertEquals(activityEvent.getTimestamp().longValue(), timestamp.getMillis());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class ActivityEventServiceTest {
                     DateTime.now());
             fail("expected exception");
         } catch (BadRequestException e) {
-            assertThat(e.getMessage(), endsWith("eventKey5"));
+            assertTrue(e.getMessage().endsWith("eventKey5"));
         }
     }
     
@@ -121,8 +121,8 @@ public class ActivityEventServiceTest {
         when(activityEventDao.getActivityEventMap("BBB")).thenReturn(map);
 
         Map<String, DateTime> results = activityEventService.getActivityEventMap("BBB");
-        assertEquals(now, results.get("enrollment"));
-        assertEquals(1, results.size());
+        assertEquals(results.get("enrollment"), now);
+        assertEquals(results.size(), 1);
         
         verify(activityEventDao).getActivityEventMap("BBB");
         verifyNoMoreInteractions(activityEventDao);
@@ -178,9 +178,9 @@ public class ActivityEventServiceTest {
         ArgumentCaptor<ActivityEvent> argument = ArgumentCaptor.forClass(ActivityEvent.class);
         verify(activityEventDao).publishEvent(argument.capture());
         
-        assertEquals("enrollment", argument.getValue().getEventId());
-        assertEquals(new Long(now.getMillis()), argument.getValue().getTimestamp());
-        assertEquals("AAA-BBB-CCC", argument.getValue().getHealthCode());
+        assertEquals(argument.getValue().getEventId(), "enrollment");
+        assertEquals(argument.getValue().getTimestamp(), new Long(now.getMillis()));
+        assertEquals(argument.getValue().getHealthCode(), "AAA-BBB-CCC");
     }
 
     @Test
@@ -215,24 +215,24 @@ public class ActivityEventServiceTest {
 
         List<ActivityEvent> publishedEventList = publishedEventCaptor.getAllValues();
 
-        assertEquals("enrollment", publishedEventList.get(0).getEventId());
-        assertEquals(enrollment.getMillis(), publishedEventList.get(0).getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(0).getHealthCode());
+        assertEquals(publishedEventList.get(0).getEventId(), "enrollment");
+        assertEquals(publishedEventList.get(0).getTimestamp().longValue(), enrollment.getMillis());
+        assertEquals(publishedEventList.get(0).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:3-days-after", publishedEventList.get(1).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"), publishedEventList.get(1)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(1).getHealthCode());
+        assertEquals(publishedEventList.get(1).getEventId(), "custom:3-days-after");
+        assertEquals(publishedEventList.get(1).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"));
+        assertEquals(publishedEventList.get(1).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:1-week-after", publishedEventList.get(2).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"), publishedEventList.get(2)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(2).getHealthCode());
+        assertEquals(publishedEventList.get(2).getEventId(), "custom:1-week-after");
+        assertEquals(publishedEventList.get(2).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"));
+        assertEquals(publishedEventList.get(2).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:13-weeks-after", publishedEventList.get(3).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-07-04T16:00-0700"), publishedEventList.get(3)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(3).getHealthCode());
+        assertEquals(publishedEventList.get(3).getEventId(), "custom:13-weeks-after");
+        assertEquals(publishedEventList.get(3).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-07-04T16:00-0700"));
+        assertEquals(publishedEventList.get(3).getHealthCode(), "AAA-BBB-CCC");
     }
     
     @Test
@@ -344,24 +344,24 @@ public class ActivityEventServiceTest {
 
         List<ActivityEvent> publishedEventList = publishedEventCaptor.getAllValues();
 
-        assertEquals("activities_retrieved", publishedEventList.get(0).getEventId());
-        assertEquals(retrieved.getMillis(), publishedEventList.get(0).getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(0).getHealthCode());
+        assertEquals(publishedEventList.get(0).getEventId(), "activities_retrieved");
+        assertEquals(publishedEventList.get(0).getTimestamp().longValue(), retrieved.getMillis());
+        assertEquals(publishedEventList.get(0).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:3-days-after", publishedEventList.get(1).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"), publishedEventList.get(1)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(1).getHealthCode());
+        assertEquals(publishedEventList.get(1).getEventId(), "custom:3-days-after");
+        assertEquals(publishedEventList.get(1).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"));
+        assertEquals(publishedEventList.get(1).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:1-week-after", publishedEventList.get(2).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"), publishedEventList.get(2)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(2).getHealthCode());
+        assertEquals(publishedEventList.get(2).getEventId(), "custom:1-week-after");
+        assertEquals(publishedEventList.get(2).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"));
+        assertEquals(publishedEventList.get(2).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:13-weeks-after", publishedEventList.get(3).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-07-04T16:00-0700"), publishedEventList.get(3)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(3).getHealthCode());
+        assertEquals(publishedEventList.get(3).getEventId(), "custom:13-weeks-after");
+        assertEquals(publishedEventList.get(3).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-07-04T16:00-0700"));
+        assertEquals(publishedEventList.get(3).getHealthCode(), "AAA-BBB-CCC");
     }
     
     @Test
@@ -385,19 +385,19 @@ public class ActivityEventServiceTest {
 
         List<ActivityEvent> publishedEventList = publishedEventCaptor.getAllValues();
         
-        assertEquals("custom:myEvent", publishedEventList.get(0).getEventId());
-        assertEquals(timestamp.getMillis(), publishedEventList.get(0).getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(0).getHealthCode());
+        assertEquals(publishedEventList.get(0).getEventId(), "custom:myEvent");
+        assertEquals(publishedEventList.get(0).getTimestamp().longValue(), timestamp.getMillis());
+        assertEquals(publishedEventList.get(0).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:3-days-after", publishedEventList.get(1).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"), publishedEventList.get(1)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(1).getHealthCode());
+        assertEquals(publishedEventList.get(1).getEventId(), "custom:3-days-after");
+        assertEquals(publishedEventList.get(1).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-07T16:00-0700"));
+        assertEquals(publishedEventList.get(1).getHealthCode(), "AAA-BBB-CCC");
 
-        assertEquals("custom:1-week-after", publishedEventList.get(2).getEventId());
-        assertEquals(DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"), publishedEventList.get(2)
-                .getTimestamp().longValue());
-        assertEquals("AAA-BBB-CCC", publishedEventList.get(2).getHealthCode());
+        assertEquals(publishedEventList.get(2).getEventId(), "custom:1-week-after");
+        assertEquals(publishedEventList.get(2).getTimestamp().longValue(),
+                DateUtils.convertToMillisFromEpoch("2018-04-11T16:00-0700"));
+        assertEquals(publishedEventList.get(2).getHealthCode(), "AAA-BBB-CCC");
     }
 
     @Test
@@ -414,9 +414,9 @@ public class ActivityEventServiceTest {
         ArgumentCaptor<ActivityEvent> argument = ArgumentCaptor.forClass(ActivityEvent.class);
         verify(activityEventDao).publishEvent(argument.capture());
         
-        assertEquals("question:BBB-CCC-DDD:answered", argument.getValue().getEventId());
-        assertEquals(new Long(now.getMillis()), argument.getValue().getTimestamp());
-        assertEquals("healthCode", argument.getValue().getHealthCode());
+        assertEquals(argument.getValue().getEventId(), "question:BBB-CCC-DDD:answered");
+        assertEquals(argument.getValue().getTimestamp(), new Long(now.getMillis()));
+        assertEquals(argument.getValue().getHealthCode(), "healthCode");
     }
     
     @Test
@@ -446,8 +446,8 @@ public class ActivityEventServiceTest {
         verify(activityEventDao).publishEvent(argument.capture());
 
         ActivityEvent event = argument.getValue();
-        assertEquals("BBB", event.getHealthCode());
-        assertEquals("activity:AAA:finished", event.getEventId());
-        assertEquals(finishedOn, event.getTimestamp().longValue());
+        assertEquals(event.getHealthCode(), "BBB");
+        assertEquals(event.getEventId(), "activity:AAA:finished");
+        assertEquals(event.getTimestamp().longValue(), finishedOn);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigElementServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigElementServiceTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
@@ -15,15 +15,15 @@ import static org.mockito.Mockito.when;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.AppConfigElementDao;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
@@ -34,7 +34,6 @@ import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
 
 import com.google.common.collect.ImmutableList;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AppConfigElementServiceTest {
     
     private static final DateTime TIMESTAMP = DateTime.now();
@@ -51,14 +50,15 @@ public class AppConfigElementServiceTest {
     @Spy
     private AppConfigElementService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         DateTimeUtils.setCurrentMillisFixed(TIMESTAMP.getMillis());
         service.setAppConfigElementDao(dao);
         elements = ImmutableList.of(AppConfigElement.create(), AppConfigElement.create());
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -69,7 +69,7 @@ public class AppConfigElementServiceTest {
         
         List<AppConfigElement> returnedElements = service.getMostRecentElements(TEST_STUDY, true);
         
-        assertEquals(2, returnedElements.size());
+        assertEquals(returnedElements.size(), 2);
         verify(dao).getMostRecentElements(TEST_STUDY, true);
     }
     
@@ -79,7 +79,7 @@ public class AppConfigElementServiceTest {
         
         List<AppConfigElement> returnedElements = service.getMostRecentElements(TEST_STUDY, false);
         
-        assertEquals(2, returnedElements.size());
+        assertEquals(returnedElements.size(), 2);
         verify(dao).getMostRecentElements(TEST_STUDY, false);
     }
     
@@ -92,27 +92,27 @@ public class AppConfigElementServiceTest {
         when(dao.saveElementRevision(element)).thenReturn(VERSION_HOLDER);
         
         VersionHolder returned = service.createElement(TEST_STUDY, element);
-        assertEquals(VERSION_HOLDER, returned);
+        assertEquals(returned, VERSION_HOLDER);
         
         verify(dao).saveElementRevision(elementCaptor.capture());
         
         // These have been correctly reset
-        assertEquals(new Long(1), elementCaptor.getValue().getRevision());
+        assertEquals(elementCaptor.getValue().getRevision(), new Long(1));
         AppConfigElement captured = elementCaptor.getValue();
         assertNull(captured.getVersion());
         assertFalse(captured.isDeleted());
-        assertEquals("api", captured.getStudyId());
-        assertEquals("api:id", captured.getKey());
-        assertEquals(TIMESTAMP.getMillis(), captured.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), captured.getModifiedOn());
+        assertEquals(captured.getStudyId(), "api");
+        assertEquals(captured.getKey(), "api:id");
+        assertEquals(captured.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(captured.getModifiedOn(), TIMESTAMP.getMillis());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createElementValidates() {
         service.createElement(TEST_STUDY, AppConfigElement.create());
     }
     
-    @Test(expected = EntityAlreadyExistsException.class)
+    @Test(expectedExceptions = EntityAlreadyExistsException.class)
     public void createElementThatExists() {
         AppConfigElement element = TestUtils.getAppConfigElement();
         when(dao.getElementRevision(TEST_STUDY, element.getId(), 3L)).thenReturn(element);
@@ -127,12 +127,12 @@ public class AppConfigElementServiceTest {
         when(dao.saveElementRevision(element)).thenReturn(VERSION_HOLDER);
         
         VersionHolder returned = service.createElement(TEST_STUDY, element);
-        assertEquals(VERSION_HOLDER, returned);
+        assertEquals(returned, VERSION_HOLDER);
         
         verify(dao).saveElementRevision(elementCaptor.capture());
         
         // Revision was maintained because it was set, and doesn't exist
-        assertEquals(new Long(3), elementCaptor.getValue().getRevision());
+        assertEquals(elementCaptor.getValue().getRevision(), new Long(3));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class AppConfigElementServiceTest {
         when(dao.getElementRevisions(TEST_STUDY, "id", true)).thenReturn(elements);
         
         List<AppConfigElement> returnedElements = service.getElementRevisions(TEST_STUDY, "id", true);
-        assertEquals(2, returnedElements.size());
+        assertEquals(returnedElements.size(), 2);
         
         verify(dao).getElementRevisions(TEST_STUDY, "id", true);
     }
@@ -150,7 +150,7 @@ public class AppConfigElementServiceTest {
         when(dao.getElementRevisions(TEST_STUDY, "id", false)).thenReturn(elements);
         
         List<AppConfigElement> returnedElements = service.getElementRevisions(TEST_STUDY, "id", false);
-        assertEquals(2, returnedElements.size());
+        assertEquals(returnedElements.size(), 2);
         
         verify(dao).getElementRevisions(TEST_STUDY, "id", false);
     }
@@ -161,12 +161,12 @@ public class AppConfigElementServiceTest {
         when(dao.getMostRecentElement(TEST_STUDY, "id")).thenReturn(element);
         
         AppConfigElement returned = service.getMostRecentElement(TEST_STUDY, "id");
-        assertEquals(element, returned);
+        assertEquals(returned, element);
         
         verify(dao).getMostRecentElement(TEST_STUDY, "id");
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getMostRecentElementDoesNotExist() {
         service.getMostRecentElement(TEST_STUDY, "id");
         
@@ -179,12 +179,12 @@ public class AppConfigElementServiceTest {
         when(dao.getElementRevision(TEST_STUDY, "id", 3L)).thenReturn(AppConfigElement.create());
         
         AppConfigElement returned = service.getElementRevision(TEST_STUDY, "id", 3L);
-        assertEquals(element, returned);
+        assertEquals(returned, element);
         
         verify(dao).getElementRevision(TEST_STUDY, "id", 3L);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getElementRevisionDoesNotExist() {
         service.getElementRevision(TEST_STUDY, "id", 3L);
         
@@ -200,22 +200,22 @@ public class AppConfigElementServiceTest {
         when(dao.saveElementRevision(element)).thenReturn(VERSION_HOLDER);
         
         VersionHolder returned = service.updateElementRevision(TEST_STUDY, element);
-        assertEquals(VERSION_HOLDER, returned);
+        assertEquals(returned, VERSION_HOLDER);
         
         verify(dao).saveElementRevision(elementCaptor.capture());
         AppConfigElement captured = elementCaptor.getValue(); 
-        assertEquals("api", captured.getStudyId());
-        assertEquals("api:id", captured.getKey());
-        assertNotEquals(TIMESTAMP.getMillis(), captured.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), captured.getModifiedOn());
+        assertEquals(captured.getStudyId(), "api");
+        assertEquals(captured.getKey(), "api:id");
+        assertNotEquals(captured.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(captured.getModifiedOn(), TIMESTAMP.getMillis());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateElementRevisionValidates() {
         service.updateElementRevision(TEST_STUDY, AppConfigElement.create());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateElementRevisionThatIsLogicallyDeleted() {
         AppConfigElement element = TestUtils.getAppConfigElement();
         element.setDeleted(true); // true as persisted and updated, should throw ENFE
@@ -224,7 +224,7 @@ public class AppConfigElementServiceTest {
         service.updateElementRevision(TEST_STUDY, element);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateElementRevisionThatDoesNotExist() {
         AppConfigElement element = TestUtils.getAppConfigElement();
         when(dao.getElementRevision(TEST_STUDY, element.getId(), element.getRevision())).thenReturn(null);
@@ -270,8 +270,8 @@ public class AppConfigElementServiceTest {
         
         for(AppConfigElement element : elements) {
             assertTrue(element.isDeleted());
-            assertNotEquals(TIMESTAMP.getMillis(), element.getCreatedOn());
-            assertEquals(TIMESTAMP.getMillis(), element.getModifiedOn());
+            assertNotEquals(element.getCreatedOn(), TIMESTAMP.getMillis());
+            assertEquals(element.getModifiedOn(), TIMESTAMP.getMillis());
         }
         verify(dao, times(2)).saveElementRevision(elementCaptor.capture());
         assertTrue(elementCaptor.getAllValues().get(0).isDeleted());
@@ -303,12 +303,12 @@ public class AppConfigElementServiceTest {
         
         verify(dao).saveElementRevision(elementCaptor.capture());
         AppConfigElement captured = elementCaptor.getValue();
-        assertNotEquals(TIMESTAMP.getMillis(), captured.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), captured.getModifiedOn());
+        assertNotEquals(captured.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(captured.getModifiedOn(), TIMESTAMP.getMillis());
         assertTrue(elementCaptor.getValue().isDeleted());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteElementRevisionThatDoesNotExist() {
         service.deleteElementRevision(TEST_STUDY, "id", 3L);
     }
@@ -324,7 +324,7 @@ public class AppConfigElementServiceTest {
         verify(dao).deleteElementRevisionPermanently(TEST_STUDY, "id", 3L);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteElementRevisionPermanentlyThatDoesNotExist() {
         service.deleteElementRevisionPermanently(TEST_STUDY, "id", 3L);
     }    

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -16,15 +16,15 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -50,7 +50,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AppConfigServiceTest {
     
     private static final List<AppConfig>  RESULTS = Lists.newArrayList();
@@ -108,8 +107,10 @@ public class AppConfigServiceTest {
 
     private Study study;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service.setAppConfigDao(mockDao);
         service.setStudyService(mockStudyService);
         service.setSurveyService(mockSurveyService);
@@ -136,7 +137,7 @@ public class AppConfigServiceTest {
         study.setIdentifier(TEST_STUDY.getIdentifier());
     }
     
-    @After
+    @AfterMethod
     public void after() {
         RESULTS.clear();
     }
@@ -181,7 +182,7 @@ public class AppConfigServiceTest {
         when(mockDao.getAppConfigs(TEST_STUDY, false)).thenReturn(RESULTS);
         
         List<AppConfig> results = service.getAppConfigs(TEST_STUDY, false);
-        assertEquals(RESULTS, results);
+        assertEquals(results, RESULTS);
         
         verify(mockDao).getAppConfigs(TEST_STUDY, false);
     }
@@ -209,10 +210,10 @@ public class AppConfigServiceTest {
         AppConfig appConfig2 = setupConfigsForUser();
         
         AppConfig match = service.getAppConfigForUser(context, true);
-        assertEquals(appConfig2, match);
+        assertEquals(match, appConfig2);
         
         // Verify that we called the resolver on this as well
-        assertEquals("theIdentifier", match.getSurveyReferences().get(0).getIdentifier());
+        assertEquals(match.getSurveyReferences().get(0).getIdentifier(), "theIdentifier");
     }
     
     @Test
@@ -247,16 +248,16 @@ public class AppConfigServiceTest {
         
         AppConfig match = service.getAppConfigForUser(context, true);
         
-        assertEquals(2, match.getConfigElements().size());
-        assertEquals(clientData1, match.getConfigElements().get("id1"));
-        assertEquals(clientData2, match.getConfigElements().get("id2"));
+        assertEquals(match.getConfigElements().size(), 2);
+        assertEquals(match.getConfigElements().get("id1"), clientData1);
+        assertEquals(match.getConfigElements().get("id2"), clientData2);
         
         // The references are still there. They list the versions being used
-        assertEquals(2, match.getConfigReferences().size());
-        assertEquals("id1", match.getConfigReferences().get(0).getId());
-        assertEquals(new Long(1), match.getConfigReferences().get(0).getRevision());
-        assertEquals("id2", match.getConfigReferences().get(1).getId());
-        assertEquals(new Long(2), match.getConfigReferences().get(1).getRevision());
+        assertEquals(match.getConfigReferences().size(), 2);
+        assertEquals(match.getConfigReferences().get(0).getId(), "id1");
+        assertEquals(match.getConfigReferences().get(0).getRevision(), new Long(1));
+        assertEquals(match.getConfigReferences().get(1).getId(), "id2");
+        assertEquals(match.getConfigReferences().get(1).getRevision(), new Long(2));
     }
     
     @Test
@@ -285,10 +286,10 @@ public class AppConfigServiceTest {
         
         AppConfig match = service.getAppConfigForUser(context, true);
         
-        assertEquals(1, match.getConfigElements().size());
+        assertEquals(match.getConfigElements().size(), 1);
         // id1 is not included but this does not prevent id2 from being included.
         assertNull(match.getConfigElements().get("id1"));
-        assertEquals(clientData2, match.getConfigElements().get("id2"));
+        assertEquals(match.getConfigElements().get("id2"), clientData2);
         
         verify(service).logError("AppConfig[guid=abc-def] references missing AppConfigElement[id=id1, revision=1]");
     }
@@ -315,7 +316,7 @@ public class AppConfigServiceTest {
         
         AppConfig appConfig = service.getAppConfigForUser(context, false);
 
-        assertEquals(appConfig2, appConfig);
+        assertEquals(appConfig, appConfig2);
     }
     
     // This should not actually ever happen. We're suppressing exceptions if the survey is missing.
@@ -328,9 +329,9 @@ public class AppConfigServiceTest {
         AppConfig appConfig2 = setupConfigsForUser();
         
         AppConfig match = service.getAppConfigForUser(context, true);
-        assertEquals(appConfig2, match);
+        assertEquals(match, appConfig2);
         
-        assertEquals(SURVEY_REF_LIST.get(0), match.getSurveyReferences().get(0));        
+        assertEquals(match.getSurveyReferences().get(0), SURVEY_REF_LIST.get(0));        
     }
     
     @Test
@@ -344,11 +345,11 @@ public class AppConfigServiceTest {
         
         AppConfig match = service.getAppConfigForUser(context, true);
         
-        assertEquals("anIdentifier", match.getSurveyReferences().get(0).getIdentifier());
+        assertEquals(match.getSurveyReferences().get(0).getIdentifier(), "anIdentifier");
         verify(mockSurveyService, never()).getSurvey(eq(TestConstants.TEST_STUDY), any(), eq(false), eq(true));
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAppConfigForUserThrowsException() {
         CriteriaContext context = new CriteriaContext.Builder()
                 .withClientInfo(ClientInfo.fromUserAgentCache("app/21 (Motorola Flip-Phone; Android/14) BridgeJavaSDK/10"))
@@ -383,8 +384,8 @@ public class AppConfigServiceTest {
         
         setupConfigsForUser();
         AppConfig appConfig = service.getAppConfigForUser(context, true);
-        assertEquals(EARLIER_TIMESTAMP, appConfig.getCreatedOn());
-        assertEquals("theIdentifier", appConfig.getSurveyReferences().get(0).getIdentifier());
+        assertEquals(appConfig.getCreatedOn(), EARLIER_TIMESTAMP);
+        assertEquals(appConfig.getSurveyReferences().get(0).getIdentifier(), "theIdentifier");
     }
     
     @Test
@@ -404,22 +405,22 @@ public class AppConfigServiceTest {
         
         AppConfig returnValue = service.createAppConfig(TEST_STUDY, newConfig);
         
-        assertEquals(TIMESTAMP.getMillis(), returnValue.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), returnValue.getModifiedOn());
-        assertEquals(GUID, returnValue.getGuid());
-        assertEquals(newConfig.getLabel(), returnValue.getLabel()); //
-        assertEquals(TEST_STUDY.getIdentifier(), returnValue.getStudyId()); //
-        assertEquals(TestUtils.getClientData(), returnValue.getClientData());
-        assertEquals(SURVEY_REF_LIST, returnValue.getSurveyReferences());
-        assertEquals(SCHEMA_REF_LIST, returnValue.getSchemaReferences());
-        assertEquals(CONFIG_REF_LIST, returnValue.getConfigReferences());
+        assertEquals(returnValue.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(returnValue.getModifiedOn(), TIMESTAMP.getMillis());
+        assertEquals(returnValue.getGuid(), GUID);
+        assertEquals(returnValue.getLabel(), newConfig.getLabel()); //
+        assertEquals(returnValue.getStudyId(), TEST_STUDY.getIdentifier()); //
+        assertEquals(returnValue.getClientData(), TestUtils.getClientData());
+        assertEquals(returnValue.getSurveyReferences(), SURVEY_REF_LIST);
+        assertEquals(returnValue.getSchemaReferences(), SCHEMA_REF_LIST);
+        assertEquals(returnValue.getConfigReferences(), CONFIG_REF_LIST);
         
         verify(mockDao).createAppConfig(appConfigCaptor.capture());
         
         AppConfig captured = appConfigCaptor.getValue();
-        assertEquals(TIMESTAMP.getMillis(), captured.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), captured.getModifiedOn());
-        assertEquals(GUID, captured.getGuid());
+        assertEquals(captured.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(captured.getModifiedOn(), TIMESTAMP.getMillis());
+        assertEquals(captured.getGuid(), GUID);
         
         verify(substudyService).getSubstudyIds(TEST_STUDY);
     }
@@ -434,25 +435,25 @@ public class AppConfigServiceTest {
         oldConfig.setGuid(GUID);
         AppConfig returnValue = service.updateAppConfig(TEST_STUDY, oldConfig);
         
-        assertEquals(TIMESTAMP.getMillis(), returnValue.getCreatedOn());
-        assertEquals(TIMESTAMP.getMillis(), returnValue.getModifiedOn());
+        assertEquals(returnValue.getCreatedOn(), TIMESTAMP.getMillis());
+        assertEquals(returnValue.getModifiedOn(), TIMESTAMP.getMillis());
         
         verify(mockDao).updateAppConfig(appConfigCaptor.capture());
-        assertEquals(oldConfig, appConfigCaptor.getValue());
+        assertEquals(appConfigCaptor.getValue(), oldConfig);
         
         verify(substudyService).getSubstudyIds(TEST_STUDY);
 
-        assertEquals(returnValue, oldConfig);
+        assertEquals(oldConfig, returnValue);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createAppConfigValidates() {
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         
         service.createAppConfig(TEST_STUDY, AppConfig.create());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateAppConfigValidates() {
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -1,12 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -19,25 +12,26 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
@@ -86,14 +80,15 @@ import org.sagebionetworks.bridge.validators.SignInValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.sagebionetworks.bridge.validators.ValidatorUtils;
 import org.springframework.validation.Errors;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AuthenticationServiceMockTest {
     private static final Set<String> DATA_GROUP_SET = ImmutableSet.of("group1", "group2");
     private static final String IP_ADDRESS = "ip-address";
@@ -178,8 +173,9 @@ public class AuthenticationServiceMockTest {
 
     private Account account;
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         // Create inputs.
         study = Study.create();
         study.setIdentifier(STUDY_ID);
@@ -206,7 +202,7 @@ public class AuthenticationServiceMockTest {
         doReturn(study).when(studyService).getStudy(STUDY_ID);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
     }
@@ -243,22 +239,22 @@ public class AuthenticationServiceMockTest {
         inOrder.verify(cacheProvider).removeSessionByUserId(USER_ID);
         inOrder.verify(cacheProvider).setUserSession(session);
         
-        assertEquals(CONSENTED_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getConsentStatuses(), CONSENTED_STATUS_MAP);
         assertTrue(session.isAuthenticated());
-        assertEquals("127.1.1.11", session.getIpAddress());
-        assertEquals("SESSION_TOKEN", session.getSessionToken());
-        assertEquals("SESSION_TOKEN", session.getInternalSessionToken());
-        assertEquals(REAUTH_TOKEN, session.getReauthToken());
-        assertEquals(Environment.PROD, session.getEnvironment());
-        assertEquals(TestConstants.TEST_STUDY, session.getStudyIdentifier());
+        assertEquals(session.getIpAddress(), "127.1.1.11");
+        assertEquals(session.getSessionToken(), "SESSION_TOKEN");
+        assertEquals(session.getInternalSessionToken(), "SESSION_TOKEN");
+        assertEquals(session.getReauthToken(), REAUTH_TOKEN);
+        assertEquals(session.getEnvironment(), Environment.PROD);
+        assertEquals(session.getStudyIdentifier(), TestConstants.TEST_STUDY);
 
         // updated context
         CriteriaContext updatedContext = contextCaptor.getValue();
-        assertEquals(HEALTH_CODE, updatedContext.getHealthCode());
-        assertEquals(LANGUAGES, updatedContext.getLanguages());
-        assertEquals(DATA_GROUP_SET, updatedContext.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, updatedContext.getUserSubstudyIds());
-        assertEquals(USER_ID, updatedContext.getUserId());
+        assertEquals(updatedContext.getHealthCode(), HEALTH_CODE);
+        assertEquals(updatedContext.getLanguages(), LANGUAGES);
+        assertEquals(updatedContext.getUserDataGroups(), DATA_GROUP_SET);
+        assertEquals(updatedContext.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(updatedContext.getUserId(), USER_ID);
         
         verify(accountSecretDao).createSecret(AccountSecretType.REAUTH, USER_ID, REAUTH_TOKEN);
     }
@@ -281,7 +277,7 @@ public class AuthenticationServiceMockTest {
         verifyNoMoreInteractions(accountDao);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void signInWithBadCredentials() throws Exception {
         service.signIn(study, CONTEXT, new SignIn.Builder().build());
     }
@@ -323,22 +319,22 @@ public class AuthenticationServiceMockTest {
         inOrder.verify(cacheProvider).removeSessionByUserId(USER_ID);
         inOrder.verify(cacheProvider).setUserSession(session);
         
-        assertEquals(UNCONSENTED_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getConsentStatuses(), UNCONSENTED_STATUS_MAP);
         assertTrue(session.isAuthenticated());
-        assertEquals("127.1.1.11", session.getIpAddress());
-        assertEquals("SESSION_TOKEN", session.getSessionToken());
-        assertEquals("SESSION_TOKEN", session.getInternalSessionToken());
-        assertEquals(REAUTH_TOKEN, session.getReauthToken());
-        assertEquals(Environment.PROD, session.getEnvironment());
-        assertEquals(TestConstants.TEST_STUDY, session.getStudyIdentifier());
+        assertEquals(session.getIpAddress(), "127.1.1.11");
+        assertEquals(session.getSessionToken(), "SESSION_TOKEN");
+        assertEquals(session.getInternalSessionToken(), "SESSION_TOKEN");
+        assertEquals(session.getReauthToken(), REAUTH_TOKEN);
+        assertEquals(session.getEnvironment(), Environment.PROD);
+        assertEquals(session.getStudyIdentifier(), TestConstants.TEST_STUDY);
 
         // updated context
         CriteriaContext updatedContext = contextCaptor.getValue();
-        assertEquals(HEALTH_CODE, updatedContext.getHealthCode());
-        assertEquals(LANGUAGES, updatedContext.getLanguages());
-        assertEquals(DATA_GROUP_SET, updatedContext.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, updatedContext.getUserSubstudyIds());
-        assertEquals(USER_ID, updatedContext.getUserId());
+        assertEquals(updatedContext.getHealthCode(), HEALTH_CODE);
+        assertEquals(updatedContext.getLanguages(), LANGUAGES);
+        assertEquals(updatedContext.getUserDataGroups(), DATA_GROUP_SET);
+        assertEquals(updatedContext.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
+        assertEquals(updatedContext.getUserId(), USER_ID);
         
         verify(accountSecretDao).createSecret(AccountSecretType.REAUTH, USER_ID, REAUTH_TOKEN);
     }
@@ -353,12 +349,12 @@ public class AuthenticationServiceMockTest {
 
         UserSession retrieved = service.signIn(study, CONTEXT, EMAIL_PASSWORD_SIGN_IN);
         
-        assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
+        assertEquals(retrieved.getReauthToken(), REAUTH_TOKEN);
         verify(cacheProvider).removeSessionByUserId(USER_ID);
         verify(cacheProvider).setUserSession(retrieved);
     }
     
-    @Test(expected = ConsentRequiredException.class)
+    @Test(expectedExceptions = ConsentRequiredException.class)
     public void unconsentedSignInWithEmail() {
         doReturn(account).when(accountDao).authenticate(study, EMAIL_PASSWORD_SIGN_IN);
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
@@ -379,8 +375,8 @@ public class AuthenticationServiceMockTest {
         // Does not throw consent required exception, despite being unconsented, because user has DEVELOPER role.
         UserSession retrieved = service.signIn(study, CONTEXT, EMAIL_PASSWORD_SIGN_IN);
         
-        assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
-        assertEquals(UNCONSENTED_STATUS_MAP, retrieved.getConsentStatuses());
+        assertEquals(retrieved.getReauthToken(), REAUTH_TOKEN);
+        assertEquals(retrieved.getConsentStatuses(), UNCONSENTED_STATUS_MAP);
     }
     
     @Test
@@ -393,12 +389,12 @@ public class AuthenticationServiceMockTest {
 
         UserSession retrieved = service.signIn(study, CONTEXT, PHONE_PASSWORD_SIGN_IN);
         
-        assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
+        assertEquals(retrieved.getReauthToken(), REAUTH_TOKEN);
         verify(cacheProvider).removeSessionByUserId(USER_ID);
         verify(cacheProvider).setUserSession(retrieved);
     }
     
-    @Test(expected = ConsentRequiredException.class)
+    @Test(expectedExceptions = ConsentRequiredException.class)
     public void unconsentedSignInWithPhone() {
         doReturn(account).when(accountDao).authenticate(study, PHONE_PASSWORD_SIGN_IN);
         doReturn(PARTICIPANT).when(participantService).getParticipant(study, account, false);
@@ -419,8 +415,8 @@ public class AuthenticationServiceMockTest {
         // Does not throw consent required exception, despite being unconsented, because user has RESEARCHER role. 
         UserSession retrieved = service.signIn(study, CONTEXT, PHONE_PASSWORD_SIGN_IN);
 
-        assertEquals(REAUTH_TOKEN, retrieved.getReauthToken());
-        assertEquals(UNCONSENTED_STATUS_MAP, retrieved.getConsentStatuses());
+        assertEquals(retrieved.getReauthToken(), REAUTH_TOKEN);
+        assertEquals(retrieved.getConsentStatuses(), UNCONSENTED_STATUS_MAP);
     }
     
     @Test
@@ -458,7 +454,7 @@ public class AuthenticationServiceMockTest {
         UserSession retSession = service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
         
         assertNotNull(retSession);
-        assertEquals(REAUTH_TOKEN, retSession.getReauthToken());
+        assertEquals(retSession.getReauthToken(), REAUTH_TOKEN);
         
         InOrder inOrder = Mockito.inOrder(cacheProvider, accountDao);
         inOrder.verify(accountDao).getAccount(SIGN_IN_WITH_EMAIL.getAccountId());
@@ -468,13 +464,13 @@ public class AuthenticationServiceMockTest {
         inOrder.verify(cacheProvider).setUserSession(retSession);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void emailSignInNoAccount() {
         when(accountDao.getAccount(any())).thenReturn(null);
         service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
     }
     
-    @Test(expected = AuthenticationFailedException.class)
+    @Test(expectedExceptions = AuthenticationFailedException.class)
     public void emailSignInAuthenticationFailed() {
         doThrow(new AuthenticationFailedException()).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL,
                 CONTEXT, SIGN_IN_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
@@ -482,7 +478,7 @@ public class AuthenticationServiceMockTest {
         service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void emailSignInInvalidEntity() {
         doThrow(new InvalidEntityException("")).when(accountWorkflowService).channelSignIn(ChannelType.EMAIL, CONTEXT,
                 SIGN_IN_REQUEST_WITH_EMAIL, SignInValidator.EMAIL_SIGNIN);
@@ -490,7 +486,7 @@ public class AuthenticationServiceMockTest {
         service.emailSignIn(CONTEXT, SIGN_IN_REQUEST_WITH_EMAIL);
     }
     
-    @Test(expected = AccountDisabledException.class)
+    @Test(expectedExceptions = AccountDisabledException.class)
     public void emailSignInThrowsAccountDisabled() {
         account.setStatus(AccountStatus.DISABLED);
         
@@ -517,7 +513,7 @@ public class AuthenticationServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConsentRequiredException e) {
             verify(cacheProvider).setUserSession(e.getUserSession());
-            assertEquals(UNCONSENTED_STATUS_MAP, e.getUserSession().getConsentStatuses());
+            assertEquals(e.getUserSession().getConsentStatuses(), UNCONSENTED_STATUS_MAP);
         }
     }
     
@@ -534,7 +530,7 @@ public class AuthenticationServiceMockTest {
         
         // Does not throw a consent required exception because the participant is an admin. 
         UserSession retrieved = service.emailSignIn(CONTEXT, SIGN_IN_WITH_EMAIL);
-        assertEquals(UNCONSENTED_STATUS_MAP, retrieved.getConsentStatuses());
+        assertEquals(retrieved.getConsentStatuses(), UNCONSENTED_STATUS_MAP);
     }
     
     @Test
@@ -550,20 +546,20 @@ public class AuthenticationServiceMockTest {
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         
         UserSession session = service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
-        assertEquals(RECIPIENT_EMAIL, session.getParticipant().getEmail());
-        assertEquals(REAUTH_TOKEN, session.getReauthToken());
+        assertEquals(session.getParticipant().getEmail(), RECIPIENT_EMAIL);
+        assertEquals(session.getReauthToken(), REAUTH_TOKEN);
         
         verify(accountDao).reauthenticate(study, REAUTH_REQUEST);
         verify(cacheProvider).setUserSession(sessionCaptor.capture());
         
         UserSession captured = sessionCaptor.getValue();
-        assertEquals(RECIPIENT_EMAIL, captured.getParticipant().getEmail());
-        assertEquals(REAUTH_TOKEN, captured.getReauthToken());
+        assertEquals(captured.getParticipant().getEmail(), RECIPIENT_EMAIL);
+        assertEquals(captured.getReauthToken(), REAUTH_TOKEN);
         
         verify(accountSecretDao).createSecret(REAUTH, USER_ID, REAUTH_TOKEN);
     }
     
-    @Test(expected = ConsentRequiredException.class)
+    @Test(expectedExceptions = ConsentRequiredException.class)
     public void reauthenticateThrowsConsentRequiredException() {
         study.setReauthenticationEnabled(true);
 
@@ -603,11 +599,11 @@ public class AuthenticationServiceMockTest {
         doReturn(participant).when(participantService).getParticipant(study, account, false);
         
         UserSession session = service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
-        assertEquals("existingToken", session.getSessionToken());
-        assertEquals("existingInternalToken", session.getInternalSessionToken());
+        assertEquals(session.getSessionToken(), "existingToken");
+        assertEquals(session.getInternalSessionToken(), "existingInternalToken");
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void reauthTokenRequired() {
         service.reauthenticate(study, CONTEXT, SIGN_IN_WITH_EMAIL); // doesn't have reauth token
     }
@@ -625,11 +621,11 @@ public class AuthenticationServiceMockTest {
             service.reauthenticate(study, CONTEXT, REAUTH_REQUEST);
             fail("Should have thrown exception");
         } catch(ConsentRequiredException e) {
-            assertEquals(UNCONSENTED_STATUS_MAP, e.getUserSession().getConsentStatuses());
+            assertEquals(e.getUserSession().getConsentStatuses(), UNCONSENTED_STATUS_MAP);
         }
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void requestResetInvalid() {
         SignIn signIn = new SignIn.Builder().withStudy(STUDY_ID).withPhone(TestConstants.PHONE)
                 .withEmail(RECIPIENT_EMAIL).build();
@@ -655,8 +651,8 @@ public class AuthenticationServiceMockTest {
         
         verify(participantService).createParticipant(eq(study), participantCaptor.capture(), eq(true));
         StudyParticipant captured = participantCaptor.getValue();
-        assertEquals(RECIPIENT_EMAIL, captured.getEmail());
-        assertEquals(PASSWORD, captured.getPassword());
+        assertEquals(captured.getEmail(), RECIPIENT_EMAIL);
+        assertEquals(captured.getPassword(), PASSWORD);
     }
 
     @Test
@@ -669,8 +665,8 @@ public class AuthenticationServiceMockTest {
         
         verify(participantService).createParticipant(eq(study), participantCaptor.capture(), eq(true));
         StudyParticipant captured = participantCaptor.getValue();
-        assertEquals(TestConstants.PHONE.getNumber(), captured.getPhone().getNumber());
-        assertEquals(PASSWORD, captured.getPassword());
+        assertEquals(captured.getPhone().getNumber(), TestConstants.PHONE.getNumber());
+        assertEquals(captured.getPassword(), PASSWORD);
     }
     
     @Test
@@ -687,8 +683,8 @@ public class AuthenticationServiceMockTest {
         verify(accountWorkflowService).notifyAccountExists(eq(study), accountIdCaptor.capture());
         
         AccountId captured = accountIdCaptor.getValue();
-        assertEquals("user-id", captured.getId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, captured.getStudyId());
+        assertEquals(captured.getId(), "user-id");
+        assertEquals(captured.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
     }
     
     @Test
@@ -706,8 +702,8 @@ public class AuthenticationServiceMockTest {
         verify(accountWorkflowService).notifyAccountExists(eq(study), accountIdCaptor.capture());
         
         AccountId captured = accountIdCaptor.getValue();
-        assertEquals(EXTERNAL_ID, captured.getExternalId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, captured.getStudyId());
+        assertEquals(captured.getExternalId(), EXTERNAL_ID);
+        assertEquals(captured.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
     }
     
     @Test
@@ -744,9 +740,9 @@ public class AuthenticationServiceMockTest {
         // Execute and validate.
         UserSession session = service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
 
-        assertEquals(RECIPIENT_EMAIL, session.getParticipant().getEmail());
-        assertEquals("Test", session.getParticipant().getFirstName());
-        assertEquals("Tester", session.getParticipant().getLastName());
+        assertEquals(session.getParticipant().getEmail(), RECIPIENT_EMAIL);
+        assertEquals(session.getParticipant().getFirstName(), "Test");
+        assertEquals(session.getParticipant().getLastName(), "Tester");
         
         // this doesn't pass if our mock calls above aren't executed, but verify these:
         InOrder inOrder = Mockito.inOrder(cacheProvider, accountDao);
@@ -756,13 +752,13 @@ public class AuthenticationServiceMockTest {
         inOrder.verify(cacheProvider).setUserSession(session);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void phoneSignInNoAccount() {
         when(accountDao.getAccount(any())).thenReturn(null);
         service.phoneSignIn(CONTEXT, SIGN_IN_WITH_PHONE);
     }
     
-    @Test(expected = AuthenticationFailedException.class)
+    @Test(expectedExceptions = AuthenticationFailedException.class)
     public void phoneSignInFails() {
         doThrow(new AuthenticationFailedException()).when(accountWorkflowService).channelSignIn(ChannelType.PHONE,
                 CONTEXT, SIGN_IN_WITH_PHONE, SignInValidator.PHONE_SIGNIN);
@@ -786,7 +782,7 @@ public class AuthenticationServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConsentRequiredException e) {
             verify(cacheProvider).setUserSession(e.getUserSession());
-            assertEquals(UNCONSENTED_STATUS_MAP, e.getUserSession().getConsentStatuses());            
+            assertEquals(e.getUserSession().getConsentStatuses(), UNCONSENTED_STATUS_MAP);            
         }
     }
     
@@ -801,7 +797,7 @@ public class AuthenticationServiceMockTest {
         verify(accountDao).verifyChannel(ChannelType.EMAIL, account);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void verifyEmailInvalid() {
         Verification ev = new Verification(null);
         service.verifyChannel(ChannelType.EMAIL, ev);
@@ -818,7 +814,7 @@ public class AuthenticationServiceMockTest {
         verify(accountDao).verifyChannel(ChannelType.PHONE, account);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void verifyPhoneInvalid() {
         Verification ev = new Verification(null);
         service.verifyChannel(ChannelType.PHONE, ev);
@@ -851,8 +847,8 @@ public class AuthenticationServiceMockTest {
         
         verify(accountWorkflowService).resendVerificationToken(eq(ChannelType.EMAIL), accountIdCaptor.capture());
         
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountIdCaptor.getValue().getStudyId());
-        assertEquals(RECIPIENT_EMAIL, accountIdCaptor.getValue().getEmail());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountIdCaptor.getValue().getEmail(), RECIPIENT_EMAIL);
     }
 
     @Test
@@ -866,7 +862,7 @@ public class AuthenticationServiceMockTest {
         service.resendVerification(ChannelType.EMAIL, accountId);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void resendEmailVerificationInvalid() throws Exception {
         AccountId accountId = BridgeObjectMapper.get().readValue("{}", AccountId.class);
         service.resendVerification(ChannelType.EMAIL, accountId);
@@ -879,36 +875,36 @@ public class AuthenticationServiceMockTest {
         
         verify(accountWorkflowService).resendVerificationToken(eq(ChannelType.PHONE), accountIdCaptor.capture());
         
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountIdCaptor.getValue().getStudyId());
-        assertEquals(TestConstants.PHONE, accountIdCaptor.getValue().getPhone());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountIdCaptor.getValue().getPhone(), TestConstants.PHONE);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void resendPhoneVerificationInvalid() throws Exception {
         AccountId accountId = BridgeObjectMapper.get().readValue("{}", AccountId.class);
         service.resendVerification(ChannelType.PHONE, accountId);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void generatePasswordExternalIdManagementDisabled() {
         study.setExternalIdValidationEnabled(false);
         service.generatePassword(study, EXTERNAL_ID, true);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void generatePasswordExternalIdNotSubmitted() {
         study.setExternalIdValidationEnabled(true);
         service.generatePassword(study, null, true);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void generatePasswordExternalIdRecordMissing() {
         when(externalIdService.getExternalId(study.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.empty());
         study.setExternalIdValidationEnabled(true);
         service.generatePassword(study, EXTERNAL_ID, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void generatePasswordNoAccountDoNotCreateAccount() {
         ExternalIdentifier externalIdentifier = ExternalIdentifier.create(study.getStudyIdentifier(), EXTERNAL_ID);
         study.setExternalIdValidationEnabled(true);
@@ -930,12 +926,12 @@ public class AuthenticationServiceMockTest {
         when(participantService.createParticipant(eq(study), participantCaptor.capture(), eq(false))).thenReturn(idHolder);
         
         GeneratedPassword password = service.generatePassword(study, EXTERNAL_ID, true);
-        assertEquals(EXTERNAL_ID, password.getExternalId());
-        assertEquals(PASSWORD, password.getPassword());
+        assertEquals(password.getExternalId(), EXTERNAL_ID);
+        assertEquals(password.getPassword(), PASSWORD);
         
         StudyParticipant participant = participantCaptor.getValue();
-        assertEquals(EXTERNAL_ID, participant.getExternalId());
-        assertEquals(PASSWORD, participant.getPassword());
+        assertEquals(participant.getExternalId(), EXTERNAL_ID);
+        assertEquals(participant.getPassword(), PASSWORD);
     }
     
     @Test
@@ -993,8 +989,8 @@ public class AuthenticationServiceMockTest {
         account.setHealthCode(HEALTH_CODE);
         
         GeneratedPassword password = service.generatePassword(study, EXTERNAL_ID, true);
-        assertEquals(EXTERNAL_ID, password.getExternalId());
-        assertEquals(PASSWORD, password.getPassword());
+        assertEquals(password.getExternalId(), EXTERNAL_ID);
+        assertEquals(password.getPassword(), PASSWORD);
         
         verify(accountDao).changePassword(account, null, PASSWORD);
     }
@@ -1007,10 +1003,10 @@ public class AuthenticationServiceMockTest {
         Errors errors = Validate.getErrorsFor(password);
         ValidatorUtils.validatePassword(errors, PasswordPolicy.DEFAULT_PASSWORD_POLICY, password);
         assertFalse(errors.hasErrors());
-        assertEquals(100, password.length());
+        assertEquals(password.length(), 100);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void generatePasswordExternalIdMismatchesCallerSubstudies() {
         BridgeUtils.setRequestContext(
                 new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of("substudyB")).build());
@@ -1026,7 +1022,7 @@ public class AuthenticationServiceMockTest {
         service.generatePassword(study, EXTERNAL_ID, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void generatePasswordAccountMismatchesCallerSubstudies() {
         BridgeUtils.setRequestContext(
                 new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of("substudyA")).build());
@@ -1043,7 +1039,7 @@ public class AuthenticationServiceMockTest {
         service.generatePassword(study, EXTERNAL_ID, false);
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void creatingExternalIdOnlyAccountFailsIfIdsNotManaged() {
         study.setExternalIdValidationEnabled(false);
         
@@ -1188,15 +1184,15 @@ public class AuthenticationServiceMockTest {
         
         // Execute and validate.
         UserSession session = service.getSessionFromAccount(study, context, account);
-        assertSame(PARTICIPANT, session.getParticipant());
+        assertSame(session.getParticipant(), PARTICIPANT);
         assertNotNull(session.getSessionToken());
         assertNotNull(session.getInternalSessionToken());
         assertTrue(session.isAuthenticated());
-        assertEquals(Environment.LOCAL, session.getEnvironment());
-        assertEquals(IP_ADDRESS, session.getIpAddress());
-        assertEquals(TestConstants.TEST_STUDY, session.getStudyIdentifier());
-        assertEquals(REAUTH_TOKEN, session.getReauthToken());
-        assertEquals(CONSENTED_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getEnvironment(), Environment.LOCAL);
+        assertEquals(session.getIpAddress(), IP_ADDRESS);
+        assertEquals(session.getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(session.getReauthToken(), REAUTH_TOKEN);
+        assertEquals(session.getConsentStatuses(), CONSENTED_STATUS_MAP);
         
         verify(accountSecretDao).createSecret(AccountSecretType.REAUTH, USER_ID, REAUTH_TOKEN);
     }
@@ -1219,7 +1215,7 @@ public class AuthenticationServiceMockTest {
         
         // Execute and validate.
         UserSession session = service.getSessionFromAccount(study, context, account);
-        assertNull(REAUTH_TOKEN, session.getReauthToken());
+        assertNull(session.getReauthToken());
         
         verify(service, never()).generateReauthToken();
         verify(accountSecretDao, never()).createSecret(any(), any(), any());
@@ -1257,7 +1253,7 @@ public class AuthenticationServiceMockTest {
         verify(accountWorkflowService).resetPassword(reset);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void resetPasswordInvalid() {
         PasswordResetValidator validator = new PasswordResetValidator();
         validator.setStudyService(studyService);
@@ -1285,7 +1281,7 @@ public class AuthenticationServiceMockTest {
         
         UserSession session = service.signIn(study, context, EMAIL_PASSWORD_SIGN_IN);
         
-        assertEquals(TestConstants.LANGUAGES, session.getParticipant().getLanguages());
+        assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
         verify(accountDao, never()).editAccount(any(), any(), any());
    }
@@ -1307,7 +1303,7 @@ public class AuthenticationServiceMockTest {
         
         UserSession session = service.signIn(study, context, EMAIL_PASSWORD_SIGN_IN);
         
-        assertEquals(TestConstants.LANGUAGES, session.getParticipant().getLanguages());
+        assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
         // Note that the context does not have the healthCode, you must use the participant
         verify(accountDao).editAccount(eq(TestConstants.TEST_STUDY), eq(HEALTH_CODE), any());

--- a/src/test/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
@@ -1,21 +1,21 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -42,7 +42,7 @@ public class CompoundActivityDefinitionServiceTest {
     private CompoundActivityDefinitionDao dao;
     private CompoundActivityDefinitionService service;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         dao = mock(CompoundActivityDefinitionDao.class);
         schedulePlanService = mock(SchedulePlanService.class);
@@ -69,10 +69,10 @@ public class CompoundActivityDefinitionServiceTest {
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
         assertSame(serviceInput, daoInput);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInput.getStudyId());
+        assertEquals(daoInput.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
 
         // Validate that the service result is the same as the dao result.
-        assertSame(daoResult, serviceResult);
+        assertSame(serviceResult, daoResult);
     }
 
     @Test
@@ -137,10 +137,10 @@ public class CompoundActivityDefinitionServiceTest {
             service.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, TASK_ID);
             fail("Shoud have thrown exception");
         } catch(ConstraintViolationException e) {
-            assertEquals("GGG", e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(TASK_ID, e.getEntityKeys().get("taskId"));
-            assertEquals("CompoundActivityDefinition", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), "GGG");
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("taskId"), TASK_ID);
+            assertEquals(e.getEntityKeys().get("type"), "CompoundActivityDefinition");
         }
     }
 
@@ -150,7 +150,7 @@ public class CompoundActivityDefinitionServiceTest {
             service.deleteCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("taskId must be specified", ex.getMessage());
+            assertEquals(ex.getMessage(), "taskId must be specified");
         }
 
         // verify dao is never called
@@ -181,7 +181,7 @@ public class CompoundActivityDefinitionServiceTest {
                 TestConstants.TEST_STUDY);
 
         // Validate that the service result is the same as the dao result.
-        assertSame(daoResultList, serviceResultList);
+        assertSame(serviceResultList, daoResultList);
     }
 
     // GET
@@ -197,7 +197,7 @@ public class CompoundActivityDefinitionServiceTest {
                 TASK_ID);
 
         // Validate that the service result is the same as the dao result.
-        assertSame(daoResult, serviceResult);
+        assertSame(serviceResult, daoResult);
     }
 
     @Test
@@ -221,7 +221,7 @@ public class CompoundActivityDefinitionServiceTest {
             service.getCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("taskId must be specified", ex.getMessage());
+            assertEquals(ex.getMessage(), "taskId must be specified");
         }
 
         // verify dao is never called
@@ -245,12 +245,12 @@ public class CompoundActivityDefinitionServiceTest {
 
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
-        assertSame(serviceInput, daoInput);
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInput.getStudyId());
-        assertEquals(TASK_ID, daoInput.getTaskId());
+        assertSame(daoInput, serviceInput);
+        assertEquals(daoInput.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(daoInput.getTaskId(), TASK_ID);
 
         // Validate that the service result is the same as the dao result.
-        assertSame(daoResult, serviceResult);
+        assertSame(serviceResult, daoResult);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class CompoundActivityDefinitionServiceTest {
             service.updateCompoundActivityDefinition(TestConstants.TEST_STUDY, taskId, makeValidDef());
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("taskId must be specified", ex.getMessage());
+            assertEquals(ex.getMessage(), "taskId must be specified");
         }
 
         // verify dao is never called

--- a/src/test/java/org/sagebionetworks/bridge/services/ConsentPdfTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ConsentPdfTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import java.io.FileInputStream;
 
@@ -8,10 +8,10 @@ import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -35,7 +35,7 @@ public class ConsentPdfTest {
     private String consentBodyTemplate;
     private Study study;
     
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
         DateTimeUtils.setCurrentMillisFixed(TIMESTAMP);
         consentBodyTemplate = IOUtils.toString(new FileInputStream(new ClassPathResource(
@@ -49,7 +49,7 @@ public class ConsentPdfTest {
         study.setConsentNotificationEmailVerified(true);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -73,7 +73,7 @@ public class ConsentPdfTest {
         
         String output = consentPdf.getFormattedConsentDocument();
         String dateStr = ConsentPdf.FORMATTER.print(DateTime.now(DateTimeZone.UTC));
-        assertTrue("Signing date formatted with default zone", output.contains(dateStr));
+        assertTrue(output.contains(dateStr), "Signing date formatted with default zone");
     }
     
     @Test
@@ -189,7 +189,7 @@ public class ConsentPdfTest {
                 NEW_DOCUMENT_FRAGMENT, consentBodyTemplate);
         String output = consentPdf.getFormattedConsentDocument();
 
-        assertTrue("Contains formatted date", output.contains("October 4, 2017 (GMT)"));
+        assertTrue(output.contains("October 4, 2017 (GMT)"), "Contains formatted date");
     }
     
     private static ConsentSignature makeSignatureWithoutImage() {
@@ -209,20 +209,20 @@ public class ConsentPdfTest {
 
     private static void validateLegacyDocBody(String bodyContent) throws Exception {
         String dateStr = ConsentPdf.FORMATTER.print(DateTime.now());
-        assertTrue("Signing date correct", bodyContent.contains(dateStr));
-        assertTrue("Name correct", bodyContent.contains("|Test Person|"));
-        assertTrue("User email correct", bodyContent.contains("|user@user.com|"));
-        assertTrue("Sharing correct", bodyContent.contains("|Not Sharing|"));
-        assertTrue("HTML markup preserved", bodyContent.contains("<html><head></head><body>Passed through as is."));
+        assertTrue(bodyContent.contains(dateStr), "Signing date correct");
+        assertTrue(bodyContent.contains("|Test Person|"), "Name correct");
+        assertTrue(bodyContent.contains("|user@user.com|"), "User email correct");
+        assertTrue(bodyContent.contains("|Not Sharing|"), "Sharing correct");
+        assertTrue(bodyContent.contains("<html><head></head><body>Passed through as is."), "HTML markup preserved");
     }
 
     private static void validateNewDocBody(String bodyContent) throws Exception {
         String dateStr = ConsentPdf.FORMATTER.print(DateTime.now());
-        assertTrue("Signing date correct", bodyContent.contains(dateStr));
-        assertTrue("Study name correct", bodyContent.contains("<title>Study Name Consent To Research</title>"));
-        assertTrue("Name correct", bodyContent.contains(">Test Person<"));
-        assertTrue("User email correct", bodyContent.contains(">user@user.com<"));
-        assertTrue("Sharing correct", bodyContent.contains(">Not Sharing<"));
-        assertTrue("Contact correctly labeled", bodyContent.contains(">Email Address<"));
+        assertTrue(bodyContent.contains(dateStr), "Signing date correct");
+        assertTrue(bodyContent.contains("<title>Study Name Consent To Research</title>"), "Study name correct");
+        assertTrue(bodyContent.contains(">Test Person<"), "Name correct");
+        assertTrue(bodyContent.contains(">user@user.com<"), "User email correct");
+        assertTrue(bodyContent.contains(">Not Sharing<"), "Sharing correct");
+        assertTrue(bodyContent.contains(">Email Address<"), "Contact correctly labeled");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -1,11 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -13,6 +7,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -31,14 +31,11 @@ import com.google.common.collect.Sets;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -71,8 +68,9 @@ import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("ConstantConditions")
 public class ConsentServiceMockTest {
     private static final String SHORT_URL = "https://ws.sagebridge.org/r/XXXXX";
@@ -103,7 +101,7 @@ public class ConsentServiceMockTest {
 
     @Spy
     private ConsentService consentService;
-    
+
     private Study study;
 
     @Mock
@@ -123,7 +121,7 @@ public class ConsentServiceMockTest {
     @Mock
     private S3Helper s3Helper;
     @Mock
-    private UrlShortenerService urlShortenerService; 
+    private UrlShortenerService urlShortenerService;
     @Mock
     private Subpopulation subpopulation;
     @Mock
@@ -136,12 +134,14 @@ public class ConsentServiceMockTest {
     private ArgumentCaptor<Account> accountCaptor;
 
     private Account account;
-    
-    @Before
+
+    @BeforeMethod
     public void before() throws IOException {
-        String documentString = IOUtils.toString(new FileInputStream(new ClassPathResource(
-                "conf/study-defaults/consent-page.xhtml").getFile()));
-        
+        MockitoAnnotations.initMocks(this);
+
+        String documentString = IOUtils.toString(
+                new FileInputStream(new ClassPathResource("conf/study-defaults/consent-page.xhtml").getFile()));
+
         consentService.setAccountDao(accountDao);
         consentService.setSendMailService(sendMailService);
         consentService.setActivityEventService(activityEventService);
@@ -152,47 +152,52 @@ public class ConsentServiceMockTest {
         consentService.setUrlShortenerService(urlShortenerService);
         consentService.setNotificationsService(notificationsService);
         consentService.setConsentTemplate(new ByteArrayResource((documentString).getBytes()));
-        
+
         study = TestUtils.getValidStudy(ConsentServiceMockTest.class);
 
         account = Account.create();
         account.setId(ID);
-        
+
         when(accountDao.getAccount(any(AccountId.class))).thenReturn(account);
-        
+
         when(s3Helper.generatePresignedUrl(eq(ConsentService.USERSIGNED_CONSENTS_BUCKET), any(), any(),
                 eq(HttpMethod.GET))).thenReturn(new URL(LONG_URL));
         when(urlShortenerService.shortenUrl(LONG_URL, BridgeConstants.SIGNED_CONSENT_DOWNLOAD_EXPIRE_IN_SECONDS))
-            .thenReturn(SHORT_URL);
-        
+                .thenReturn(SHORT_URL);
+
         when(studyConsentView.getCreatedOn()).thenReturn(CONSENT_CREATED_ON);
-        when(studyConsentView.getDocumentContent()).thenReturn("<p>This is content of the final HTML document we assemble.</p>");
+        when(studyConsentView.getDocumentContent())
+                .thenReturn("<p>This is content of the final HTML document we assemble.</p>");
         when(studyConsentService.getActiveConsent(subpopulation)).thenReturn(studyConsentView);
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void userCannotGetConsentSignatureForSubpopulationToWhichTheyAreNotMapped() {
-        when(subpopService.getSubpopulation(study, SUBPOP_GUID)).thenThrow(new EntityNotFoundException(Subpopulation.class));
-        
+        when(subpopService.getSubpopulation(study, SUBPOP_GUID))
+                .thenThrow(new EntityNotFoundException(Subpopulation.class));
+
         consentService.getConsentSignature(study, SUBPOP_GUID, PARTICIPANT.getId());
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void userCannotGetConsentSignatureWithNoActiveSig() {
         // set signatures in the account... but not the right signatures
-        account.setConsentSignatureHistory(SubpopulationGuid.create("second-subpop"), ImmutableList.of(CONSENT_SIGNATURE));
-        
+        account.setConsentSignatureHistory(SubpopulationGuid.create("second-subpop"),
+                ImmutableList.of(CONSENT_SIGNATURE));
+
         consentService.getConsentSignature(study, SUBPOP_GUID, PARTICIPANT.getId());
     }
-    
-    @Test(expected = EntityNotFoundException.class)
-    public void userCannotConsentToSubpopulationToWhichTheyAreNotMapped() {
-        when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenThrow(new EntityNotFoundException(Subpopulation.class));
 
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void userCannotConsentToSubpopulationToWhichTheyAreNotMapped() {
+        when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID))
+                .thenThrow(new EntityNotFoundException(Subpopulation.class));
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                false);
     }
-    
+
     @Test
     public void giveConsentSuccess() {
         // Account already has a withdrawn consent, to make sure we're correctly appending consents.
@@ -202,68 +207,71 @@ public class ConsentServiceMockTest {
         // those properly in ConsentService.
         ConsentSignature sig = new ConsentSignature.Builder().withConsentSignature(CONSENT_SIGNATURE)
                 .withConsentCreatedOn(CONSENT_CREATED_ON + 20000).withWithdrewOn(12345L).build();
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
 
         // verify consents were set on account properly
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
 
         Account updatedAccount = accountCaptor.getValue();
         List<ConsentSignature> updatedConsentList = updatedAccount.getConsentSignatureHistory(SUBPOP_GUID);
-        assertEquals(2, updatedConsentList.size());
+        assertEquals(updatedConsentList.size(), 2);
 
         // First consent is the same.
-        assertEquals(WITHDRAWN_CONSENT_SIGNATURE, updatedConsentList.get(0));
+        assertEquals(updatedConsentList.get(0), WITHDRAWN_CONSENT_SIGNATURE);
 
         // Second consent has consentCreatedOn added and withdrawnOn clear, but is otherwise the same.
-        assertEquals(sig.getBirthdate(), updatedConsentList.get(1).getBirthdate());
-        assertEquals(sig.getName(), updatedConsentList.get(1).getName());
-        assertEquals(sig.getSignedOn(), updatedConsentList.get(1).getSignedOn());
-        assertEquals(CONSENT_CREATED_ON, updatedConsentList.get(1).getConsentCreatedOn());
+        assertEquals(updatedConsentList.get(1).getBirthdate(), sig.getBirthdate());
+        assertEquals(updatedConsentList.get(1).getName(), sig.getName());
+        assertEquals(updatedConsentList.get(1).getSignedOn(), sig.getSignedOn());
+        assertEquals(updatedConsentList.get(1).getConsentCreatedOn(), CONSENT_CREATED_ON);
         assertNull(updatedConsentList.get(1).getWithdrewOn());
 
         // Consent we send to activityEventService is same as the second consent.
-        verify(activityEventService).publishEnrollmentEvent(study, PARTICIPANT.getHealthCode(), updatedConsentList.get(1));
+        verify(activityEventService).publishEnrollmentEvent(study, PARTICIPANT.getHealthCode(),
+                updatedConsentList.get(1));
 
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         // We notify the study administrator and send a copy to the user.
         BasicEmailProvider email = emailCaptor.getValue();
-        assertEquals(EmailType.SIGN_CONSENT, email.getType());
+        assertEquals(email.getType(), EmailType.SIGN_CONSENT);
 
         Set<String> recipients = email.getRecipientEmails();
-        assertEquals(2, recipients.size());
+        assertEquals(recipients.size(), 2);
         assertTrue(recipients.contains(study.getConsentNotificationEmail()));
         assertTrue(recipients.contains(PARTICIPANT.getEmail()));
     }
-    
+
     @Test
     public void emailConsentAgreementSuccess() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
         BasicEmailProvider email = emailCaptor.getValue();
-        assertEquals(1, email.getRecipientEmails().size());
+        assertEquals(email.getRecipientEmails().size(), 1);
         assertTrue(email.getRecipientEmails().contains(PARTICIPANT.getEmail()));
-        assertEquals(EmailType.RESEND_CONSENT, email.getType());
+        assertEquals(email.getType(), EmailType.RESEND_CONSENT);
     }
-    
+
     @Test
     public void noConsentIfTooYoung() {
         ConsentSignature consentSignature = new ConsentSignature.Builder().withConsentSignature(CONSENT_SIGNATURE)
                 .withBirthdate("2018-05-12").build();
-        
+
         try {
-            consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, consentSignature, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, consentSignature, SharingScope.NO_SHARING,
+                    false);
             fail("Exception expected.");
-        } catch(InvalidEntityException e) {
+        } catch (InvalidEntityException e) {
             verifyNoMoreInteractions(activityEventService);
             verifyNoMoreInteractions(accountDao);
         }
     }
-    
+
     @Test
     public void noConsentIfAlreadyConsented() {
         ConsentSignature sig = new ConsentSignature.Builder().withConsentCreatedOn(CONSENT_CREATED_ON)
@@ -271,27 +279,29 @@ public class ConsentServiceMockTest {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(sig));
 
         try {
-            consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE,
+                    SharingScope.NO_SHARING, false);
             fail("Exception expected.");
-        } catch(EntityAlreadyExistsException e) {
+        } catch (EntityAlreadyExistsException e) {
             verifyNoMoreInteractions(activityEventService);
             verify(accountDao).getAccount(any());
             verifyNoMoreInteractions(accountDao);
         }
     }
-    
+
     @Test
     public void noConsentIfDaoFails() {
         try {
-            consentService.consentToResearch(study, SubpopulationGuid.create("badGuid"), PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
+            consentService.consentToResearch(study, SubpopulationGuid.create("badGuid"), PARTICIPANT, CONSENT_SIGNATURE,
+                    SharingScope.NO_SHARING, false);
             fail("Exception expected.");
-        } catch(Throwable e) {
+        } catch (Throwable e) {
             verifyNoMoreInteractions(activityEventService);
             verify(accountDao).getAccount(any());
             verifyNoMoreInteractions(accountDao);
         }
     }
-    
+
     @Test
     public void withdrawConsentWithParticipant() throws Exception {
         account.setEmail(EMAIL);
@@ -299,7 +309,8 @@ public class ConsentServiceMockTest {
 
         // Add two consents to the account, one withdrawn, one active. This tests to make sure we're not accidentally
         // dropping withdrawn consents from the history.
-        account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(WITHDRAWN_CONSENT_SIGNATURE, CONSENT_SIGNATURE));
+        account.setConsentSignatureHistory(SUBPOP_GUID,
+                ImmutableList.of(WITHDRAWN_CONSENT_SIGNATURE, CONSENT_SIGNATURE));
 
         // Execute and validate.
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, SIGNED_ON + 10000);
@@ -307,34 +318,35 @@ public class ConsentServiceMockTest {
         verify(accountDao).getAccount(CONTEXT.getAccountId());
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         Account account = accountCaptor.getValue();
 
         // Both signatures are there, and the second one is now withdrawn.
         assertNull(account.getActiveConsentSignature(SUBPOP_GUID));
 
         List<ConsentSignature> updatedConsentList = account.getConsentSignatureHistory(SUBPOP_GUID);
-        assertEquals(2, updatedConsentList.size());
+        assertEquals(updatedConsentList.size(), 2);
 
         // First consent is unchanged.
-        assertEquals(WITHDRAWN_CONSENT_SIGNATURE, updatedConsentList.get(0));
+        assertEquals(updatedConsentList.get(0), WITHDRAWN_CONSENT_SIGNATURE);
 
         // Second consent has withdrawnOn tacked on, but is otherwise the same.
-        assertEquals(CONSENT_SIGNATURE.getBirthdate(), updatedConsentList.get(1).getBirthdate());
-        assertEquals(CONSENT_SIGNATURE.getName(), updatedConsentList.get(1).getName());
-        assertEquals(CONSENT_SIGNATURE.getSignedOn(), updatedConsentList.get(1).getSignedOn());
-        assertEquals(SIGNED_ON + 10000, updatedConsentList.get(1).getWithdrewOn().longValue());
+        assertEquals(updatedConsentList.get(1).getBirthdate(), CONSENT_SIGNATURE.getBirthdate());
+        assertEquals(updatedConsentList.get(1).getName(), CONSENT_SIGNATURE.getName());
+        assertEquals(updatedConsentList.get(1).getSignedOn(), CONSENT_SIGNATURE.getSignedOn());
+        assertEquals(updatedConsentList.get(1).getWithdrewOn().longValue(), SIGNED_ON + 10000);
 
         MimeTypeEmailProvider provider = emailCaptor.getValue();
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        
-        assertEquals("\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>", email.getSenderAddress());
-        assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));
-        assertEquals("Notification of consent withdrawal for Test Study [ConsentServiceMockTest]", email.getSubject());
-        assertEquals("<p>User   &lt;" + EMAIL + "&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>",
-                email.getMessageParts().get(0).getContent());
+
+        assertEquals(email.getSenderAddress(),
+                "\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>");
+        assertEquals(email.getRecipientAddresses().get(0), "bridge-testing+consent@sagebase.org");
+        assertEquals(email.getSubject(), "Notification of consent withdrawal for Test Study [ConsentServiceMockTest]");
+        assertEquals(email.getMessageParts().get(0).getContent(), "<p>User   &lt;" + EMAIL
+                + "&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>");
     }
-    
+
     @Test
     public void withdrawConsentRemovesDataGroups() throws Exception {
         Set<String> dataGroups = Sets.newHashSet(TestConstants.USER_DATA_GROUPS);
@@ -345,19 +357,19 @@ public class ConsentServiceMockTest {
         when(subpopulation.getDataGroupsAssignedWhileConsented()).thenReturn(TestConstants.USER_DATA_GROUPS);
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
         when(accountDao.getAccount(any())).thenReturn(account);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
-        assertEquals(ImmutableSet.of("leaveBehind1", "leaveBehind2"), account.getDataGroups());
+
+        assertEquals(account.getDataGroups(), ImmutableSet.of("leaveBehind1", "leaveBehind2"));
         verify(subpopulation).getDataGroupsAssignedWhileConsented();
         verify(subpopulation, never()).getSubstudyIdsAssignedOnConsent();
     }
-    
+
     @Test
     public void withdrawConsentWithAccount() throws Exception {
         setupWithdrawTest();
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, SIGNED_ON);
-        
+
         verify(accountDao).updateAccount(account, null);
         verify(sendMailService).sendEmail(any(WithdrawConsentEmailProvider.class));
 
@@ -367,11 +379,11 @@ public class ConsentServiceMockTest {
     @Test
     public void withdrawFromStudyWithEmail() throws Exception {
         setupWithdrawTest();
-        
+
         consentService.withdrawFromStudy(study, PARTICIPANT, WITHDRAWAL, SIGNED_ON);
 
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
 
         ArgumentCaptor<MimeTypeEmailProvider> emailCaptor = ArgumentCaptor.forClass(MimeTypeEmailProvider.class);
         verify(sendMailService).sendEmail(emailCaptor.capture());
@@ -379,14 +391,15 @@ public class ConsentServiceMockTest {
         MimeTypeEmailProvider provider = emailCaptor.getValue();
         MimeTypeEmail email = provider.getMimeTypeEmail();
 
-        assertEquals("\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>", email.getSenderAddress());
-        assertEquals("bridge-testing+consent@sagebase.org", email.getRecipientAddresses().get(0));
-        assertEquals("Notification of consent withdrawal for Test Study [ConsentServiceMockTest]", email.getSubject());
-        assertEquals("<p>User Allen Wrench &lt;" + EMAIL + "&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>",
-                email.getMessageParts().get(0).getContent());
+        assertEquals(email.getSenderAddress(),
+                "\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>");
+        assertEquals(email.getRecipientAddresses().get(0), "bridge-testing+consent@sagebase.org");
+        assertEquals(email.getSubject(), "Notification of consent withdrawal for Test Study [ConsentServiceMockTest]");
+        assertEquals(email.getMessageParts().get(0).getContent(), "<p>User Allen Wrench &lt;" + EMAIL
+                + "&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>For reasons.</p>");
 
         Account updatedAccount = accountCaptor.getValue();
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
         assertNull(account.getFirstName());
         assertNull(account.getLastName());
         assertFalse(account.getNotifyByEmail());
@@ -394,31 +407,31 @@ public class ConsentServiceMockTest {
         assertFalse(account.getEmailVerified());
         assertNull(account.getPhone());
         assertFalse(account.getPhoneVerified());
-        assertEquals("externalId", account.getExternalId());
+        assertEquals(account.getExternalId(), "externalId");
         // This association is not removed
-        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(account.getAccountSubstudies().size(), 1);
         AccountSubstudy acctSubstudy = account.getAccountSubstudies().iterator().next();
-        assertEquals("substudyId", acctSubstudy.getSubstudyId());
-        assertEquals("anExternalId", acctSubstudy.getExternalId());
+        assertEquals(acctSubstudy.getSubstudyId(), "substudyId");
+        assertEquals(acctSubstudy.getExternalId(), "anExternalId");
         for (List<ConsentSignature> signatures : updatedAccount.getAllConsentSignatureHistories().values()) {
             for (ConsentSignature sig : signatures) {
                 assertNotNull(sig.getWithdrewOn());
             }
         }
     }
-    
+
     @Test
     public void withdrawFromStudyWithPhone() {
         account.setPhone(TestConstants.PHONE);
         account.setHealthCode(PARTICIPANT.getHealthCode());
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         consentService.withdrawFromStudy(study, PHONE_PARTICIPANT, WITHDRAWAL, SIGNED_ON);
 
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
         verify(sendMailService, never()).sendEmail(any(MimeTypeEmailProvider.class));
-        
+
         Account updatedAccount = accountCaptor.getValue();
         for (List<ConsentSignature> signatures : updatedAccount.getAllConsentSignatureHistories().values()) {
             for (ConsentSignature sig : signatures) {
@@ -428,7 +441,7 @@ public class ConsentServiceMockTest {
 
         verify(notificationsService).deleteAllRegistrations(study.getStudyIdentifier(), HEALTH_CODE);
     }
-    
+
     @Test
     public void withdrawFromStudyRemovesDataGroups() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
@@ -443,19 +456,19 @@ public class ConsentServiceMockTest {
         when(accountDao.getAccount(any())).thenReturn(account);
 
         consentService.withdrawFromStudy(study, PARTICIPANT, WITHDRAWAL, WITHDREW_ON);
-        
-        assertEquals(ImmutableSet.of("remainingDataGroup1", "remainingDataGroup2"), account.getDataGroups());
+
+        assertEquals(account.getDataGroups(), ImmutableSet.of("remainingDataGroup1", "remainingDataGroup2"));
         verify(subpopulation).getDataGroupsAssignedWhileConsented();
         verify(subpopulation, never()).getSubstudyIdsAssignedOnConsent();
     }
-    
+
     @Test
     public void accountFailureConsistent() {
         when(accountDao.getAccount(any())).thenThrow(new BridgeServiceException("Something bad happend", 500));
         try {
             consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
             fail("Should have thrown an exception");
-        } catch(BridgeServiceException e) {
+        } catch (BridgeServiceException e) {
             // expected exception
         }
         verifyNoMoreInteractions(sendMailService);
@@ -500,15 +513,15 @@ public class ConsentServiceMockTest {
         // verified=false means the email is never sent.
         verify(sendMailService, never()).sendEmail(any());
     }
-    
+
     @Test
     public void withdrawFromOneRequiredConsentSetsAccountToNoSharing() throws Exception {
         setupWithdrawTest(true, false);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
-        assertEquals(new Long(WITHDREW_ON), account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn());
+
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
+        assertEquals(account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn(), new Long(WITHDREW_ON));
         assertNull(account.getConsentSignatureHistory(SECOND_SUBPOP).get(0).getWithdrewOn());
 
         verify(notificationsService).deleteAllRegistrations(study.getStudyIdentifier(), HEALTH_CODE);
@@ -517,100 +530,102 @@ public class ConsentServiceMockTest {
     @Test
     public void withdrawFromOneOfTwoRequiredConsentsSetsAcountToNoSharing() throws Exception {
         setupWithdrawTest(true, true);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
+
         // You must sign all required consents to sign.
-        assertEquals(SharingScope.NO_SHARING, account.getSharingScope());
-        assertEquals(new Long(WITHDREW_ON), account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn());
+        assertEquals(account.getSharingScope(), SharingScope.NO_SHARING);
+        assertEquals(account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn(), new Long(WITHDREW_ON));
         assertNull(account.getConsentSignatureHistory(SECOND_SUBPOP).get(0).getWithdrewOn());
 
         verify(notificationsService).deleteAllRegistrations(study.getStudyIdentifier(), HEALTH_CODE);
     }
-    
+
     @Test
     public void withdrawFromOneOptionalConsentDoesNotChangeSharing() throws Exception {
         setupWithdrawTest(false, true);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
+
         // Not changed because all the required consents are still signed.
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
-        
-        assertEquals(new Long(WITHDREW_ON), account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn());
+        assertEquals(account.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+
+        assertEquals(account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn(), new Long(WITHDREW_ON));
         assertNull(account.getConsentSignatureHistory(SECOND_SUBPOP).get(0).getWithdrewOn());
 
         verify(notificationsService, never()).deleteAllRegistrations(any(), any());
     }
-    
+
     @Test
     public void withdrawFromOneOfTwoOptionalConsentsDoesNotChangeSharing() throws Exception {
         setupWithdrawTest(false, false);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
+
         // Not changed because all the required consents are still signed.
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
-        assertEquals(new Long(WITHDREW_ON), account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn());
+        assertEquals(account.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        assertEquals(account.getConsentSignatureHistory(SUBPOP_GUID).get(0).getWithdrewOn(), new Long(WITHDREW_ON));
         assertNull(account.getConsentSignatureHistory(SECOND_SUBPOP).get(0).getWithdrewOn());
 
         verify(notificationsService, never()).deleteAllRegistrations(any(), any());
     }
-    
-    @Test(expected = EntityNotFoundException.class)
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void withdrawConsentWhenAllConsentsAreWithdrawn() {
         Subpopulation subpop1 = Subpopulation.create();
         subpop1.setName(SUBPOP_GUID.getGuid());
         subpop1.setGuid(SUBPOP_GUID);
         subpop1.setRequired(true);
-        
+
         Subpopulation subpop2 = Subpopulation.create();
         subpop2.setName(SECOND_SUBPOP.getGuid());
         subpop2.setGuid(SECOND_SUBPOP);
         subpop2.setRequired(true);
-        
+
         ConsentSignature withdrawnSignature = new ConsentSignature.Builder().withName("Test User")
                 .withBirthdate("1990-01-01").withWithdrewOn(WITHDREW_ON).withSignedOn(SIGNED_ON).build();
-        
+
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE, withdrawnSignature));
         account.setConsentSignatureHistory(SECOND_SUBPOP, ImmutableList.of(withdrawnSignature));
 
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
     }
-    
+
     @Test
     public void consentToResearchNoConsentAdministratorEmail() {
         study.setConsentNotificationEmail(null);
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
         Set<String> recipients = emailCaptor.getValue().getRecipientEmails();
-        assertEquals(1, recipients.size());
+        assertEquals(recipients.size(), 1);
         assertTrue(recipients.contains(PARTICIPANT.getEmail()));
     }
-    
+
     @Test
     public void consentToResearchSuppressEmailNotification() {
         when(subpopulation.isAutoSendConsentSuppressed()).thenReturn(true);
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
         Set<String> recipients = emailCaptor.getValue().getRecipientEmails();
-        assertEquals(1, recipients.size());
+        assertEquals(recipients.size(), 1);
         assertTrue(recipients.contains(study.getConsentNotificationEmail()));
     }
-    
+
     @Test
     public void consentToResearchNoParticipantEmail() {
         StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT).withEmail(null).build();
-        
+
         consentService.consentToResearch(study, SUBPOP_GUID, noEmail, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
         Set<String> recipients = emailCaptor.getValue().getRecipientEmails();
-        assertEquals(1, recipients.size());
+        assertEquals(recipients.size(), 1);
         assertTrue(recipients.contains(study.getConsentNotificationEmail()));
     }
 
@@ -619,29 +634,31 @@ public class ConsentServiceMockTest {
         // easiest to test this if we null out the study consent email.
         study.setConsentNotificationEmail(null);
         when(subpopulation.isAutoSendConsentSuppressed()).thenReturn(true);
-        
-        // sendEmail = true because the system would otherwise send it based on the call, but hasn't looked to suppress yet.
+
+        // sendEmail = true because the system would otherwise send it based on the call, but hasn't looked to suppress
+        // yet.
         consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE,
                 SharingScope.ALL_QUALIFIED_RESEARCHERS, true);
-        
+
         verify(sendMailService, never()).sendEmail(any());
     }
-    
+
     @Test
     public void consentToResearchSucceedsWithoutNotification() {
         // In this call, we explicitly override any other settings to suppress notifications
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
-        
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                false);
+
         verify(sendMailService, never()).sendEmail(any());
     }
-    
+
     @Test
     public void withdrawConsentNoConsentAdministratorEmail() {
         setupWithdrawTest(true, true);
         study.setConsentNotificationEmail(null);
-        
+
         consentService.withdrawConsent(study, SUBPOP_GUID, PARTICIPANT, CONTEXT, WITHDRAWAL, WITHDREW_ON);
-        
+
         verify(sendMailService, never()).sendEmail(any());
     }
 
@@ -649,47 +666,47 @@ public class ConsentServiceMockTest {
     public void withdrawAllConsentsNoConsentAdministratorEmail() {
         setupWithdrawTest(true, true);
         study.setConsentNotificationEmail(null);
-        
+
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SECOND_SUBPOP)).thenReturn(subpopulation);
-        
+
         consentService.withdrawFromStudy(study, PARTICIPANT, WITHDRAWAL, WITHDREW_ON);
-        
+
         verify(sendMailService, never()).sendEmail(any());
     }
-    
+
     @Test
     public void emailConsentAgreementNoConsentAdministratorEmail() {
         study.setConsentNotificationEmail(null);
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        assertEquals(1, emailCaptor.getValue().getRecipientEmails().size());
-        assertEquals(PARTICIPANT.getEmail(), emailCaptor.getValue().getRecipientEmails().iterator().next());
+        assertEquals(emailCaptor.getValue().getRecipientEmails().size(), 1);
+        assertEquals(emailCaptor.getValue().getRecipientEmails().iterator().next(), PARTICIPANT.getEmail());
     }
-    
+
     @Test
     public void emailConsentAgreementDoesNotSuppressEmailNotification() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
-        
+
         verify(subpopulation, never()).isAutoSendConsentSuppressed();
-        
+
         // Despite explicitly suppressing email, if the user makes this call, we will send the email.
         verify(sendMailService).sendEmail(emailCaptor.capture());
         Set<String> recipients = emailCaptor.getValue().getRecipientEmails();
-        assertEquals(1, recipients.size());
+        assertEquals(recipients.size(), 1);
         assertTrue(recipients.contains(PARTICIPANT.getEmail()));
     }
-    
-    @Test(expected = BadRequestException.class)
+
+    @Test(expectedExceptions = BadRequestException.class)
     public void emailConsentAgreementNoParticipantEmail() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT).withEmail(null).build();
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, noEmail);
     }
 
@@ -698,16 +715,16 @@ public class ConsentServiceMockTest {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
         // easiest to test this if we null out the study consent email.
         study.setConsentNotificationEmail(null);
-        
+
         StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT).withEmail(null).build();
         try {
             consentService.resendConsentAgreement(study, SUBPOP_GUID, noEmail);
             fail("Should have thrown an exception");
-        } catch(BadRequestException e) {
+        } catch (BadRequestException e) {
         }
         verify(sendMailService, never()).sendEmail(any());
     }
-    
+
     // Tests of the construction of recipients for email, originally part of special email builder.
 
     @Test
@@ -716,53 +733,53 @@ public class ConsentServiceMockTest {
         study.setConsentNotificationEmailVerified(false);
 
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         MimeTypeEmailProvider provider = emailCaptor.getValue();
 
         // Validate email recipients does not include consent notification email.
         MimeTypeEmail email = provider.getMimeTypeEmail();
         List<String> recipientList = email.getRecipientAddresses();
-        assertEquals(1, recipientList.size());
-        assertEquals("email@email.com", recipientList.get(0));
+        assertEquals(recipientList.size(), 1);
+        assertEquals(recipientList.get(0), "email@email.com");
     }
-    
+
     @Test
     public void emailConsentAgreementWithoutStudyRecipientsDoesSend() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
         study.setConsentNotificationEmail(null);
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PARTICIPANT);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         assertFalse(emailCaptor.getValue().getRecipientEmails().isEmpty());
-        assertEquals(PARTICIPANT.getEmail(), emailCaptor.getValue().getRecipientEmails().iterator().next());
+        assertEquals(emailCaptor.getValue().getRecipientEmails().iterator().next(), PARTICIPANT.getEmail());
     }
-    
+
     @Test
     public void consentToResearchNoNotificationEmailSends() throws Exception {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         // For backwards-compatibility, consentNotificationEmailVerified=null means we still send it to the consent
         // notification email.
         study.setConsentNotificationEmailVerified(null);
 
         consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
                 true);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         MimeTypeEmailProvider provider = emailCaptor.getValue();
 
         // Validate common elements.
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals("signedConsent subject", email.getSubject());
-        assertEquals("\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>",
-                email.getSenderAddress());
-        assertEquals(Sets.newHashSet("email@email.com","bridge-testing+consent@sagebase.org"),
-                Sets.newHashSet(email.getRecipientAddresses()));
+        assertEquals(email.getSubject(), "signedConsent subject");
+        assertEquals(email.getSenderAddress(),
+                "\"Test Study [ConsentServiceMockTest]\" <bridge-testing+support@sagebase.org>");
+        assertEquals(Sets.newHashSet(email.getRecipientAddresses()),
+                Sets.newHashSet("email@email.com", "bridge-testing+consent@sagebase.org"));
     }
 
     @Test
@@ -771,85 +788,90 @@ public class ConsentServiceMockTest {
 
         study.setConsentNotificationEmailVerified(false);
 
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         MimeTypeEmailProvider provider = emailCaptor.getValue();
 
         // Validate email recipients does not include consent notification email.
         MimeTypeEmail email = provider.getMimeTypeEmail();
         List<String> recipientList = email.getRecipientAddresses();
-        assertEquals(1, recipientList.size());
-        assertEquals("email@email.com", recipientList.get(0));
+        assertEquals(recipientList.size(), 1);
+        assertEquals(recipientList.get(0), "email@email.com");
     }
-    
+
     @Test
     public void consentToResearchWithNoRecipientsDoesNotSend() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         study.setConsentNotificationEmail(null);
-        
+
         // The provider reports that there are no addresses to send to, which is correct
         StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT).withEmail(null).build();
         consentService.consentToResearch(study, SUBPOP_GUID, noEmail, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
         verify(sendMailService, never()).sendEmail(emailCaptor.capture());
     }
-    
+
     @Test
     public void consentToResearchWithoutStudyRecipientsDoesSend() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
         study.setConsentNotificationEmail(null);
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         assertFalse(emailCaptor.getValue().getRecipientEmails().isEmpty());
-        assertEquals(PARTICIPANT.getEmail(), emailCaptor.getValue().getRecipientEmails().iterator().next());
+        assertEquals(emailCaptor.getValue().getRecipientEmails().iterator().next(), PARTICIPANT.getEmail());
     }
-    
+
     @Test
     public void consentToResearchWithoutParticipantEmailDoesSend() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         StudyParticipant noEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT).withEmail(null).build();
-        
+
         consentService.consentToResearch(study, SUBPOP_GUID, noEmail, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
         verify(sendMailService).sendEmail(emailCaptor.capture());
-        
+
         assertFalse(emailCaptor.getValue().getRecipientEmails().isEmpty());
-        assertEquals(study.getConsentNotificationEmail(), emailCaptor.getValue().getRecipientEmails().iterator().next());
-    }    
-    
+        assertEquals(emailCaptor.getValue().getRecipientEmails().iterator().next(),
+                study.getConsentNotificationEmail());
+    }
+
     @Test
     public void consentToResearchWithPhoneOK() throws Exception {
         doReturn("asdf.pdf").when(consentService).getSignedConsentUrl();
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE,
+                SharingScope.NO_SHARING, true);
+
         verify(smsService).sendSmsMessage(eq(ID), smsProviderCaptor.capture());
-        
+
         ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
         verify(s3Helper).writeBytesToS3(eq(ConsentService.USERSIGNED_CONSENTS_BUCKET), eq("asdf.pdf"), any(),
                 metadataCaptor.capture());
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
-        
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+
         SmsMessageProvider provider = smsProviderCaptor.getValue();
-        assertEquals(PHONE_PARTICIPANT.getPhone(), provider.getPhone());
-        assertEquals(study, provider.getStudy());
-        assertEquals("Transactional", provider.getSmsType());
-        assertEquals(SHORT_URL, provider.getTokenMap().get("consentUrl"));
-        assertEquals(study.getSignedConsentSmsTemplate(), provider.getTemplate());
+        assertEquals(provider.getPhone(), PHONE_PARTICIPANT.getPhone());
+        assertEquals(provider.getStudy(), study);
+        assertEquals(provider.getSmsType(), "Transactional");
+        assertEquals(provider.getTokenMap().get("consentUrl"), SHORT_URL);
+        assertEquals(provider.getTemplate(), study.getSignedConsentSmsTemplate());
     }
 
     @Test
     public void consentToResearchWithPhoneAutoSuppressed() {
         when(subpopulation.isAutoSendConsentSuppressed()).thenReturn(true);
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE,
+                SharingScope.NO_SHARING, true);
 
         verify(smsService, never()).sendSmsMessage(any(), any());
     }
@@ -858,40 +880,44 @@ public class ConsentServiceMockTest {
     public void consentToResearchPrefersEmailToPhone() {
         StudyParticipant phoneAndEmail = new StudyParticipant.Builder().copyOf(PHONE_PARTICIPANT).withEmail(EMAIL)
                 .withEmailVerified(Boolean.TRUE).build();
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, phoneAndEmail, CONSENT_SIGNATURE, SharingScope.NO_SHARING, true);
-        
+
+        consentService.consentToResearch(study, SUBPOP_GUID, phoneAndEmail, CONSENT_SIGNATURE, SharingScope.NO_SHARING,
+                true);
+
         verify(sendMailService).sendEmail(any());
         verify(smsService, never()).sendSmsMessage(any(), any());
     }
 
     @Test
     public void consentToResearchWithPhoneSuppressedByCallFlag() {
-        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
-        
+        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE,
+                SharingScope.NO_SHARING, false);
+
         verify(smsService, never()).sendSmsMessage(any(), any());
     }
-    
+
     @Test
     public void consentToResearchAssignsDataGroupsAndSubstudies() throws Exception {
         when(subpopulation.getDataGroupsAssignedWhileConsented()).thenReturn(TestConstants.USER_DATA_GROUPS);
         when(subpopulation.getSubstudyIdsAssignedOnConsent()).thenReturn(TestConstants.USER_SUBSTUDY_IDS);
-        
+
         when(subpopService.getSubpopulation(study.getStudyIdentifier(), SUBPOP_GUID)).thenReturn(subpopulation);
         when(accountDao.getAccount(any())).thenReturn(account);
-        
-        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE, SharingScope.NO_SHARING, false);
-        
-        assertEquals(TestConstants.USER_DATA_GROUPS, account.getDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, account.getAccountSubstudies().stream()
-                .map(AccountSubstudy::getSubstudyId).collect(Collectors.toSet()));
+
+        consentService.consentToResearch(study, SUBPOP_GUID, PHONE_PARTICIPANT, CONSENT_SIGNATURE,
+                SharingScope.NO_SHARING, false);
+
+        assertEquals(account.getDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(account.getAccountSubstudies().stream().map(
+                AccountSubstudy::getSubstudyId).collect(Collectors.toSet()),
+                TestConstants.USER_SUBSTUDY_IDS);
     }
 
     @Test
     public void resendConsentAgreementWithPhoneOK() throws Exception {
         doReturn("asdf.pdf").when(consentService).getSignedConsentUrl();
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         consentService.resendConsentAgreement(study, SUBPOP_GUID, PHONE_PARTICIPANT);
 
         verify(smsService).sendSmsMessage(eq(ID), smsProviderCaptor.capture());
@@ -899,106 +925,106 @@ public class ConsentServiceMockTest {
         ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
         verify(s3Helper).writeBytesToS3(eq(ConsentService.USERSIGNED_CONSENTS_BUCKET), eq("asdf.pdf"), any(),
                 metadataCaptor.capture());
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
-        
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+
         SmsMessageProvider provider = smsProviderCaptor.getValue();
-        assertEquals(PHONE_PARTICIPANT.getPhone(), provider.getPhone());
-        assertEquals(study, provider.getStudy());
-        assertEquals("Transactional", provider.getSmsType());
-        assertEquals(SHORT_URL, provider.getTokenMap().get("consentUrl"));
-        assertEquals(study.getSignedConsentSmsTemplate(), provider.getTemplate());
+        assertEquals(provider.getPhone(), PHONE_PARTICIPANT.getPhone());
+        assertEquals(provider.getStudy(), study);
+        assertEquals(provider.getSmsType(), "Transactional");
+        assertEquals(provider.getTokenMap().get("consentUrl"), SHORT_URL);
+        assertEquals(provider.getTemplate(), study.getSignedConsentSmsTemplate());
     }
 
     @Test
     public void resendConsentAgreementWithPhonePrefersEmailToPhone() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         StudyParticipant phoneAndEmail = new StudyParticipant.Builder().copyOf(PHONE_PARTICIPANT).withEmail(EMAIL)
                 .withEmailVerified(Boolean.TRUE).build();
 
         consentService.resendConsentAgreement(study, SUBPOP_GUID, phoneAndEmail);
-        
+
         verify(sendMailService).sendEmail(any());
         verify(smsService, never()).sendSmsMessage(any(), any());
     }
-    
-    @Test(expected = BadRequestException.class)
+
+    @Test(expectedExceptions = BadRequestException.class)
     public void resendConsentAgreementNoVerifiedChannelThrows() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
-        
+
         StudyParticipant noPhoneOrEmail = new StudyParticipant.Builder().copyOf(PARTICIPANT)
                 .withPhone(TestConstants.PHONE).withEmailVerified(null).withPhoneVerified(null).build();
         consentService.resendConsentAgreement(study, SUBPOP_GUID, noPhoneOrEmail);
     }
-    
+
     @Test
     public void getSignedConsentUrl() {
         String url = consentService.getSignedConsentUrl();
         assertTrue(url.endsWith(".pdf"));
-        assertEquals(25, url.length());
+        assertEquals(url.length(), 25);
     }
 
     @Test
     public void getConsentStatuses() {
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
         account.setConsentSignatureHistory(SECOND_SUBPOP, ImmutableList.of(WITHDRAWN_CONSENT_SIGNATURE));
-        
+
         Subpopulation subpop1 = Subpopulation.create();
         subpop1.setName(SUBPOP_GUID.getGuid());
         subpop1.setGuid(SUBPOP_GUID);
         subpop1.setRequired(true);
-        
+
         Subpopulation subpop2 = Subpopulation.create();
         subpop2.setName(SECOND_SUBPOP.getGuid());
         subpop2.setGuid(SECOND_SUBPOP);
         subpop2.setRequired(true);
-        
+
         doReturn(ImmutableList.of(subpop1, subpop2)).when(subpopService).getSubpopulationsForUser(any());
-        
+
         Map<SubpopulationGuid, ConsentStatus> map = consentService.getConsentStatuses(CONTEXT, account);
 
         ConsentStatus status1 = map.get(SUBPOP_GUID);
-        assertEquals(SUBPOP_GUID.getGuid(), status1.getName());
-        assertEquals(SUBPOP_GUID.getGuid(), status1.getSubpopulationGuid());
+        assertEquals(status1.getName(), SUBPOP_GUID.getGuid());
+        assertEquals(status1.getSubpopulationGuid(), SUBPOP_GUID.getGuid());
         assertTrue(status1.isRequired());
         assertTrue(status1.isConsented());
         assertTrue(status1.getSignedMostRecentConsent());
-        assertEquals(new Long(SIGNED_ON), status1.getSignedOn());
-        
+        assertEquals(status1.getSignedOn(), new Long(SIGNED_ON));
+
         ConsentStatus status2 = map.get(SECOND_SUBPOP);
         assertNull(status2.getSignedOn());
-        assertEquals(SECOND_SUBPOP.getGuid(), status2.getName());
-        assertEquals(SECOND_SUBPOP.getGuid(), status2.getSubpopulationGuid());
+        assertEquals(status2.getName(), SECOND_SUBPOP.getGuid());
+        assertEquals(status2.getSubpopulationGuid(), SECOND_SUBPOP.getGuid());
         assertTrue(status2.isRequired());
         assertFalse(status2.isConsented());
         assertFalse(status2.getSignedMostRecentConsent());
         assertNull(status2.getSignedOn());
     }
-    
+
     private void setupWithdrawTest(boolean subpop1Required, boolean subpop2Required) {
         // two consents, withdrawing one does not turn sharing entirely off.
         account.setSharingScope(SharingScope.ALL_QUALIFIED_RESEARCHERS);
         account.setHealthCode(PARTICIPANT.getHealthCode());
-        
+
         Subpopulation subpop1 = Subpopulation.create();
         subpop1.setName(SUBPOP_GUID.getGuid());
         subpop1.setGuid(SUBPOP_GUID);
         subpop1.setRequired(subpop1Required);
-        
+
         Subpopulation subpop2 = Subpopulation.create();
         subpop2.setName(SECOND_SUBPOP.getGuid());
         subpop2.setGuid(SECOND_SUBPOP);
         subpop2.setRequired(subpop2Required);
-        
+
         doReturn(ImmutableList.of(subpop1, subpop2)).when(subpopService).getSubpopulationsForUser(any());
-        
+
         ConsentSignature secondConsentSignature = new ConsentSignature.Builder().withName("Test User")
                 .withBirthdate("1990-01-01").withSignedOn(SIGNED_ON).build();
-        
+
         account.setConsentSignatureHistory(SUBPOP_GUID, ImmutableList.of(CONSENT_SIGNATURE));
         account.setConsentSignatureHistory(SECOND_SUBPOP, ImmutableList.of(secondConsentSignature));
     }
-    
+
     private void setupWithdrawTest() {
         account.setFirstName("Allen");
         account.setLastName("Wrench");

--- a/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceAsyncHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceAsyncHandlerTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.List;
@@ -22,9 +22,9 @@ import com.amazonaws.services.simpleemail.model.SetIdentityNotificationTopicRequ
 import com.amazonaws.services.simpleemail.model.SetIdentityNotificationTopicResult;
 import com.amazonaws.services.simpleemail.model.VerifyEmailIdentityRequest;
 import com.amazonaws.services.simpleemail.model.VerifyEmailIdentityResult;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.BridgeConfig;
 
@@ -37,7 +37,7 @@ public class EmailVerificationServiceAsyncHandlerTest {
     private int numSetBounceNotificationCalls;
     private int numSetComplaintNotificationCalls;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Mock config.
         BridgeConfig mockConfig = mock(BridgeConfig.class);
@@ -139,9 +139,9 @@ public class EmailVerificationServiceAsyncHandlerTest {
                 .capture());
 
         List<VerifyEmailIdentityRequest> verifyEmailRequestList = verifyEmailRequestCaptor.getAllValues();
-        assertEquals(2, verifyEmailRequestList.size());
+        assertEquals(verifyEmailRequestList.size(), 2);
         for (VerifyEmailIdentityRequest oneVerifyEmailRequest : verifyEmailRequestList) {
-            assertEquals(EMAIL_ADDRESS, oneVerifyEmailRequest.getEmailAddress());
+            assertEquals(oneVerifyEmailRequest.getEmailAddress(), EMAIL_ADDRESS);
         }
 
         // Verify get notifications calls.
@@ -152,11 +152,11 @@ public class EmailVerificationServiceAsyncHandlerTest {
 
         List<GetIdentityNotificationAttributesRequest> getNotificationRequestList = getNotificationRequestCaptor
                 .getAllValues();
-        assertEquals(2, getNotificationRequestList.size());
+        assertEquals(getNotificationRequestList.size(), 2);
         for (GetIdentityNotificationAttributesRequest oneGetNotificationRequest : getNotificationRequestList) {
             List<String> identityList = oneGetNotificationRequest.getIdentities();
-            assertEquals(1, identityList.size());
-            assertEquals(EMAIL_ADDRESS, identityList.get(0));
+            assertEquals(identityList.size(), 1);
+            assertEquals(identityList.get(0), EMAIL_ADDRESS);
         }
     }
 
@@ -167,19 +167,19 @@ public class EmailVerificationServiceAsyncHandlerTest {
                 SetIdentityNotificationTopicRequest.class);
         verify(mockSesClient, times(4)).setIdentityNotificationTopic(requestCaptor.capture());
         List<SetIdentityNotificationTopicRequest> requestList = requestCaptor.getAllValues();
-        assertEquals(4, requestList.size());
+        assertEquals(requestList.size(), 4);
 
         // Verify common args in all calls.
         for (SetIdentityNotificationTopicRequest oneRequest : requestList) {
-            assertEquals(EMAIL_ADDRESS, oneRequest.getIdentity());
-            assertEquals(DUMMY_NOTIFICATION_ARN, oneRequest.getSnsTopic());
+            assertEquals(oneRequest.getIdentity(), EMAIL_ADDRESS);
+            assertEquals(oneRequest.getSnsTopic(), DUMMY_NOTIFICATION_ARN);
         }
 
         // Verify notification types.
-        assertEquals("Bounce", requestList.get(0).getNotificationType());
-        assertEquals("Bounce", requestList.get(1).getNotificationType());
-        assertEquals("Complaint", requestList.get(2).getNotificationType());
-        assertEquals("Complaint", requestList.get(3).getNotificationType());
+        assertEquals(requestList.get(0).getNotificationType(), "Bounce");
+        assertEquals(requestList.get(1).getNotificationType(), "Bounce");
+        assertEquals(requestList.get(2).getNotificationType(), "Complaint");
+        assertEquals(requestList.get(3).getNotificationType(), "Complaint");
     }
 
     private static AmazonServiceException makeAwsInternalError() {

--- a/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceCallWrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceCallWrapperTest.java
@@ -1,18 +1,19 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.util.concurrent.Callable;
 
 import com.amazonaws.AmazonServiceException;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 
@@ -24,7 +25,7 @@ public class EmailVerificationServiceCallWrapperTest {
     private Callable<String> mockCallable;
     private EmailVerificationService.AsyncSnsTopicHandler asyncHandler;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Set up service. For testing purposes, set to 2 tries and a large rate limit.
         EmailVerificationService service = new EmailVerificationService();
@@ -42,7 +43,7 @@ public class EmailVerificationServiceCallWrapperTest {
     public void immediateSuccess() throws Exception {
         when(mockCallable.call()).thenReturn(HELLO_WORLD);
         String result = asyncHandler.callWrapper(mockCallable);
-        assertEquals(HELLO_WORLD, result);
+        assertEquals(result, HELLO_WORLD);
         verify(mockCallable, times(1)).call();
     }
 
@@ -59,7 +60,7 @@ public class EmailVerificationServiceCallWrapperTest {
             fail("expected exception");
         } catch (BridgeServiceException thrownEx) {
             // Make sure the second error is the one that is propagated.
-            assertSame(ex2, thrownEx.getCause());
+            assertSame(thrownEx.getCause(), ex2);
         }
 
         // We call the callable twice.
@@ -79,7 +80,7 @@ public class EmailVerificationServiceCallWrapperTest {
             fail("expected exception");
         } catch (BridgeServiceException thrownEx) {
             // Make sure the second error is the one that is propagated.
-            assertSame(ex2, thrownEx.getCause());
+            assertSame(thrownEx.getCause(), ex2);
         }
 
         // We call the callable twice.
@@ -98,7 +99,7 @@ public class EmailVerificationServiceCallWrapperTest {
             fail("expected exception");
         } catch (BridgeServiceException thrownEx) {
             // Only 1 error thrown.
-            assertSame(awsEx, thrownEx.getCause());
+            assertSame(thrownEx.getCause(), awsEx);
         }
 
         // We call the callable once.
@@ -117,7 +118,7 @@ public class EmailVerificationServiceCallWrapperTest {
             fail("expected exception");
         } catch (BridgeServiceException thrownEx) {
             // Only 1 error thrown.
-            assertSame(otherEx, thrownEx.getCause());
+            assertSame(thrownEx.getCause(), otherEx);
         }
 
         // We call the callable once.

--- a/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationServiceTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -10,17 +7,19 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.CacheKey;
@@ -31,7 +30,6 @@ import com.amazonaws.services.simpleemail.model.GetIdentityVerificationAttribute
 import com.amazonaws.services.simpleemail.model.IdentityVerificationAttributes;
 import com.google.common.collect.Maps;
 
-@RunWith(MockitoJUnitRunner.class)
 public class EmailVerificationServiceTest {
 
     private static final String EMAIL_ADDRESS = "foo@foo.com";
@@ -53,8 +51,9 @@ public class EmailVerificationServiceTest {
     
     private ArgumentCaptor<GetIdentityVerificationAttributesRequest> getCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         service.setAmazonSimpleEmailServiceClient(sesClient);
         service.setAsyncExecutorService(asyncExecutorService);
         service.setCacheProvider(cacheProvider);
@@ -76,10 +75,10 @@ public class EmailVerificationServiceTest {
 
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
 
-        assertEquals(EmailVerificationStatus.VERIFIED, status);
+        assertEquals(status, EmailVerificationStatus.VERIFIED);
         verify(asyncExecutorService, never()).execute(any());
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
-        assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+        assertEquals(getCaptor.getValue().getIdentities().get(0), EMAIL_ADDRESS);
 
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
@@ -90,10 +89,10 @@ public class EmailVerificationServiceTest {
 
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
 
-        assertEquals(EmailVerificationStatus.PENDING, status);
+        assertEquals(status, EmailVerificationStatus.PENDING);
         verifyAsyncHandler();
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
-        assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+        assertEquals(getCaptor.getValue().getIdentities().get(0), EMAIL_ADDRESS);
 
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
@@ -104,10 +103,10 @@ public class EmailVerificationServiceTest {
 
         EmailVerificationStatus status = service.verifyEmailAddress(EMAIL_ADDRESS);
 
-        assertEquals(EmailVerificationStatus.PENDING, status);
+        assertEquals(status, EmailVerificationStatus.PENDING);
         verifyAsyncHandler();
         verify(sesClient).getIdentityVerificationAttributes(getCaptor.capture());
-        assertEquals(EMAIL_ADDRESS, getCaptor.getValue().getIdentities().get(0));
+        assertEquals(getCaptor.getValue().getIdentities().get(0), EMAIL_ADDRESS);
         
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("PENDING"), anyInt());
     }
@@ -119,7 +118,7 @@ public class EmailVerificationServiceTest {
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
 
         verify(sesClient).getIdentityVerificationAttributes(any());
-        assertEquals(EmailVerificationStatus.VERIFIED, status);
+        assertEquals(status, EmailVerificationStatus.VERIFIED);
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("VERIFIED"), anyInt());
     }
     
@@ -133,7 +132,7 @@ public class EmailVerificationServiceTest {
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
 
         verify(sesClient).getIdentityVerificationAttributes(any());
-        assertEquals(EmailVerificationStatus.UNVERIFIED, status);
+        assertEquals(status, EmailVerificationStatus.UNVERIFIED);
         
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
@@ -151,7 +150,7 @@ public class EmailVerificationServiceTest {
         EmailVerificationStatus status = service.getEmailStatus(EMAIL_ADDRESS);
 
         verify(sesClient).getIdentityVerificationAttributes(any());
-        assertEquals(EmailVerificationStatus.UNVERIFIED, status);
+        assertEquals(status, EmailVerificationStatus.UNVERIFIED);
         
         verify(cacheProvider).setObject(eq(EMAIL_ADDRESS_KEY), eq("UNVERIFIED"), anyInt());        
     }
@@ -205,6 +204,6 @@ public class EmailVerificationServiceTest {
         ArgumentCaptor<EmailVerificationService.AsyncSnsTopicHandler> handlerCaptor = ArgumentCaptor.forClass(
                 EmailVerificationService.AsyncSnsTopicHandler.class);
         verify(asyncExecutorService).execute(handlerCaptor.capture());
-        assertEquals(EMAIL_ADDRESS, handlerCaptor.getValue().getEmailAddress());
+        assertEquals(handlerCaptor.getValue().getEmailAddress(), EMAIL_ADDRESS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationStatusTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EmailVerificationStatusTest.java
@@ -3,21 +3,21 @@ package org.sagebionetworks.bridge.services;
 import static org.sagebionetworks.bridge.services.EmailVerificationStatus.PENDING;
 import static org.sagebionetworks.bridge.services.EmailVerificationStatus.UNVERIFIED;
 import static org.sagebionetworks.bridge.services.EmailVerificationStatus.VERIFIED;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class EmailVerificationStatusTest {
 
     @Test
     public void testStringsConvertToTypes() {
-        assertEquals(PENDING, EmailVerificationStatus.fromSesVerificationStatus("Pending"));
-        assertEquals(VERIFIED, EmailVerificationStatus.fromSesVerificationStatus("Success"));
-        assertEquals(UNVERIFIED, EmailVerificationStatus.fromSesVerificationStatus("Anything Else"));
-        assertEquals(PENDING, EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.PENDING.name()));
-        assertEquals(VERIFIED, EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.VERIFIED.name()));
-        assertEquals(UNVERIFIED, EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.UNVERIFIED.name()));
-        assertEquals(UNVERIFIED, EmailVerificationStatus.fromSesVerificationStatus(null));
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus("Pending"), PENDING);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus("Success"), VERIFIED);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus("Anything Else"), UNVERIFIED);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.PENDING.name()), PENDING);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.VERIFIED.name()), VERIFIED);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus(EmailVerificationStatus.UNVERIFIED.name()), UNVERIFIED);
+        assertEquals(EmailVerificationStatus.fromSesVerificationStatus(null), UNVERIFIED);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ExportViaSqsServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ExportViaSqsServiceTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.SendMessageResult;
@@ -12,10 +12,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -28,12 +28,12 @@ public class ExportViaSqsServiceTest {
     private static final String SQS_MESSAGE_ID = "dummy-message-id";
     private static final String SQS_URL = "dummy-sqs-url";
 
-    @Before
+    @BeforeMethod
     public void mockNow() {
         DateTimeUtils.setCurrentMillisFixed(MOCK_NOW);
     }
 
-    @After
+    @AfterMethod
     public void cleanup() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -60,15 +60,15 @@ public class ExportViaSqsServiceTest {
 
         String sqsMessageText = sqsMessageCaptor.getValue();
         JsonNode sqsMessageNode = JSON_OBJECT_MAPPER.readTree(sqsMessageText);
-        assertEquals(4, sqsMessageNode.size());
-        assertEquals(EXPECTED_END_DATE_TIME_STRING, sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_END_DATE_TIME)
-                .textValue());
-        assertEquals("On-Demand Export studyId=" + TestConstants.TEST_STUDY_IDENTIFIER + " endDateTime=" +
-                EXPECTED_END_DATE_TIME_STRING, sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_TAG).textValue());
+        assertEquals(sqsMessageNode.size(), 4);
+        assertEquals(sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_END_DATE_TIME).textValue(),
+                EXPECTED_END_DATE_TIME_STRING);
+        assertEquals(sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_TAG).textValue(), "On-Demand Export studyId="
+                + TestConstants.TEST_STUDY_IDENTIFIER + " endDateTime=" + EXPECTED_END_DATE_TIME_STRING);
         assertTrue(sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_USE_LAST_EXPORT_TIME).booleanValue());
 
         JsonNode studyWhitelistNode = sqsMessageNode.get(ExportViaSqsService.REQUEST_KEY_STUDY_WHITELIST);
-        assertEquals(1, studyWhitelistNode.size());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, studyWhitelistNode.get(0).textValue());
+        assertEquals(studyWhitelistNode.size(), 1);
+        assertEquals(studyWhitelistNode.get(0).textValue(), TestConstants.TEST_STUDY_IDENTIFIER);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -1,21 +1,20 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -34,7 +33,6 @@ import org.sagebionetworks.bridge.models.substudies.Substudy;
 
 import com.google.common.collect.ImmutableSet;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ExternalIdServiceTest {
 
     private static final String ID = "AAA";
@@ -53,8 +51,10 @@ public class ExternalIdServiceTest {
     
     private ExternalIdService externalIdService;
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerStudyId(TestConstants.TEST_STUDY).build());
         study = Study.create();
@@ -66,7 +66,7 @@ public class ExternalIdServiceTest {
         externalIdService.setSubstudyService(substudyService);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(null);
     }
@@ -76,7 +76,7 @@ public class ExternalIdServiceTest {
         when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, ID)).thenReturn(Optional.of(extId));
         
         Optional<ExternalIdentifier> retrieved = externalIdService.getExternalId(TestConstants.TEST_STUDY, ID);
-        assertEquals(extId, retrieved.get());
+        assertEquals(retrieved.get(), extId);
     }
     
     @Test
@@ -102,12 +102,12 @@ public class ExternalIdServiceTest {
                 null, null);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getExternalIdsUnderMinPageSizeThrows() {
         externalIdService.getExternalIds(null, 0, null, null);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getExternalIdsOverMaxPageSizeThrows() {
         externalIdService.getExternalIds(null, 10000, null, null);
     }
@@ -155,7 +155,7 @@ public class ExternalIdServiceTest {
         verify(externalIdDao).createExternalId(extId);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createExternalIdDoesNotSetSubstudyIdAmbiguous() {
         extId.setSubstudyId(null); // not set by caller
         
@@ -166,12 +166,12 @@ public class ExternalIdServiceTest {
         externalIdService.createExternalId(extId, false);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createExternalIdValidates() {
         externalIdService.createExternalId(ExternalIdentifier.create(new StudyIdentifierImpl("nonsense"), "nonsense"), false);
     }
     
-    @Test(expected = EntityAlreadyExistsException.class)
+    @Test(expectedExceptions = EntityAlreadyExistsException.class)
     public void createExternalIdAlreadyExistsThrows() {
         when(substudyService.getSubstudy(TestConstants.TEST_STUDY, SUBSTUDY_ID, false))
             .thenReturn(Substudy.create());
@@ -190,21 +190,21 @@ public class ExternalIdServiceTest {
         verify(externalIdDao).deleteExternalId(extId);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteExternalIdPermanentlyThrowsIfValidationEnabled() {
         study.setExternalIdValidationEnabled(true);
         
         externalIdService.deleteExternalIdPermanently(study, extId);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteExternalIdPermanentlyMissingThrows() {
         when(externalIdDao.getExternalId(TestConstants.TEST_STUDY, extId.getIdentifier())).thenReturn(Optional.empty());
         
         externalIdService.deleteExternalIdPermanently(study, extId);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteExternalIdPermanentlyOutsideSubstudiesThrows() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerStudyId(TestConstants.TEST_STUDY)

--- a/src/test/java/org/sagebionetworks/bridge/services/FPHSServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/FPHSServiceTest.java
@@ -1,23 +1,23 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.FPHSExternalIdentifierDao;
@@ -31,7 +31,6 @@ import org.sagebionetworks.bridge.models.accounts.FPHSExternalIdentifier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FPHSServiceTest {
 
     private FPHSService service;
@@ -44,15 +43,16 @@ public class FPHSServiceTest {
     
     private ExternalIdentifier externalId;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         externalId = ExternalIdentifier.create(TEST_STUDY, "gar");
         service = new FPHSService();
         service.setFPHSExternalIdentifierDao(mockDao);
         service.setAccountDao(mockAccountDao);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateIdThrowsException() throws Exception {
         service.verifyExternalIdentifier(ExternalIdentifier.create(TEST_STUDY, ""));
     }
@@ -63,14 +63,14 @@ public class FPHSServiceTest {
         verify(mockDao).verifyExternalId(externalId);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void verifyExternalIdentifierFailsOnNotFound() throws Exception {
         doThrow(new EntityNotFoundException(ExternalIdentifier.class)).when(mockDao).verifyExternalId(externalId);
         
         service.verifyExternalIdentifier(externalId);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void registerIdThrowsException() throws Exception {
         service.registerExternalIdentifier(TEST_STUDY, "BBB", ExternalIdentifier.create(TEST_STUDY, null));
     }
@@ -84,7 +84,7 @@ public class FPHSServiceTest {
         service.registerExternalIdentifier(TEST_STUDY, "BBB", externalId);
         verify(mockDao).registerExternalId(externalId);
         verify(mockAccount).setExternalId(externalId.getIdentifier());
-        assertEquals(Sets.newHashSet("football_player"), dataGroups);
+        assertEquals(dataGroups, Sets.newHashSet("football_player"));
     }
     
     @Test
@@ -123,7 +123,7 @@ public class FPHSServiceTest {
         
         List<FPHSExternalIdentifier> identifiers = service.getExternalIdentifiers();
         
-        assertEquals(externalIds, identifiers);
+        assertEquals(identifiers, externalIds);
         verify(mockDao).getExternalIds();
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/HealthDataServiceTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.HealthDataDao;
@@ -41,12 +41,12 @@ public class HealthDataServiceTest {
     private static final String TEST_UPLOAD_DATE_STR = "2017-08-11";
     private static final LocalDate TEST_UPLOAD_DATE = LocalDate.parse(TEST_UPLOAD_DATE_STR);
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createOrUpdateRecordNullRecord() {
         new HealthDataService().createOrUpdateRecord(null);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createOrUpdateRecordInvalidRecord() {
         new HealthDataService().createOrUpdateRecord(HealthDataRecord.create());
     }
@@ -63,15 +63,15 @@ public class HealthDataServiceTest {
 
         // execute and validate
         String retVal = svc.createOrUpdateRecord(record);
-        assertEquals(TEST_RECORD_ID, retVal);
+        assertEquals(retVal, TEST_RECORD_ID);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteRecordsForHealthCodeNullHealthCode() {
         new HealthDataService().deleteRecordsForHealthCode(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteRecordsForHealthCodeEmptyHealthCode() {
         new HealthDataService().deleteRecordsForHealthCode("");
     }
@@ -86,25 +86,25 @@ public class HealthDataServiceTest {
 
         // execute and verify
         int numDeleted = svc.deleteRecordsForHealthCode(TEST_HEALTH_CODE);
-        assertEquals(37, numDeleted);
+        assertEquals(numDeleted, 37);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsForUploadDateNullUploadDate() {
         new HealthDataService().getRecordsForUploadDate(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsForUploadDateEmptyUploadDate() {
         new HealthDataService().getRecordsForUploadDate("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsForUploadDateMalformedUploadDate() {
         new HealthDataService().getRecordsForUploadDate("This is not a calendar date.");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsForUploadDateInvalidUploadDate() {
         new HealthDataService().getRecordsForUploadDate("2014-02-31");
     }
@@ -133,20 +133,20 @@ public class HealthDataServiceTest {
 
         // execute and validate
         List<HealthDataRecord> recordList = svc.getRecordsForUploadDate(TEST_UPLOAD_DATE_STR);
-        assertEquals(3, recordList.size());
-        assertEquals("foo healthcode", recordList.get(0).getHealthCode());
-        assertEquals("bar healthcode", recordList.get(1).getHealthCode());
-        assertEquals("baz healthcode", recordList.get(2).getHealthCode());
+        assertEquals(recordList.size(), 3);
+        assertEquals(recordList.get(0).getHealthCode(), "foo healthcode");
+        assertEquals(recordList.get(1).getHealthCode(), "bar healthcode");
+        assertEquals(recordList.get(2).getHealthCode(), "baz healthcode");
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateRecordsWithExporterStatusNullRecordIds() {
         RecordExportStatusRequest request = new RecordExportStatusRequest();
         request.setSynapseExporterStatus(HealthDataRecord.ExporterStatus.SUCCEEDED);
         new HealthDataService().updateRecordsWithExporterStatus(request);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateRecordsWithExporterStatusEmptyRecordIds() {
         RecordExportStatusRequest request = new RecordExportStatusRequest();
         request.setRecordIds(ImmutableList.of());
@@ -154,14 +154,14 @@ public class HealthDataServiceTest {
         new HealthDataService().updateRecordsWithExporterStatus(request);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateRecordsWithExporterStatusNullStatus() {
         RecordExportStatusRequest request = new RecordExportStatusRequest();
         request.setRecordIds(ImmutableList.of(TEST_RECORD_ID));
         new HealthDataService().updateRecordsWithExporterStatus(request);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateRecordsWithExporterStatusExceedRecordIdListLimit() {
         RecordExportStatusRequest request = new RecordExportStatusRequest();
         List<String> recordIds = new ArrayList<>();
@@ -193,7 +193,7 @@ public class HealthDataServiceTest {
 
         // execute and validate
         String retVal = svc.createOrUpdateRecord(record);
-        assertEquals(TEST_RECORD_ID, retVal);
+        assertEquals(retVal, TEST_RECORD_ID);
 
         // then create a mock json request
         RecordExportStatusRequest recordExportStatusRequest = createMockRecordExportStatusRequest();
@@ -205,11 +205,11 @@ public class HealthDataServiceTest {
         verify(mockDao).getRecordById(TEST_RECORD_ID);
         HealthDataRecord recordAfter = svc.getRecordById(TEST_RECORD_ID);
         assertNotNull(recordAfter.getSynapseExporterStatus());
-        assertEquals(HealthDataRecord.ExporterStatus.SUCCEEDED, recordAfter.getSynapseExporterStatus());
+        assertEquals(recordAfter.getSynapseExporterStatus(), HealthDataRecord.ExporterStatus.SUCCEEDED);
         verify(mockDao).getRecordById(TEST_RECORD_ID_2);
         HealthDataRecord record2After = svc.getRecordById(TEST_RECORD_ID_2);
         assertNotNull(record2After.getSynapseExporterStatus());
-        assertEquals(HealthDataRecord.ExporterStatus.SUCCEEDED, record2After.getSynapseExporterStatus());
+        assertEquals(record2After.getSynapseExporterStatus(), HealthDataRecord.ExporterStatus.SUCCEEDED);
 
     }
 
@@ -221,43 +221,43 @@ public class HealthDataServiceTest {
         return request;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void getRecordsByHealthCodeCreatedOn_NullHealthCode() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn(null, TEST_CREATED_ON_DATE_TIME,
                 TEST_CREATED_ON_END_DATE_TIME);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void getRecordsByHealthCodeCreatedOn_EmptyHealthCode() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn("", TEST_CREATED_ON_DATE_TIME,
                 TEST_CREATED_ON_END_DATE_TIME);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void getRecordsByHealthCodeCreatedOn_BlankHealthCode() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn("   ", TEST_CREATED_ON_DATE_TIME,
                 TEST_CREATED_ON_END_DATE_TIME);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthCodeCreatedOn_NullCreatedOnStart() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, null,
                 TEST_CREATED_ON_END_DATE_TIME);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthCodeCreatedOn_NullCreatedOnEnd() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, TEST_CREATED_ON_DATE_TIME,
                 null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthCodeCreatedOn_StartOnAfterEndOn() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, TEST_CREATED_ON_END_DATE_TIME,
                 TEST_CREATED_ON_DATE_TIME);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthCodeCreatedOn_DateRangeTooLarge() {
         new HealthDataService().getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE, TEST_CREATED_ON_DATE_TIME,
                 TEST_CREATED_ON_DATE_TIME.plusDays(16));
@@ -277,7 +277,7 @@ public class HealthDataServiceTest {
         // Execute and verify.
         List<HealthDataRecord> retList = svc.getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE,
                 TEST_CREATED_ON_DATE_TIME, TEST_CREATED_ON_END_DATE_TIME);
-        assertEquals(mockResult, retList);
+        assertEquals(retList, mockResult);
     }
 
     @Test
@@ -294,25 +294,25 @@ public class HealthDataServiceTest {
         // Execute and verify.
         List<HealthDataRecord> retList = svc.getRecordsByHealthCodeCreatedOn(TEST_HEALTH_CODE,
                 TEST_CREATED_ON_DATE_TIME, TEST_CREATED_ON_DATE_TIME);
-        assertEquals(mockResult, retList);
+        assertEquals(retList, mockResult);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByEmptyHealthcodeCreatedOnSchemaId() {
         new HealthDataService().getRecordsByHealthcodeCreatedOnSchemaId("", TEST_CREATED_ON, TEST_SCHEMA_ID);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByNullHealthcodeCreatedOnSchemaId() {
         new HealthDataService().getRecordsByHealthcodeCreatedOnSchemaId(null, TEST_CREATED_ON, TEST_SCHEMA_ID);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthcodeCreatedOnEmptySchemaId() {
         new HealthDataService().getRecordsByHealthcodeCreatedOnSchemaId(TEST_HEALTH_CODE, TEST_CREATED_ON, "");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getRecordsByHealthcodeCreatedOnNullSchemaId() {
         new HealthDataService().getRecordsByHealthcodeCreatedOnSchemaId(TEST_HEALTH_CODE, TEST_CREATED_ON, null);
     }
@@ -340,8 +340,8 @@ public class HealthDataServiceTest {
         // execute and verify
         List<HealthDataRecord> retList = svc.getRecordsByHealthcodeCreatedOnSchemaId(TEST_HEALTH_CODE, TEST_CREATED_ON,
                 TEST_SCHEMA_ID);
-        assertEquals(1, retList.size());
-        assertSame(record, retList.get(0));
+        assertEquals(retList.size(), 1);
+        assertSame(retList.get(0), record);
     }
 
     private static HealthDataRecord makeValidRecord() {

--- a/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
@@ -10,18 +8,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.util.Map;
 
 import javax.mail.internet.MimeBodyPart;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -51,7 +51,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-@RunWith(MockitoJUnitRunner.class)
 public class IntentServiceTest {
 
     private static final long TIMESTAMP = 1000L; 
@@ -97,8 +96,10 @@ public class IntentServiceTest {
     @Captor
     ArgumentCaptor<MimeTypeEmailProvider> mimeTypeEmailProviderCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service = new IntentService();
         service.setSmsService(mockSmsService);
         service.setSendMailService(mockSendMailService);
@@ -128,18 +129,18 @@ public class IntentServiceTest {
         service.submitIntentToParticipate(intent);
         
         verify(mockSubpopService).getSubpopulation(eq(mockStudy), subpopGuidCaptor.capture());
-        assertEquals(intent.getSubpopGuid(), subpopGuidCaptor.getValue().getGuid());
+        assertEquals(subpopGuidCaptor.getValue().getGuid(), intent.getSubpopGuid());
         
         verify(mockCacheProvider).setObject(keyCaptor.capture(), eq(intent), eq(4 * 60 * 60));
-        assertEquals(cacheKey, keyCaptor.getValue());
+        assertEquals(keyCaptor.getValue(), cacheKey);
 
         verify(mockSmsService).sendSmsMessage(isNull(), smsMessageProviderCaptor.capture());
 
         SmsMessageProvider provider = smsMessageProviderCaptor.getValue();
-        assertEquals(mockStudy, provider.getStudy());
-        assertEquals(intent.getPhone(), provider.getPhone());
-        assertEquals("this-is-a-link", provider.getSmsRequest().getMessage());
-        assertEquals("Transactional", provider.getSmsType());
+        assertEquals(provider.getStudy(), mockStudy);
+        assertEquals(provider.getPhone(), intent.getPhone());
+        assertEquals(provider.getSmsRequest().getMessage(), "this-is-a-link");
+        assertEquals(provider.getSmsType(), "Transactional");
     }
     
     // In this case when there isn't an install link for the OS or that is marked
@@ -162,18 +163,18 @@ public class IntentServiceTest {
         service.submitIntentToParticipate(intent);
         
         verify(mockSubpopService).getSubpopulation(eq(mockStudy), subpopGuidCaptor.capture());
-        assertEquals(intent.getSubpopGuid(), subpopGuidCaptor.getValue().getGuid());
+        assertEquals(subpopGuidCaptor.getValue().getGuid(), intent.getSubpopGuid());
         
         verify(mockCacheProvider).setObject(keyCaptor.capture(), eq(intent), eq(4 * 60 * 60));
-        assertEquals(cacheKey, keyCaptor.getValue());
+        assertEquals(keyCaptor.getValue(), cacheKey);
 
         verify(mockSmsService).sendSmsMessage(isNull(), smsMessageProviderCaptor.capture());
 
         SmsMessageProvider provider = smsMessageProviderCaptor.getValue();
-        assertEquals(mockStudy, provider.getStudy());
-        assertEquals(intent.getPhone(), provider.getPhone());
-        assertEquals("this-is-a-link", provider.getSmsRequest().getMessage());
-        assertEquals("Transactional", provider.getSmsType());        
+        assertEquals(provider.getStudy(), mockStudy);
+        assertEquals(provider.getPhone(), intent.getPhone());
+        assertEquals(provider.getSmsRequest().getMessage(), "this-is-a-link");
+        assertEquals(provider.getSmsType(), "Transactional");        
     }
     
     @Test
@@ -196,29 +197,29 @@ public class IntentServiceTest {
         service.submitIntentToParticipate(intent);
         
         verify(mockSubpopService).getSubpopulation(eq(mockStudy), subpopGuidCaptor.capture());
-        assertEquals(intent.getSubpopGuid(), subpopGuidCaptor.getValue().getGuid());
+        assertEquals(subpopGuidCaptor.getValue().getGuid(), intent.getSubpopGuid());
         
         verify(mockCacheProvider).setObject(keyCaptor.capture(), eq(intent), eq(4 * 60 * 60));
-        assertEquals(cacheKey, keyCaptor.getValue());
+        assertEquals(keyCaptor.getValue(), cacheKey);
 
         verify(mockSendMailService).sendEmail(mimeTypeEmailProviderCaptor.capture());
 
         BasicEmailProvider provider = (BasicEmailProvider)mimeTypeEmailProviderCaptor.getValue();
-        assertEquals(mockStudy, provider.getStudy());
-        assertEquals("email@email.com", Iterables.getFirst(provider.getRecipientEmails(), null));
-        assertEquals(EmailType.APP_INSTALL, provider.getType());
+        assertEquals(provider.getStudy(), mockStudy);
+        assertEquals(Iterables.getFirst(provider.getRecipientEmails(), null), "email@email.com");
+        assertEquals(provider.getType(), EmailType.APP_INSTALL);
         
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals("\"null\" <null>", email.getSenderAddress());
-        assertEquals("subject", email.getSubject());
+        assertEquals(email.getSenderAddress(), "\"null\" <null>");
+        assertEquals(email.getSubject(), "subject");
         MimeBodyPart body = email.getMessageParts().get(0);
-        assertEquals("body this-is-a-link", body.getContent());
-        assertEquals("email@email.com", email.getRecipientAddresses().get(0));
-        assertEquals(1, email.getRecipientAddresses().size());
-        assertEquals(EmailType.APP_INSTALL, email.getType());
+        assertEquals(body.getContent(), "body this-is-a-link");
+        assertEquals(email.getRecipientAddresses().get(0), "email@email.com");
+        assertEquals(email.getRecipientAddresses().size(), 1);
+        assertEquals(email.getType(), EmailType.APP_INSTALL);
     }    
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void submitIntentToParticipateInvalid() {
         IntentToParticipate intent = TestUtils.getIntentToParticipate(TIMESTAMP).build();
         IntentToParticipate invalid = new IntentToParticipate.Builder().copyOf(intent).withPhone(null).build();
@@ -244,7 +245,7 @@ public class IntentServiceTest {
         service.submitIntentToParticipate(intent);
         
         verify(mockSubpopService).getSubpopulation(eq(mockStudy), subpopGuidCaptor.capture());
-        assertEquals(intent.getSubpopGuid(), subpopGuidCaptor.getValue().getGuid());
+        assertEquals(subpopGuidCaptor.getValue().getGuid(), intent.getSubpopGuid());
 
         // These are not called.
         verify(mockCacheProvider, never()).setObject(cacheKey, intent, (4 * 60 * 60));
@@ -450,11 +451,11 @@ public class IntentServiceTest {
         service.submitIntentToParticipate(intent);
         
         verify(mockSubpopService).getSubpopulation(eq(mockStudy), subpopGuidCaptor.capture());
-        assertEquals(intent.getSubpopGuid(), subpopGuidCaptor.getValue().getGuid());
+        assertEquals(subpopGuidCaptor.getValue().getGuid(), intent.getSubpopGuid());
         
         // We do store the intent
         verify(mockCacheProvider).setObject(keyCaptor.capture(), eq(intent), eq(4 * 60 * 60));
-        assertEquals(cacheKey, keyCaptor.getValue());
+        assertEquals(keyCaptor.getValue(), cacheKey);
 
         // But we don't send a message because installLinks map is empty
         verify(mockSmsService, never()).sendSmsMessage(any(), any());
@@ -466,11 +467,11 @@ public class IntentServiceTest {
         installLinks.put("iPhone OS", "iphone-os-link");
         
         // Lacking android or universal, find the only link that's there.
-        assertEquals("iphone-os-link", service.getInstallLink("Android", installLinks));
+        assertEquals(service.getInstallLink("Android", installLinks), "iphone-os-link");
         
         installLinks.put("Universal", "universal-link");
-        assertEquals("iphone-os-link", service.getInstallLink("iPhone OS", installLinks));
-        assertEquals("universal-link", service.getInstallLink("Android", installLinks));
+        assertEquals(service.getInstallLink("iPhone OS", installLinks), "iphone-os-link");
+        assertEquals(service.getInstallLink("Android", installLinks), "universal-link");
         
         Map<String,String> emptyInstallLinks = Maps.newHashMap();
         assertNull(service.getInstallLink("iPhone OS", emptyInstallLinks));

--- a/src/test/java/org/sagebionetworks/bridge/services/NotificationTopicServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/NotificationTopicServiceTest.java
@@ -6,10 +6,10 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationTopic;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -19,13 +19,12 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.NotificationRegistrationDao;
@@ -48,7 +47,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-@RunWith(MockitoJUnitRunner.class)
 public class NotificationTopicServiceTest {
     private static final String CRITERIA_GROUP_1 = "criteria-group-1";
     private static final String CRITERIA_GROUP_2 = "criteria-group-2";
@@ -144,8 +142,10 @@ public class NotificationTopicServiceTest {
 
     private NotificationTopicService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service = new NotificationTopicService();
         service.setNotificationTopicDao(mockTopicDao);
         service.setSnsClient(mockSnsClient);
@@ -159,7 +159,7 @@ public class NotificationTopicServiceTest {
         doReturn(list).when(mockTopicDao).listTopics(TEST_STUDY, true);
         
         List<NotificationTopic> results = service.listTopics(TEST_STUDY, true);
-        assertEquals(2, results.size());
+        assertEquals(results.size(), 2);
         
         verify(mockTopicDao).listTopics(TEST_STUDY, true);
     }
@@ -170,7 +170,7 @@ public class NotificationTopicServiceTest {
         doReturn(topic).when(mockTopicDao).getTopic(TEST_STUDY, topic.getGuid());
         
         NotificationTopic result = service.getTopic(TEST_STUDY, topic.getGuid());
-        assertEquals(topic, result);
+        assertEquals(result, topic);
         
         verify(mockTopicDao).getTopic(TEST_STUDY, topic.getGuid());
     }
@@ -181,7 +181,7 @@ public class NotificationTopicServiceTest {
         doReturn(topic).when(mockTopicDao).createTopic(topic);
         
         NotificationTopic result = service.createTopic(topic);
-        assertEquals(topic, result);
+        assertEquals(result, topic);
         
         verify(mockTopicDao).createTopic(topic);
     }
@@ -204,7 +204,7 @@ public class NotificationTopicServiceTest {
         doReturn(topic).when(mockTopicDao).updateTopic(topic);
         
         NotificationTopic result = service.updateTopic(topic);
-        assertEquals(topic, result);
+        assertEquals(result, topic);
         
         verify(mockTopicDao).updateTopic(topic);
     }
@@ -253,9 +253,9 @@ public class NotificationTopicServiceTest {
         
         verify(mockSnsClient).publish(publishRequestCaptor.capture());
         PublishRequest request = publishRequestCaptor.getValue();
-        assertEquals("a subject", request.getSubject());
-        assertEquals("a message", request.getMessage());
-        assertEquals("topicARN", request.getTopicArn());
+        assertEquals(request.getSubject(), "a subject");
+        assertEquals(request.getMessage(), "a message");
+        assertEquals(request.getTopicArn(), "topicARN");
     }
     
     private NotificationTopic createTopic(String guid) {
@@ -440,22 +440,22 @@ public class NotificationTopicServiceTest {
         // Execute. We want to subscribe to 1 and 3.
         List<SubscriptionStatus> statusList = service.subscribe(TEST_STUDY, HEALTH_CODE, PUSH_REGISTRATION.getGuid(),
                 ImmutableSet.of(MANUAL_TOPIC_1.getGuid(), MANUAL_TOPIC_3.getGuid()));
-        assertEquals(4, statusList.size());
+        assertEquals(statusList.size(), 4);
 
-        assertEquals(MANUAL_TOPIC_1.getGuid(), statusList.get(0).getTopicGuid());
-        assertEquals(MANUAL_TOPIC_1.getName(), statusList.get(0).getTopicName());
+        assertEquals(statusList.get(0).getTopicGuid(), MANUAL_TOPIC_1.getGuid());
+        assertEquals(statusList.get(0).getTopicName(), MANUAL_TOPIC_1.getName());
         assertTrue(statusList.get(0).isSubscribed());
 
-        assertEquals(MANUAL_TOPIC_2.getGuid(), statusList.get(1).getTopicGuid());
-        assertEquals(MANUAL_TOPIC_2.getName(), statusList.get(1).getTopicName());
+        assertEquals(statusList.get(1).getTopicGuid(), MANUAL_TOPIC_2.getGuid());
+        assertEquals(statusList.get(1).getTopicName(), MANUAL_TOPIC_2.getName());
         assertFalse(statusList.get(1).isSubscribed());
 
-        assertEquals(MANUAL_TOPIC_3.getGuid(), statusList.get(2).getTopicGuid());
-        assertEquals(MANUAL_TOPIC_3.getName(), statusList.get(2).getTopicName());
+        assertEquals(statusList.get(2).getTopicGuid(), MANUAL_TOPIC_3.getGuid());
+        assertEquals(statusList.get(2).getTopicName(), MANUAL_TOPIC_3.getName());
         assertTrue(statusList.get(2).isSubscribed());
 
-        assertEquals(MANUAL_TOPIC_4.getGuid(), statusList.get(3).getTopicGuid());
-        assertEquals(MANUAL_TOPIC_4.getName(), statusList.get(3).getTopicName());
+        assertEquals(statusList.get(3).getTopicGuid(), MANUAL_TOPIC_4.getGuid());
+        assertEquals(statusList.get(3).getTopicName(), MANUAL_TOPIC_4.getName());
         assertFalse(statusList.get(3).isSubscribed());
 
         // Verify back-ends. We unsub from topic 2 and sub to topic 3.

--- a/src/test/java/org/sagebionetworks/bridge/services/OAuthServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OAuthServiceTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -13,14 +13,14 @@ import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.OAuthAccessGrantDao;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
@@ -34,7 +34,6 @@ import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.Lists;
 
-@RunWith(MockitoJUnitRunner.class)
 public class OAuthServiceTest {
 
     private static final DateTime NOW = DateTime.now(DateTimeZone.UTC);
@@ -66,8 +65,9 @@ public class OAuthServiceTest {
     
     private Study study;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         service.setOAuthAccessGrantDao(mockGrantDao);
         service.setOAuthProviderService(mockProviderService);
         
@@ -122,17 +122,17 @@ public class OAuthServiceTest {
     }
     
     private void assertAccessToken(OAuthAccessToken authToken) {
-        assertEquals(VENDOR_ID, authToken.getVendorId());
-        assertEquals(ACCESS_TOKEN, authToken.getAccessToken());
-        assertEquals(EXPIRES_ON, authToken.getExpiresOn());
+        assertEquals(authToken.getVendorId(), VENDOR_ID);
+        assertEquals(authToken.getAccessToken(), ACCESS_TOKEN);
+        assertEquals(authToken.getExpiresOn(), EXPIRES_ON);
     }
     private void assertGrant(OAuthAccessGrant grant) {
-        assertEquals(HEALTH_CODE, grant.getHealthCode());
-        assertEquals(VENDOR_ID, grant.getVendorId());
-        assertEquals(ACCESS_TOKEN, grant.getAccessToken());
-        assertEquals(REFRESH_TOKEN, grant.getRefreshToken());
-        assertEquals(NOW.getMillis(), grant.getCreatedOn());
-        assertEquals(EXPIRES_ON.getMillis(), grant.getExpiresOn());
+        assertEquals(grant.getHealthCode(), HEALTH_CODE);
+        assertEquals(grant.getVendorId(), VENDOR_ID);
+        assertEquals(grant.getAccessToken(), ACCESS_TOKEN);
+        assertEquals(grant.getRefreshToken(), REFRESH_TOKEN);
+        assertEquals(grant.getCreatedOn(), NOW.getMillis());
+        assertEquals(grant.getExpiresOn(), EXPIRES_ON.getMillis());
     }
     
     // All of these tests are for requestAccessToken(...)
@@ -199,12 +199,12 @@ public class OAuthServiceTest {
         assertGrant(grantCaptor.getValue());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getHealthCodesThrowsExceptionOnIncorrectOAuthProvider() {
         service.getHealthCodesGrantingAccess(study, "notAVendor", 50, null);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getHealthCodesThrowsExceptionOnIncorrectOAuthProvider2() {
         service.getHealthCodesGrantingAccess(study, "notAVendor", 50, null);
     }
@@ -256,7 +256,7 @@ public class OAuthServiceTest {
         assertGrant(grantCaptor.getValue());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getExpiredGrantInvalidRefreshToken() {
         setupDaoWithExpiredGrant(); 
         setupInvalidRefreshCall();
@@ -264,7 +264,7 @@ public class OAuthServiceTest {
         service.getAccessToken(study, VENDOR_ID, HEALTH_CODE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getNoGrant() {
         service.getAccessToken(study, VENDOR_ID, HEALTH_CODE);
     }
@@ -284,8 +284,8 @@ public class OAuthServiceTest {
         
         verify(mockGrantDao).getAccessGrants(study, VENDOR_ID, "offsetKey", 30);
         // Just verify a couple of fields to verify this is the page returned
-        assertEquals("nextPageOffset", results.getNextPageOffsetKey());
-        assertEquals(2, results.getItems().size());
+        assertEquals(results.getNextPageOffsetKey(), "nextPageOffset");
+        assertEquals(results.getItems().size(), 2);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -1,12 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -21,6 +14,13 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -34,16 +34,15 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -101,7 +100,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ParticipantServiceTest {
     private static final ClientInfo CLIENT_INFO = new ClientInfo.Builder().withAppName("unit test")
             .withAppVersion(4).build();
@@ -239,8 +237,10 @@ public class ParticipantServiceTest {
     
     private ExternalIdentifier extId;
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         extId = ExternalIdentifier.create(STUDY.getStudyIdentifier(), EXTERNAL_ID);
         STUDY.setExternalIdValidationEnabled(false);
         STUDY.setExternalIdRequiredOnSignup(false);
@@ -286,7 +286,7 @@ public class ParticipantServiceTest {
                 .withCallerSubstudies(CALLER_SUBS).build());
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
     }
@@ -330,7 +330,7 @@ public class ParticipantServiceTest {
         when(externalIdService.getExternalId(STUDY.getStudyIdentifier(), EXTERNAL_ID)).thenReturn(Optional.of(extId));
         
         IdentifierHolder idHolder = participantService.createParticipant(STUDY, PARTICIPANT, true);
-        assertEquals(ID, idHolder.getIdentifier());
+        assertEquals(idHolder.getIdentifier(), ID);
         
         verify(externalIdService).commitAssignExternalId(extId);
         
@@ -339,31 +339,31 @@ public class ParticipantServiceTest {
         verify(accountWorkflowService).sendEmailVerificationToken(STUDY, ID, EMAIL);
         
         Account account = accountCaptor.getValue();
-        assertEquals(ID, account.getId());
-        assertEquals(STUDY.getIdentifier(), account.getStudyId());
+        assertEquals(account.getId(), ID);
+        assertEquals(account.getStudyId(), STUDY.getIdentifier());
         // Not healthCode because the mock always returns the ID value, but this is
         // set by calling the generateGUID() method, which is correct.
-        assertEquals(ID, account.getHealthCode());
-        assertEquals(EMAIL, account.getEmail());
+        assertEquals(account.getHealthCode(), ID);
+        assertEquals(account.getEmail(), EMAIL);
         assertFalse(account.getEmailVerified());
-        assertEquals(PHONE, account.getPhone());
+        assertEquals(account.getPhone(), PHONE);
         assertFalse(account.getPhoneVerified());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         assertNotNull(account.getPasswordHash());
-        assertEquals(PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM, account.getPasswordAlgorithm());
-        assertNotEquals(PASSWORD, account.getPasswordHash());
-        assertEquals(FIRST_NAME, account.getFirstName());
-        assertEquals(LAST_NAME, account.getLastName());
-        assertEquals("true", account.getAttributes().get("can_be_recontacted"));
-        assertEquals(DEV_CALLER_ROLES, account.getRoles());
-        assertEquals(TestUtils.getClientData(), account.getClientData());
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
-        assertEquals(Boolean.TRUE, account.getNotifyByEmail());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getPasswordAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
+        assertNotEquals(account.getPasswordHash(), PASSWORD);
+        assertEquals(account.getFirstName(), FIRST_NAME);
+        assertEquals(account.getLastName(), LAST_NAME);
+        assertEquals(account.getAttributes().get("can_be_recontacted"), "true");
+        assertEquals(account.getRoles(), DEV_CALLER_ROLES);
+        assertEquals(account.getClientData(), TestUtils.getClientData());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
+        assertEquals(account.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        assertEquals(account.getNotifyByEmail(), Boolean.TRUE);
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         assertNull(account.getTimeZone());
-        assertEquals(Sets.newHashSet("group1","group2"), account.getDataGroups());
-        assertEquals(ImmutableList.of("de","fr"), account.getLanguages());
+        assertEquals(account.getDataGroups(), Sets.newHashSet("group1","group2"));
+        assertEquals(account.getLanguages(), ImmutableList.of("de","fr"));
         
         // don't update cache
         Mockito.verifyNoMoreInteractions(cacheProvider);
@@ -380,19 +380,19 @@ public class ParticipantServiceTest {
         verify(accountDao).createAccount(eq(STUDY), accountCaptor.capture(), any());
         
         Set<AccountSubstudy> accountSubstudies = accountCaptor.getValue().getAccountSubstudies();
-        assertEquals(2, accountSubstudies.size());
+        assertEquals(accountSubstudies.size(), 2);
         
         AccountSubstudy substudyA = accountSubstudies.stream()
                 .filter((as) -> as.getSubstudyId().equals("substudyA")).findAny().get();
-        assertEquals(STUDY.getIdentifier(), substudyA.getStudyId());
-        assertEquals("substudyA", substudyA.getSubstudyId());
-        assertEquals(ID, substudyA.getAccountId());
+        assertEquals(substudyA.getStudyId(), STUDY.getIdentifier());
+        assertEquals(substudyA.getSubstudyId(), "substudyA");
+        assertEquals(substudyA.getAccountId(), ID);
         
         AccountSubstudy substudyB = accountSubstudies.stream()
                 .filter((as) -> as.getSubstudyId().equals("substudyB")).findAny().get();
-        assertEquals(STUDY.getIdentifier(), substudyB.getStudyId());
-        assertEquals("substudyB", substudyB.getSubstudyId());
-        assertEquals(ID, substudyB.getAccountId());
+        assertEquals(substudyB.getStudyId(), STUDY.getIdentifier());
+        assertEquals(substudyB.getSubstudyId(), "substudyB");
+        assertEquals(substudyB.getAccountId(), ID);
     }
 
     @Test
@@ -410,7 +410,7 @@ public class ParticipantServiceTest {
         inOrder.verify(externalIdService).commitAssignExternalId(extId);
         
         Account account = accountCaptor.getValue();
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
     }
 
     @Test
@@ -435,8 +435,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
     }
     
     @Test
@@ -449,8 +449,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, participant, true);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
     }
     
     @Test
@@ -461,8 +461,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
     }
     
     @Test
@@ -473,7 +473,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, true);
 
         verify(accountWorkflowService).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertFalse(account.getEmailVerified());
     }
     
@@ -487,7 +487,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(study, PARTICIPANT, true);
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertFalse(account.getEmailVerified());
     }
 
@@ -502,7 +502,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, phoneParticipant, false);
 
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
         assertFalse(account.getEmailVerified());
     }
     
@@ -513,8 +513,8 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
-        assertEquals(Boolean.TRUE, account.getPhoneVerified());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
+        assertEquals(account.getPhoneVerified(), Boolean.TRUE);
     }
     
     @Test
@@ -525,7 +525,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, true);
 
         verify(accountWorkflowService).sendPhoneVerificationToken(STUDY, ID, PHONE);
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertFalse(account.getPhoneVerified());
     }
 
@@ -539,7 +539,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(study, PARTICIPANT, true);
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertFalse(account.getPhoneVerified());
     }
 
@@ -552,7 +552,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, emailParticipant, false);
 
         verify(accountWorkflowService, never()).sendPhoneVerificationToken(any(), any(), any());
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
         assertFalse(account.getPhoneVerified());
     }
 
@@ -573,7 +573,7 @@ public class ParticipantServiceTest {
         StudyParticipant idParticipant = new StudyParticipant.Builder().withExternalId(EXTERNAL_ID).build();
         participantService.createParticipant(STUDY, idParticipant, false);
         
-        assertEquals(AccountStatus.UNVERIFIED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.UNVERIFIED);
         assertFalse(account.getPhoneVerified());
         assertFalse(account.getEmailVerified());
     }
@@ -586,7 +586,7 @@ public class ParticipantServiceTest {
                 .withPassword(PASSWORD).build();
         participantService.createParticipant(STUDY, idParticipant, false);
         
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
         assertFalse(account.getPhoneVerified());
         assertFalse(account.getEmailVerified());
     }
@@ -691,18 +691,18 @@ public class ParticipantServiceTest {
                 registrationCaptor.capture());
 
         CriteriaContext criteriaContext = criteriaContextCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY, criteriaContext.getStudyIdentifier());
-        assertEquals(ID, criteriaContext.getUserId());
-        assertEquals(HEALTH_CODE, criteriaContext.getHealthCode());
-        assertEquals(CLIENT_INFO, criteriaContext.getClientInfo());
-        assertEquals(TestConstants.LANGUAGES, criteriaContext.getLanguages());
-        assertEquals(TestConstants.USER_DATA_GROUPS, criteriaContext.getUserDataGroups());
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, criteriaContext.getUserSubstudyIds());
+        assertEquals(criteriaContext.getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(criteriaContext.getUserId(), ID);
+        assertEquals(criteriaContext.getHealthCode(), HEALTH_CODE);
+        assertEquals(criteriaContext.getClientInfo(), CLIENT_INFO);
+        assertEquals(criteriaContext.getLanguages(), TestConstants.LANGUAGES);
+        assertEquals(criteriaContext.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(criteriaContext.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
 
         NotificationRegistration registration = registrationCaptor.getValue();
-        assertEquals(HEALTH_CODE, registration.getHealthCode());
-        assertEquals(NotificationProtocol.SMS, registration.getProtocol());
-        assertEquals(PHONE.getNumber(), registration.getEndpoint());
+        assertEquals(registration.getHealthCode(), HEALTH_CODE);
+        assertEquals(registration.getProtocol(), NotificationProtocol.SMS);
+        assertEquals(registration.getEndpoint(), PHONE.getNumber());
     }
 
     @Test
@@ -720,26 +720,26 @@ public class ParticipantServiceTest {
         verify(accountDao).getPagedAccountSummaries(STUDY, search); 
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void getPagedAccountSummariesWithBadStudy() {
         participantService.getPagedAccountSummaries(null, AccountSummarySearch.EMPTY_SEARCH);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithNegativeOffsetBy() {
         AccountSummarySearch search = new AccountSummarySearch.Builder()
                 .withOffsetBy(-1).build();
         participantService.getPagedAccountSummaries(STUDY, search);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithNegativePageSize() {
         AccountSummarySearch search = new AccountSummarySearch.Builder()
                 .withPageSize(-100).build();
         participantService.getPagedAccountSummaries(STUDY, search);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithBadDateRange() {
         AccountSummarySearch search = new AccountSummarySearch.Builder()
                 .withStartTime(END_DATE).withEndTime(START_DATE).build();
@@ -756,41 +756,41 @@ public class ParticipantServiceTest {
         verify(accountDao).getPagedAccountSummaries(STUDY, search); 
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithTooLargePageSize() {
         AccountSummarySearch search = new AccountSummarySearch.Builder().withPageSize(251).build();
         participantService.getPagedAccountSummaries(STUDY, search);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithInvalidAllOfGroup() {
         AccountSummarySearch search = new AccountSummarySearch.Builder().withAllOfGroups(Sets.newHashSet("not_real_group")).build();
 
         participantService.getPagedAccountSummaries(STUDY, search);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithInvalidNoneOfGroup() {
         AccountSummarySearch search = new AccountSummarySearch.Builder().withNoneOfGroups(Sets.newHashSet("not_real_group")).build();
 
         participantService.getPagedAccountSummaries(STUDY, search);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void getPagedAccountSummariesWithConflictingGroups() {
         AccountSummarySearch search = new AccountSummarySearch.Builder().withNoneOfGroups(Sets.newHashSet("group1"))
                 .withAllOfGroups(Sets.newHashSet("group1")).build();
         participantService.getPagedAccountSummaries(STUDY, search);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantEmailDoesNotExist() {
         when(accountDao.getAccount(ACCOUNT_ID)).thenReturn(null);
         
         participantService.getParticipant(STUDY, ID, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantAccountIdDoesNotExist() {
         participantService.getParticipant(STUDY, "externalId:some-junk", false);
     }
@@ -822,15 +822,15 @@ public class ParticipantServiceTest {
         
         StudyParticipant retrieved = participantService.getSelfParticipant(STUDY, CONTEXT, true);
         
-        assertEquals(CONTEXT.getUserId(), retrieved.getId());
-        assertEquals("lastName", retrieved.getLastName());
+        assertEquals(retrieved.getId(), CONTEXT.getUserId());
+        assertEquals(retrieved.getLastName(), "lastName");
         // These have been filtered
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, retrieved.getSubstudyIds());
+        assertEquals(retrieved.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
         // Consent was calculated
         assertTrue(retrieved.isConsented());
         // There is history
         UserConsentHistory history = retrieved.getConsentHistories().get(subpopGuid.getGuid()).get(0);
-        assertEquals(START_DATE.getMillis(), history.getConsentCreatedOn());
+        assertEquals(history.getConsentCreatedOn(), START_DATE.getMillis());
     }
     
     @Test
@@ -854,9 +854,9 @@ public class ParticipantServiceTest {
         
         StudyParticipant retrieved = participantService.getSelfParticipant(STUDY, CONTEXT, false);
         
-        assertEquals(CONTEXT.getUserId(), retrieved.getId());
+        assertEquals(retrieved.getId(), CONTEXT.getUserId());
         // These have been filtered
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, retrieved.getSubstudyIds());
+        assertEquals(retrieved.getSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
         // Consent was calculated
         assertTrue(retrieved.isConsented());
         // There is no history
@@ -926,32 +926,32 @@ public class ParticipantServiceTest {
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, true);
 
         assertTrue(participant.isConsented());
-        assertEquals(FIRST_NAME, participant.getFirstName());
-        assertEquals(LAST_NAME, participant.getLastName());
+        assertEquals(participant.getFirstName(), FIRST_NAME);
+        assertEquals(participant.getLastName(), LAST_NAME);
         assertTrue(participant.isNotifyByEmail());
-        assertEquals(Sets.newHashSet("group1","group2"), participant.getDataGroups());
-        assertEquals(EXTERNAL_ID, participant.getExternalId());
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, participant.getSharingScope());
-        assertEquals(HEALTH_CODE, participant.getHealthCode());
-        assertEquals(EMAIL, participant.getEmail());
-        assertEquals(PHONE.getNationalFormat(), participant.getPhone().getNationalFormat());
-        assertEquals(Boolean.TRUE, participant.getEmailVerified());
-        assertEquals(Boolean.FALSE, participant.getPhoneVerified());
-        assertEquals(ID, participant.getId());
-        assertEquals(AccountStatus.DISABLED, participant.getStatus());
-        assertEquals(createdOn, participant.getCreatedOn());
-        assertEquals(USER_TIME_ZONE, participant.getTimeZone());
-        assertEquals(USER_LANGUAGES, participant.getLanguages());
-        assertEquals(TestUtils.getClientData(), participant.getClientData());
-        assertEquals(2, participant.getExternalIds().size());
-        assertEquals("externalIdA", participant.getExternalIds().get("substudyA"));
-        assertEquals("externalIdB", participant.getExternalIds().get("substudyB"));
+        assertEquals(participant.getDataGroups(), Sets.newHashSet("group1","group2"));
+        assertEquals(participant.getExternalId(), EXTERNAL_ID);
+        assertEquals(participant.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        assertEquals(participant.getHealthCode(), HEALTH_CODE);
+        assertEquals(participant.getEmail(), EMAIL);
+        assertEquals(participant.getPhone().getNationalFormat(), PHONE.getNationalFormat());
+        assertEquals(participant.getEmailVerified(), Boolean.TRUE);
+        assertEquals(participant.getPhoneVerified(), Boolean.FALSE);
+        assertEquals(participant.getId(), ID);
+        assertEquals(participant.getStatus(), AccountStatus.DISABLED);
+        assertEquals(participant.getCreatedOn(), createdOn);
+        assertEquals(participant.getTimeZone(), USER_TIME_ZONE);
+        assertEquals(participant.getLanguages(), USER_LANGUAGES);
+        assertEquals(participant.getClientData(), TestUtils.getClientData());
+        assertEquals(participant.getExternalIds().size(), 2);
+        assertEquals(participant.getExternalIds().get("substudyA"), "externalIdA");
+        assertEquals(participant.getExternalIds().get("substudyB"), "externalIdB");
         
         assertNull(participant.getAttributes().get("attr1"));
-        assertEquals("anAttribute2", participant.getAttributes().get("attr2"));
+        assertEquals(participant.getAttributes().get("attr2"), "anAttribute2");
         
         List<UserConsentHistory> retrievedHistory1 = participant.getConsentHistories().get(subpop1.getGuidString());
-        assertEquals(1, retrievedHistory1.size());
+        assertEquals(retrievedHistory1.size(), 1);
         
         List<UserConsentHistory> retrievedHistory2 = participant.getConsentHistories().get(subpop2.getGuidString());
         assertTrue(retrievedHistory2.isEmpty());
@@ -961,13 +961,13 @@ public class ParticipantServiceTest {
         verify(consentService).getConsentStatuses(criteriaContextCaptor.capture(), same(account));
 
         CriteriaContext criteriaContext = criteriaContextCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY, criteriaContext.getStudyIdentifier());
-        assertEquals(ID, criteriaContext.getUserId());
-        assertEquals(HEALTH_CODE, criteriaContext.getHealthCode());
-        assertEquals(CLIENT_INFO, criteriaContext.getClientInfo());
-        assertEquals(TestConstants.LANGUAGES, criteriaContext.getLanguages());
-        assertEquals(TestConstants.USER_DATA_GROUPS, criteriaContext.getUserDataGroups());
-        assertEquals(ImmutableSet.of("substudyA", "substudyB", "substudyC"), criteriaContext.getUserSubstudyIds());
+        assertEquals(criteriaContext.getStudyIdentifier(), TestConstants.TEST_STUDY);
+        assertEquals(criteriaContext.getUserId(), ID);
+        assertEquals(criteriaContext.getHealthCode(), HEALTH_CODE);
+        assertEquals(criteriaContext.getClientInfo(), CLIENT_INFO);
+        assertEquals(criteriaContext.getLanguages(), TestConstants.LANGUAGES);
+        assertEquals(criteriaContext.getUserDataGroups(), TestConstants.USER_DATA_GROUPS);
+        assertEquals(criteriaContext.getUserSubstudyIds(), ImmutableSet.of("substudyA", "substudyB", "substudyC"));
     }
     
     @Test
@@ -988,11 +988,11 @@ public class ParticipantServiceTest {
                 .withCallerSubstudies(ImmutableSet.of("substudyA", "substudyC")).build());
         
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, false);
-        assertEquals(ImmutableSet.of("substudyA", "substudyC"), participant.getSubstudyIds());
-        assertEquals(ImmutableMap.of("substudyA", "externalIdA"), participant.getExternalIds());
+        assertEquals(participant.getSubstudyIds(), ImmutableSet.of("substudyA", "substudyC"));
+        assertEquals(participant.getExternalIds(), ImmutableMap.of("substudyA", "externalIdA"));
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void signOutUserWhoDoesNotExist() {
         participantService.signUserOut(STUDY, ID, true);
     }
@@ -1032,8 +1032,8 @@ public class ParticipantServiceTest {
         verify(accountDao).deleteReauthToken(accountIdCaptor.capture());
         verify(cacheProvider).removeSessionByUserId(ID);
 
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountIdCaptor.getValue().getStudyId());
-        assertEquals(EMAIL, accountIdCaptor.getValue().getEmail());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountIdCaptor.getValue().getEmail(), EMAIL);
     }
 
     @Test
@@ -1054,16 +1054,16 @@ public class ParticipantServiceTest {
         inOrder.verify(externalIdService).commitAssignExternalId(extId);
         
         Account account = accountCaptor.getValue();
-        assertEquals(FIRST_NAME, account.getFirstName());
-        assertEquals(LAST_NAME, account.getLastName());
-        assertEquals("true", account.getAttributes().get("can_be_recontacted"));
-        assertEquals(TestUtils.getClientData(), account.getClientData());
+        assertEquals(account.getFirstName(), FIRST_NAME);
+        assertEquals(account.getLastName(), LAST_NAME);
+        assertEquals(account.getAttributes().get("can_be_recontacted"), "true");
+        assertEquals(account.getClientData(), TestUtils.getClientData());
         
-        assertEquals(SharingScope.ALL_QUALIFIED_RESEARCHERS, account.getSharingScope());
-        assertEquals(Boolean.TRUE, account.getNotifyByEmail());
-        assertEquals(Sets.newHashSet("group1","group2"), account.getDataGroups());
-        assertEquals(ImmutableList.of("de","fr"), account.getLanguages());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getSharingScope(), SharingScope.ALL_QUALIFIED_RESEARCHERS);
+        assertEquals(account.getNotifyByEmail(), Boolean.TRUE);
+        assertEquals(account.getDataGroups(), Sets.newHashSet("group1","group2"));
+        assertEquals(account.getLanguages(), ImmutableList.of("de","fr"));
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         assertNull(account.getTimeZone());
     }
 
@@ -1090,18 +1090,18 @@ public class ParticipantServiceTest {
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
         
         Set<AccountSubstudy> accountSubstudies = accountCaptor.getValue().getAccountSubstudies();
-        assertEquals(2, accountSubstudies.size());
+        assertEquals(accountSubstudies.size(), 2);
         
         // Not changed at all, because user isn't an admin
         AccountSubstudy substudyA = accountSubstudies.stream()
                 .filter((as) -> as.getSubstudyId().equals("substudyC")).findAny().get();
-        assertEquals(STUDY.getIdentifier(), substudyA.getStudyId());
-        assertEquals(ID, substudyA.getAccountId());
+        assertEquals(substudyA.getStudyId(), STUDY.getIdentifier());
+        assertEquals(substudyA.getAccountId(), ID);
         
         AccountSubstudy substudyB = accountSubstudies.stream()
                 .filter((as) -> as.getSubstudyId().equals("substudyA")).findAny().get();
-        assertEquals(STUDY.getIdentifier(), substudyB.getStudyId());
-        assertEquals(ID, substudyB.getAccountId());
+        assertEquals(substudyB.getStudyId(), STUDY.getIdentifier());
+        assertEquals(substudyB.getAccountId(), ID);
     }
 
     @Test
@@ -1118,7 +1118,7 @@ public class ParticipantServiceTest {
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
         
         Set<AccountSubstudy> accountSubstudies = accountCaptor.getValue().getAccountSubstudies();
-        assertEquals(2, accountSubstudies.size());
+        assertEquals(accountSubstudies.size(), 2);
         
         // get() throws exception if accountSubstudy not found
         accountSubstudies.stream()
@@ -1137,7 +1137,7 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals(2, account.getAccountSubstudies().size());
+        assertEquals(account.getAccountSubstudies().size(), 2);
         verify(externalIdService, never()).unassignExternalId(any(), any());
         verify(cacheProvider).removeSessionByUserId(ID);
     }
@@ -1158,7 +1158,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
         
         // We've tested this collection more thoroughly in updateParticipantTransfersSubstudyIdsForAdmins()
-        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(account.getAccountSubstudies().size(), 1);
         verify(externalIdService).unassignExternalId(account, "extB");
         verify(cacheProvider).removeSessionByUserId(ID);
     }
@@ -1194,7 +1194,7 @@ public class ParticipantServiceTest {
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
         
         Set<AccountSubstudy> accountSubstudies = accountCaptor.getValue().getAccountSubstudies();
-        assertEquals(2, accountSubstudies.size());
+        assertEquals(accountSubstudies.size(), 2);
         
         // get() throws exception if accountSubstudy not found
         accountSubstudies.stream()
@@ -1203,7 +1203,7 @@ public class ParticipantServiceTest {
                 .filter((as) -> as.getSubstudyId().equals("substudyC")).findAny().get();
     }    
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateParticipantWithInvalidParticipant() {
         mockHealthCodeAndAccountRetrieval();
         
@@ -1264,7 +1264,7 @@ public class ParticipantServiceTest {
 
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
         Account account = accountCaptor.getValue();
-        assertEquals(AccountStatus.ENABLED, account.getStatus());
+        assertEquals(account.getStatus(), AccountStatus.ENABLED);
     }
 
     @Test
@@ -1327,8 +1327,8 @@ public class ParticipantServiceTest {
         assertNotNull(participant);
         
         verify(accountDao).getAccount(accountIdCaptor.capture());
-        assertEquals(STUDY.getIdentifier(), accountIdCaptor.getValue().getStudyId());
-        assertEquals(ID, accountIdCaptor.getValue().getHealthCode());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), STUDY.getIdentifier());
+        assertEquals(accountIdCaptor.getValue().getHealthCode(), ID);
     }
     
     @Test
@@ -1341,8 +1341,8 @@ public class ParticipantServiceTest {
         assertNotNull(participant);
         
         verify(accountDao).getAccount(accountIdCaptor.capture());
-        assertEquals(STUDY.getIdentifier(), accountIdCaptor.getValue().getStudyId());
-        assertEquals(ID, accountIdCaptor.getValue().getExternalId());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), STUDY.getIdentifier());
+        assertEquals(accountIdCaptor.getValue().getExternalId(), ID);
     }
     
     @Test
@@ -1354,11 +1354,11 @@ public class ParticipantServiceTest {
         assertNotNull(participant);
         
         verify(accountDao).getAccount(accountIdCaptor.capture());
-        assertEquals(STUDY.getIdentifier(), accountIdCaptor.getValue().getStudyId());
-        assertEquals(ID, accountIdCaptor.getValue().getId());
+        assertEquals(accountIdCaptor.getValue().getStudyId(), STUDY.getIdentifier());
+        assertEquals(accountIdCaptor.getValue().getId(), ID);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantByAccountIdThrowsException() {
         participantService.getParticipant(STUDY, ID, true);
     }
@@ -1373,7 +1373,7 @@ public class ParticipantServiceTest {
         
         StudyParticipant participant = participantService.getParticipant(STUDY, ID, true);
 
-        assertEquals(1, participant.getConsentHistories().keySet().size());
+        assertEquals(participant.getConsentHistories().keySet().size(), 1);
     }
 
     @Test
@@ -1469,16 +1469,16 @@ public class ParticipantServiceTest {
         StudyParticipant participant = participantService.getParticipant(STUDY, account, false);
         
         // The most important thing here is that participant includes health code
-        assertEquals(HEALTH_CODE, participant.getHealthCode());
+        assertEquals(participant.getHealthCode(), HEALTH_CODE);
         // Other fields exist too, but getParticipant() is tested in its entirety earlier in this test.
-        assertEquals(EMAIL, participant.getEmail());
-        assertEquals(ID, participant.getId());
-        assertEquals(TestUtils.getClientData(), participant.getClientData());
+        assertEquals(participant.getEmail(), EMAIL);
+        assertEquals(participant.getId(), ID);
+        assertEquals(participant.getClientData(), TestUtils.getClientData());
     }
 
     // Contrived test case for a case that never happens, but somehow does.
     // See https://sagebionetworks.jira.com/browse/BRIDGE-1463
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getStudyParticipantWithoutAccountThrows404() {
         participantService.getParticipant(STUDY, (Account) null, false);
     }
@@ -1518,7 +1518,7 @@ public class ParticipantServiceTest {
         verify(scheduledActivityService).getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, null, null, null, PAGE_SIZE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getActivityHistoryV2NoUserThrowsCorrectException() {
         participantService.getActivityHistory(STUDY, ID, ACTIVITY_GUID, null, null, null, PAGE_SIZE);
     }
@@ -1532,7 +1532,7 @@ public class ParticipantServiceTest {
         verify(activityDao).deleteActivitiesForUser(HEALTH_CODE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteActivitiesNoUserThrowsCorrectException() {
         participantService.deleteActivities(STUDY, ID);
     }
@@ -1546,8 +1546,8 @@ public class ParticipantServiceTest {
         verify(accountWorkflowService).resendVerificationToken(eq(ChannelType.EMAIL), accountIdCaptor.capture());
         
         AccountId accountId = accountIdCaptor.getValue();
-        assertEquals(STUDY.getIdentifier(), accountId.getStudyId());
-        assertEquals(EMAIL, accountId.getEmail());
+        assertEquals(accountId.getStudyId(), STUDY.getIdentifier());
+        assertEquals(accountId.getEmail(), EMAIL);
     }
     
     @Test
@@ -1559,11 +1559,11 @@ public class ParticipantServiceTest {
         verify(accountWorkflowService).resendVerificationToken(eq(ChannelType.PHONE), accountIdCaptor.capture());
         
         AccountId accountId = accountIdCaptor.getValue();
-        assertEquals(STUDY.getIdentifier(), accountId.getStudyId());
-        assertEquals(PHONE, accountId.getPhone());
+        assertEquals(accountId.getStudyId(), STUDY.getIdentifier());
+        assertEquals(accountId.getPhone(), PHONE);
     }
     
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void resendVerificationUnsupportedOperationException() {
         mockHealthCodeAndAccountRetrieval();
         
@@ -1580,7 +1580,7 @@ public class ParticipantServiceTest {
         verify(consentService).resendConsentAgreement(eq(STUDY), eq(SUBPOP_GUID), participantCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
-        assertEquals(ID, participant.getId());
+        assertEquals(participant.getId(), ID);
     }
     
     @Test
@@ -1594,7 +1594,7 @@ public class ParticipantServiceTest {
         
         verify(consentService).withdrawFromStudy(eq(STUDY), participantCaptor.capture(),
             eq(withdrawal), eq(withdrewOn));
-        assertEquals(ID, participantCaptor.getValue().getId());
+        assertEquals(participantCaptor.getValue().getId(), ID);
     }
     
     @Test
@@ -1608,8 +1608,8 @@ public class ParticipantServiceTest {
         
         verify(consentService).withdrawConsent(eq(STUDY), eq(SUBPOP_GUID), participantCaptor.capture(),
                 contextCaptor.capture(), eq(withdrawal), eq(withdrewOn));
-        assertEquals(ID, participantCaptor.getValue().getId());
-        assertEquals(ID, contextCaptor.getValue().getUserId());
+        assertEquals(participantCaptor.getValue().getId(), ID);
+        assertEquals(contextCaptor.getValue().getUserId(), ID);
     }
     
     @Test
@@ -1652,7 +1652,7 @@ public class ParticipantServiceTest {
         when(notificationsService.sendNotificationToUser(any(), any(), any())).thenReturn(erroredNotifications);
         
         Set<String> returnedErrors = participantService.sendNotification(STUDY, ID, message);
-        assertEquals(erroredNotifications, returnedErrors);
+        assertEquals(returnedErrors, erroredNotifications);
         
         verify(notificationsService).sendNotificationToUser(STUDY.getStudyIdentifier(), HEALTH_CODE, message);
     }
@@ -1692,11 +1692,11 @@ public class ParticipantServiceTest {
             participantService.createParticipant(STUDY, PARTICIPANT, false);
             fail("Should have thrown exception");
         } catch(LimitExceededException e) {
-            assertEquals("While study is in evaluation mode, it may not exceed 10 accounts.", e.getMessage());
+            assertEquals(e.getMessage(), "While study is in evaluation mode, it may not exceed 10 accounts.");
         }
     }
     
-    @Test(expected = LimitExceededException.class)
+    @Test(expectedExceptions = LimitExceededException.class)
     public void throwLimitExceededException() {
         STUDY.setAccountLimit(10);
         when(accountSummaries.getTotal()).thenReturn(13);
@@ -1722,7 +1722,7 @@ public class ParticipantServiceTest {
             participantService.updateIdentifiers(STUDY, CONTEXT, update);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
-            assertEquals("Account not found.", e.getMessage());
+            assertEquals(e.getMessage(), "Account not found.");
         }
         verify(accountDao, never()).updateAccount(any(), any());
     }
@@ -1749,18 +1749,18 @@ public class ParticipantServiceTest {
         
         verify(accountDao).updateAccount(eq(account), any());
         
-        assertEquals(2, account.getAccountSubstudies().size());
+        assertEquals(account.getAccountSubstudies().size(), 2);
         
         Set<String> substudyIds = account.getAccountSubstudies().stream()
                 .map(AccountSubstudy::getSubstudyId).collect(Collectors.toSet());
         Set<String> externalIds = account.getAccountSubstudies().stream()
                 .map(AccountSubstudy::getExternalId).collect(Collectors.toSet());
         
-        assertEquals(ImmutableSet.of("substudyA", "substudyB"), substudyIds);
-        assertEquals(ImmutableSet.of(EXTERNAL_ID, "newExternalId"), externalIds);
+        assertEquals(substudyIds, ImmutableSet.of("substudyA", "substudyB"));
+        assertEquals(externalIds, ImmutableSet.of(EXTERNAL_ID, "newExternalId"));
         
         // The RequestContext should be updated
-        assertEquals(ImmutableSet.of("substudyA", "substudyB"), BridgeUtils.getRequestContext().getCallerSubstudies());
+        assertEquals(BridgeUtils.getRequestContext().getCallerSubstudies(), ImmutableSet.of("substudyA", "substudyB"));
     }
     
     @Test
@@ -1775,12 +1775,12 @@ public class ParticipantServiceTest {
         
         StudyParticipant returned = participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
-        assertEquals(TestConstants.PHONE, account.getPhone());
-        assertEquals(Boolean.FALSE, account.getPhoneVerified());
+        assertEquals(account.getPhone(), TestConstants.PHONE);
+        assertEquals(account.getPhoneVerified(), Boolean.FALSE);
         verify(accountDao).authenticate(STUDY, EMAIL_PASSWORD_SIGN_IN);
         verify(accountDao).updateAccount(eq(account), eq(null));
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
-        assertEquals(PARTICIPANT.getId(), returned.getId());
+        assertEquals(returned.getId(), PARTICIPANT.getId());
     }
 
     @Test
@@ -1798,33 +1798,33 @@ public class ParticipantServiceTest {
         
         StudyParticipant returned = participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
-        assertEquals("email@email.com", account.getEmail());
-        assertEquals(Boolean.FALSE, account.getEmailVerified());
+        assertEquals(account.getEmail(), "email@email.com");
+        assertEquals(account.getEmailVerified(), Boolean.FALSE);
         verify(accountDao).authenticate(STUDY, PHONE_PASSWORD_SIGN_IN);
         verify(accountDao).updateAccount(eq(account), eq(null));
         verify(accountWorkflowService).sendEmailVerificationToken(STUDY, ID, "email@email.com");
         assertEquals(PARTICIPANT.getId(), returned.getId());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateIdentifiersValidates() {
         IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, null, null);
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateIdentifiersValidatesWithBlankEmail() {
         IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, "", null, null);
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateIdentifiersValidatesWithBlankExternalId() {
         IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, null, " ");
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateIdentifiersValidatesWithInvalidPhone() {
         IdentifierUpdate update = new IdentifierUpdate(EMAIL_PASSWORD_SIGN_IN, null, new Phone("US", "1231231234"), null);
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
@@ -1855,8 +1855,8 @@ public class ParticipantServiceTest {
 
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
-        assertEquals("email@email.com", account.getEmail());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
+        assertEquals(account.getEmail(), "email@email.com");
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
     }
     
@@ -1873,8 +1873,8 @@ public class ParticipantServiceTest {
         
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(Boolean.FALSE, account.getEmailVerified());
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getEmailVerified(), Boolean.FALSE);
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
     }
 
@@ -1893,7 +1893,7 @@ public class ParticipantServiceTest {
         
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
-        assertEquals("extid", account.getExternalId());
+        assertEquals(account.getExternalId(), "extid");
         verify(externalIdService).commitAssignExternalId(differentExternalId);
     }
 
@@ -1932,11 +1932,11 @@ public class ParticipantServiceTest {
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
         // None of these have changed.
-        assertEquals(EMAIL, account.getEmail());
-        assertEquals(Boolean.TRUE, account.getEmailVerified());
-        assertEquals(TestConstants.PHONE, account.getPhone());
-        assertEquals(Boolean.TRUE, account.getPhoneVerified());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getEmail(), EMAIL);
+        assertEquals(account.getEmailVerified(), Boolean.TRUE);
+        assertEquals(account.getPhone(), TestConstants.PHONE);
+        assertEquals(account.getPhoneVerified(), Boolean.TRUE);
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(accountDao, never()).updateAccount(any(), any());
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         verify(externalIdService, never()).commitAssignExternalId(any());
@@ -1954,13 +1954,13 @@ public class ParticipantServiceTest {
         participantService.updateIdentifiers(STUDY, CONTEXT, update);
         
         // External ID not changed, externalIdService not called
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(accountDao).updateAccount(any(), eq(null));
         verify(accountWorkflowService, never()).sendEmailVerificationToken(any(), any(), any());
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createRequiredExternalIdValidated() {
         mockHealthCodeAndAccountRetrieval();
         STUDY.setExternalIdRequiredOnSignup(true);
@@ -2031,7 +2031,7 @@ public class ParticipantServiceTest {
         }
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateMissingManagedExternalIdFails() {
         // In this case the ID is not in the external IDs table, so it fails validation.
         mockHealthCodeAndAccountRetrieval();
@@ -2054,9 +2054,9 @@ public class ParticipantServiceTest {
         
         ArgumentCaptor<ExternalIdentifier> extIdCaptor = ArgumentCaptor.forClass(ExternalIdentifier.class);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService).commitAssignExternalId(extIdCaptor.capture());
-        assertEquals(HEALTH_CODE, extIdCaptor.getValue().getHealthCode());
+        assertEquals(extIdCaptor.getValue().getHealthCode(), HEALTH_CODE);
     }
 
     @Test
@@ -2090,7 +2090,7 @@ public class ParticipantServiceTest {
                 .withExternalId("newExternalId").build();
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals("newExternalId", account.getExternalId());
+        assertEquals(account.getExternalId(), "newExternalId");
         verify(externalIdService).commitAssignExternalId(newExternalId);
     }
 
@@ -2103,7 +2103,7 @@ public class ParticipantServiceTest {
                 .withExternalId(null).build();
         participantService.updateParticipant(STUDY, participant);
         verify(externalIdService, never()).commitAssignExternalId(any());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
     }
 
     @Test
@@ -2116,7 +2116,7 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
     
@@ -2133,7 +2133,7 @@ public class ParticipantServiceTest {
         participantService.createParticipant(STUDY, PARTICIPANT, false);
         
         verify(accountDao).createAccount(any(), accountCaptor.capture(), any());
-        assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
+        assertEquals(accountCaptor.getValue().getExternalId(), EXTERNAL_ID);
         
         verify(externalIdService).commitAssignExternalId(null);
     }
@@ -2146,7 +2146,7 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
 
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService).commitAssignExternalId(null);
     }
 
@@ -2157,7 +2157,7 @@ public class ParticipantServiceTest {
         
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
     
@@ -2170,7 +2170,7 @@ public class ParticipantServiceTest {
                 .withExternalId("newExternalId").build();
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals("newExternalId", account.getExternalId());
+        assertEquals(account.getExternalId(), "newExternalId");
         // called with null, which does nothing.
         verify(externalIdService).commitAssignExternalId(null);
     }
@@ -2184,7 +2184,7 @@ public class ParticipantServiceTest {
                 .withExternalId(null).build();
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
     
@@ -2200,7 +2200,7 @@ public class ParticipantServiceTest {
                 .withExternalId("someOtherId").build();
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService, never()).unassignExternalId(any(), any());
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
@@ -2217,7 +2217,7 @@ public class ParticipantServiceTest {
                 .withExternalId(null).build();
         participantService.updateParticipant(STUDY, participant);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService, never()).unassignExternalId(any(), any());
         verify(externalIdService, never()).commitAssignExternalId(any());
     }
@@ -2237,7 +2237,7 @@ public class ParticipantServiceTest {
             participantService.createParticipant(STUDY, participant, false);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("externalId cannot be blank", e.getErrors().get("externalId").get(0));
+            assertEquals(e.getErrors().get("externalId").get(0), "externalId cannot be blank");
         }
     }
     
@@ -2251,7 +2251,7 @@ public class ParticipantServiceTest {
             participantService.createParticipant(STUDY, PARTICIPANT, false);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("externalId is not a valid external ID", e.getErrors().get("externalId").get(0));
+            assertEquals(e.getErrors().get("externalId").get(0), "externalId is not a valid external ID");
         }
     }
     @Test
@@ -2287,7 +2287,7 @@ public class ParticipantServiceTest {
             participantService.updateParticipant(STUDY, PARTICIPANT);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("externalId is not a valid external ID", e.getErrors().get("externalId").get(0));
+            assertEquals(e.getErrors().get("externalId").get(0), "externalId is not a valid external ID");
         }        
     }
     @Test
@@ -2302,7 +2302,7 @@ public class ParticipantServiceTest {
             participantService.updateParticipant(STUDY, participant);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("externalId cannot be blank", e.getErrors().get("externalId").get(0));
+            assertEquals(e.getErrors().get("externalId").get(0), "externalId cannot be blank");
         }        
     }
     @Test
@@ -2333,7 +2333,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
         verify(accountDao).updateAccount(eq(account), any());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService).commitAssignExternalId(extId);
     }
     @Test
@@ -2348,7 +2348,7 @@ public class ParticipantServiceTest {
         
         verify(externalIdService, never()).commitAssignExternalId(any());
         verify(accountDao).updateAccount(account, null);
-        assertEquals(EXTERNAL_ID, account.getExternalId()); // not erased
+        assertEquals(account.getExternalId(), EXTERNAL_ID); // not erased
     }
     @Test
     public void updateParticipantExternalIdsExistOneAddedDoesNothing() {
@@ -2366,7 +2366,7 @@ public class ParticipantServiceTest {
         
         verify(externalIdService, never()).commitAssignExternalId(any());
         verify(accountDao).updateAccount(account, null);
-        assertEquals(EXTERNAL_ID, account.getExternalId()); // not changed
+        assertEquals(account.getExternalId(), EXTERNAL_ID); // not changed
     }
     @Test
     public void updateParticipantAsResearcherNoExternalIdsNoneAddedDoesNothing() {
@@ -2394,7 +2394,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
         verify(accountDao).updateAccount(eq(account), any());
-        assertEquals(EXTERNAL_ID, account.getExternalId());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
         verify(externalIdService).commitAssignExternalId(extId);
     }
 
@@ -2413,7 +2413,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
         
         verify(accountDao).updateAccount(eq(account), any());
-        assertEquals("newExternalId", account.getExternalId());
+        assertEquals(account.getExternalId(), "newExternalId");
         verify(externalIdService).commitAssignExternalId(nextExtId);
     }
     @Test
@@ -2445,12 +2445,12 @@ public class ParticipantServiceTest {
         verify(smsService).sendSmsMessage(eq(ID), providerCaptor.capture());
         
         SmsMessageProvider provider = providerCaptor.getValue();
-        assertEquals(TestConstants.PHONE, provider.getPhone());
-        assertEquals("This is a test Bridge", provider.getSmsRequest().getMessage());
-        assertEquals("Promotional", provider.getSmsType());
+        assertEquals(provider.getPhone(), TestConstants.PHONE);
+        assertEquals(provider.getSmsRequest().getMessage(), "This is a test Bridge");
+        assertEquals(provider.getSmsType(), "Promotional");
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void sendSmsMessageThrowsIfNoPhone() { 
         when(accountDao.getAccount(any())).thenReturn(account);
         
@@ -2459,7 +2459,7 @@ public class ParticipantServiceTest {
         participantService.sendSmsMessage(STUDY, ID, template);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void sendSmsMessageThrowsIfPhoneUnverified() { 
         when(accountDao.getAccount(any())).thenReturn(account);
         account.setPhone(TestConstants.PHONE);
@@ -2470,7 +2470,7 @@ public class ParticipantServiceTest {
         participantService.sendSmsMessage(STUDY, ID, template);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void sendSmsMessageThrowsIfBlankMessage() {
         SmsTemplate template = new SmsTemplate("    "); 
         
@@ -2496,7 +2496,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, PARTICIPANT);
         
         verify(accountDao).updateAccount(accountCaptor.capture(), any());
-        assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
+        assertEquals(accountCaptor.getValue().getExternalId(), EXTERNAL_ID);
     }
     
     @Test
@@ -2511,7 +2511,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
         
         verify(accountDao).updateAccount(accountCaptor.capture(), eq(null));
-        assertEquals(EXTERNAL_ID, accountCaptor.getValue().getExternalId());
+        assertEquals(accountCaptor.getValue().getExternalId(), EXTERNAL_ID);
     }
     
     @Test
@@ -2524,7 +2524,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture(), any());
-        assertEquals("newExternalId", accountCaptor.getValue().getExternalId());
+        assertEquals(accountCaptor.getValue().getExternalId(), "newExternalId");
         // But they will not assign because there's no record to assign.
         verify(externalIdService).commitAssignExternalId(null);
     }
@@ -2543,7 +2543,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
 
         verify(accountDao).updateAccount(accountCaptor.capture(), any());
-        assertEquals("newExternalId", accountCaptor.getValue().getExternalId());
+        assertEquals(accountCaptor.getValue().getExternalId(), "newExternalId");
         verify(externalIdService).commitAssignExternalId(newExtId);
     }
     
@@ -2557,7 +2557,7 @@ public class ParticipantServiceTest {
         verify(externalIdService).commitAssignExternalId(extId);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void assignExternalIdFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2566,7 +2566,7 @@ public class ParticipantServiceTest {
         participantService.assignExternalId(ACCOUNT_ID, extId);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void createSmsRegistrationFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2575,7 +2575,7 @@ public class ParticipantServiceTest {
         participantService.createSmsRegistration(STUDY, ID);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantWithAccountFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2584,7 +2584,7 @@ public class ParticipantServiceTest {
         participantService.getParticipant(STUDY, account, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantWithAccountIdFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2593,7 +2593,7 @@ public class ParticipantServiceTest {
         participantService.getParticipant(STUDY, ID, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getParticipantWithUserIdFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2602,7 +2602,7 @@ public class ParticipantServiceTest {
         participantService.getParticipant(STUDY, ID, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void signUserOutFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2617,7 +2617,7 @@ public class ParticipantServiceTest {
         participantService.signUserOut(STUDY, EMAIL, true);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateParticipantFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2631,7 +2631,7 @@ public class ParticipantServiceTest {
         participantService.updateParticipant(STUDY, participant);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getActivityHistoryFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2643,7 +2643,7 @@ public class ParticipantServiceTest {
                 PAGE_SIZE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteActivitiesFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2654,7 +2654,7 @@ public class ParticipantServiceTest {
         verify(activityDao).deleteActivitiesForUser(HEALTH_CODE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getUploadsFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2667,7 +2667,7 @@ public class ParticipantServiceTest {
         verify(uploadService).getUploads(HEALTH_CODE, startTime, endTime, 10, "ABC");
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void listRegistrationsFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2678,7 +2678,7 @@ public class ParticipantServiceTest {
         verify(notificationsService).listRegistrations(HEALTH_CODE);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void sendNotificationFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2689,7 +2689,7 @@ public class ParticipantServiceTest {
         participantService.sendNotification(STUDY, ID, message);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void sendSmsMessageFiltersSubstudies() {
         when(accountDao.getAccount(any())).thenReturn(account);
         account.setHealthCode(HEALTH_CODE);
@@ -2705,7 +2705,7 @@ public class ParticipantServiceTest {
         participantService.sendSmsMessage(STUDY, ID, template);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getActivityEventsFiltersSubstudies() {
         mockAccountRetrievalWithSubstudyD();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -2729,19 +2729,19 @@ public class ParticipantServiceTest {
         
         ExternalIdentifier externalId = participantService.beginAssignExternalId(account, EXTERNAL_ID);
         
-        assertEquals(EXTERNAL_ID, externalId.getIdentifier());
-        assertEquals(HEALTH_CODE, externalId.getHealthCode());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, externalId.getStudyId());
-        assertEquals(SUBSTUDY_ID, externalId.getSubstudyId());
+        assertEquals(externalId.getIdentifier(), EXTERNAL_ID);
+        assertEquals(externalId.getHealthCode(), HEALTH_CODE);
+        assertEquals(externalId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(externalId.getSubstudyId(), SUBSTUDY_ID);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
-        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
+        assertEquals(account.getAccountSubstudies().size(), 1);
         
         AccountSubstudy accountSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
-        assertEquals(ID, accountSubstudy.getAccountId());
-        assertEquals(EXTERNAL_ID, accountSubstudy.getExternalId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountSubstudy.getStudyId());
-        assertEquals(SUBSTUDY_ID, accountSubstudy.getSubstudyId());
+        assertEquals(accountSubstudy.getAccountId(), ID);
+        assertEquals(accountSubstudy.getExternalId(), EXTERNAL_ID);
+        assertEquals(accountSubstudy.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountSubstudy.getSubstudyId(), SUBSTUDY_ID);
     }    
     
     @Test
@@ -2780,22 +2780,22 @@ public class ParticipantServiceTest {
         
         ExternalIdentifier externalId = participantService.beginAssignExternalId(account, EXTERNAL_ID);
         
-        assertEquals(EXTERNAL_ID, externalId.getIdentifier());
-        assertEquals(HEALTH_CODE, externalId.getHealthCode());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, externalId.getStudyId());
-        assertEquals(SUBSTUDY_ID, externalId.getSubstudyId());
+        assertEquals(externalId.getIdentifier(), EXTERNAL_ID);
+        assertEquals(externalId.getHealthCode(), HEALTH_CODE);
+        assertEquals(externalId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(externalId.getSubstudyId(), SUBSTUDY_ID);
         
-        assertEquals(EXTERNAL_ID, account.getExternalId());
-        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(account.getExternalId(), EXTERNAL_ID);
+        assertEquals(account.getAccountSubstudies().size(), 1);
         
         AccountSubstudy accountSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
-        assertEquals(ID, accountSubstudy.getAccountId());
-        assertEquals(EXTERNAL_ID, accountSubstudy.getExternalId());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, accountSubstudy.getStudyId());
-        assertEquals(SUBSTUDY_ID, accountSubstudy.getSubstudyId());
+        assertEquals(accountSubstudy.getAccountId(), ID);
+        assertEquals(accountSubstudy.getExternalId(), EXTERNAL_ID);
+        assertEquals(accountSubstudy.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(accountSubstudy.getSubstudyId(), SUBSTUDY_ID);
     }
 
-    @Test(expected = EntityAlreadyExistsException.class)
+    @Test(expectedExceptions = EntityAlreadyExistsException.class)
     public void beginAssignExternalIdHealthCodeExistsNotEqual() {
         Account account = Account.create();
         account.setStudyId(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -2820,10 +2820,10 @@ public class ParticipantServiceTest {
         
         ExternalIdentifier externalId = participantService.beginAssignExternalId(account, ID);
         
-        assertEquals(ID, externalId.getIdentifier());
-        assertEquals(HEALTH_CODE, externalId.getHealthCode());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, externalId.getStudyId());
-        assertEquals(ID, account.getExternalId());
+        assertEquals(externalId.getIdentifier(), ID);
+        assertEquals(externalId.getHealthCode(), HEALTH_CODE);
+        assertEquals(externalId.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(account.getExternalId(), ID);
         assertNull(externalId.getSubstudyId());
         assertTrue(account.getAccountSubstudies().isEmpty());
     }
@@ -2842,14 +2842,14 @@ public class ParticipantServiceTest {
         
         ExternalIdentifier externalId = participantService.beginAssignExternalId(account, ID);
         
-        assertEquals(HEALTH_CODE, externalId.getHealthCode());
+        assertEquals(externalId.getHealthCode(), HEALTH_CODE);
         
         // Not changed, but the new external ID is still recorded along with the substudy association
-        assertEquals("legacyExternalId", account.getExternalId());
-        assertEquals(1, account.getAccountSubstudies().size());
+        assertEquals(account.getExternalId(), "legacyExternalId");
+        assertEquals(account.getAccountSubstudies().size(), 1);
         
         AccountSubstudy accountSubstudy = Iterables.getFirst(account.getAccountSubstudies(), null);
-        assertEquals(ID, accountSubstudy.getExternalId());
+        assertEquals(accountSubstudy.getExternalId(), ID);
     }
     
     @Test
@@ -2920,7 +2920,7 @@ public class ParticipantServiceTest {
         Account account = accountCaptor.getValue();
 
         if (canSetStatus) {
-            assertEquals(AccountStatus.ENABLED, account.getStatus());
+            assertEquals(account.getStatus(), AccountStatus.ENABLED);
         } else {
             assertNull(account.getStatus());
         }
@@ -2940,7 +2940,7 @@ public class ParticipantServiceTest {
         Account account = accountCaptor.getValue();
         
         if (rolesThatAreSet != null) {
-            assertEquals(rolesThatAreSet, account.getRoles());
+            assertEquals(account.getRoles(), rolesThatAreSet);
         } else {
             assertEquals(Sets.newHashSet(), account.getRoles());
         }
@@ -2959,7 +2959,7 @@ public class ParticipantServiceTest {
         Account account = accountCaptor.getValue();
         
         if (expected != null) {
-            assertEquals(expected, account.getRoles());
+            assertEquals(account.getRoles(), expected);
         } else {
             assertEquals(Sets.newHashSet(), account.getRoles());
         }

--- a/src/test/java/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
@@ -1,23 +1,26 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.ClientInfo;
@@ -32,9 +35,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReferenceResolverTest {
     
     private static final ClientInfo CLIENT_INFO = ClientInfo.UNKNOWN_CLIENT;
@@ -55,11 +57,11 @@ public class ReferenceResolverTest {
     private static final CompoundActivity COMPOUND_ACTIVITY_SKINNY_REF = new CompoundActivity.Builder()
             .withTaskIdentifier(TASK_ID).build();
     private static final CompoundActivity RESOLVED_COMPOUND_ACTIVITY = new CompoundActivity.Builder()
-        .withSurveyList(Lists.newArrayList(RESOLVED_SURVEY_REF))
-        .withSchemaList(Lists.newArrayList(RESOLVED_SCHEMA_REF)).build();
+        .withSurveyList(ImmutableList.of(RESOLVED_SURVEY_REF))
+        .withSchemaList(ImmutableList.of(RESOLVED_SCHEMA_REF)).build();
     private static final CompoundActivity UNRESOLVED_COMPOUND_ACTIVITY = new CompoundActivity.Builder()
-            .withSurveyList(Lists.newArrayList(UNRESOLVED_SURVEY_REF))
-            .withSchemaList(Lists.newArrayList(UNRESOLVED_SCHEMA_REF)).build();
+            .withSurveyList(ImmutableList.of(UNRESOLVED_SURVEY_REF))
+            .withSchemaList(ImmutableList.of(UNRESOLVED_SCHEMA_REF)).build();
     private static final Survey SURVEY = Survey.create();
     static {
         SURVEY.setGuid(SURVEY_GUID);
@@ -73,13 +75,13 @@ public class ReferenceResolverTest {
     }
     private static final CompoundActivityDefinition RESOLVED_COMPOUND_ACTIVITY_DEF = CompoundActivityDefinition.create();
     static {
-        RESOLVED_COMPOUND_ACTIVITY_DEF.setSurveyList(Lists.newArrayList(RESOLVED_SURVEY_REF));
-        RESOLVED_COMPOUND_ACTIVITY_DEF.setSchemaList(Lists.newArrayList(RESOLVED_SCHEMA_REF));
+        RESOLVED_COMPOUND_ACTIVITY_DEF.setSurveyList(ImmutableList.of(RESOLVED_SURVEY_REF));
+        RESOLVED_COMPOUND_ACTIVITY_DEF.setSchemaList(ImmutableList.of(RESOLVED_SCHEMA_REF));
     }
     private static final CompoundActivityDefinition UNRESOLVED_COMPOUND_ACTIVITY_DEF = CompoundActivityDefinition.create();
     static {
-        UNRESOLVED_COMPOUND_ACTIVITY_DEF.setSurveyList(Lists.newArrayList(UNRESOLVED_SURVEY_REF));
-        UNRESOLVED_COMPOUND_ACTIVITY_DEF.setSchemaList(Lists.newArrayList(UNRESOLVED_SCHEMA_REF));
+        UNRESOLVED_COMPOUND_ACTIVITY_DEF.setSurveyList(ImmutableList.of(UNRESOLVED_SURVEY_REF));
+        UNRESOLVED_COMPOUND_ACTIVITY_DEF.setSchemaList(ImmutableList.of(UNRESOLVED_SCHEMA_REF));
     }
 
     @Mock
@@ -103,8 +105,10 @@ public class ReferenceResolverTest {
     
     private Activity.Builder activityBuilder;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         // All the dependencies are mocks or mutable maps, and can be adjusted per test
         resolver = new ReferenceResolver(compoundActivityDefinitionService, schemaService, surveyService,
                 surveyReferences, schemaReferences, CLIENT_INFO, STUDY_ID);
@@ -112,6 +116,12 @@ public class ReferenceResolverTest {
         scheduledActivity = ScheduledActivity.create();
         
         activityBuilder = new Activity.Builder();
+    }
+    
+    @AfterMethod
+    public void after() {
+        surveyReferences.clear();
+        schemaReferences.clear();
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -19,14 +19,13 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -51,7 +50,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReportServiceTest {
 
     private static final String IDENTIFIER = "MyTestReport";
@@ -112,8 +110,10 @@ public class ReportServiceTest {
     
     ReportTypeResourceList<? extends ReportIndex> indices;
     
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        
         service.setReportDataDao(mockReportDataDao);
         service.setReportIndexDao(mockReportIndexDao);
 
@@ -211,7 +211,7 @@ public class ReportServiceTest {
         doReturn(index).when(mockReportIndexDao).getIndex(key);
         
         ReportIndex retrievedKey = service.getReportIndex(key);
-        assertEquals(key.getIdentifier(), retrievedKey.getIdentifier());
+        assertEquals(retrievedKey.getIdentifier(), key.getIdentifier());
         verify(mockReportIndexDao).getIndex(key);
     }
     
@@ -223,7 +223,7 @@ public class ReportServiceTest {
                 TEST_STUDY, IDENTIFIER, START_DATE, END_DATE);
         
         verify(mockReportDataDao).getReportData(STUDY_REPORT_DATA_KEY, START_DATE, END_DATE);
-        assertEquals(results, retrieved);
+        assertEquals(retrieved, results);
     }
     
     @Test
@@ -240,9 +240,9 @@ public class ReportServiceTest {
             
             verify(mockReportDataDao).getReportData(eq(STUDY_REPORT_DATA_KEY), localDateCaptor.capture(),
                     localDateCaptor.capture());
-            assertEquals(yesterday, localDateCaptor.getAllValues().get(0));
-            assertEquals(today, localDateCaptor.getAllValues().get(1));
-            assertEquals(results, retrieved);
+            assertEquals(localDateCaptor.getAllValues().get(0), yesterday);
+            assertEquals(localDateCaptor.getAllValues().get(1), today);
+            assertEquals(retrieved, results);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }
@@ -256,7 +256,7 @@ public class ReportServiceTest {
                 TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_DATE, END_DATE);
 
         verify(mockReportDataDao).getReportData(PARTICIPANT_REPORT_DATA_KEY, START_DATE, END_DATE);
-        assertEquals(results, retrieved);
+        assertEquals(retrieved, results);
     }
 
     @Test
@@ -273,9 +273,9 @@ public class ReportServiceTest {
             
             verify(mockReportDataDao).getReportData(eq(PARTICIPANT_REPORT_DATA_KEY), localDateCaptor.capture(),
                     localDateCaptor.capture());
-            assertEquals(yesterday, localDateCaptor.getAllValues().get(0));
-            assertEquals(today, localDateCaptor.getAllValues().get(1));
-            assertEquals(results, retrieved);
+            assertEquals(localDateCaptor.getAllValues().get(0), yesterday);
+            assertEquals(localDateCaptor.getAllValues().get(1), today);
+            assertEquals(retrieved, results);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }
@@ -288,11 +288,11 @@ public class ReportServiceTest {
         
         verify(mockReportDataDao).saveReportData(reportDataCaptor.capture());
         ReportData retrieved = reportDataCaptor.getValue();
-        assertEquals(someData, retrieved);
-        assertEquals(STUDY_REPORT_DATA_KEY.getKeyString(), retrieved.getKey());
-        assertEquals("2015-02-10", retrieved.getDate());
-        assertEquals("First", retrieved.getData().get("field1").asText());
-        assertEquals("Name", retrieved.getData().get("field2").asText());
+        assertEquals(retrieved, someData);
+        assertEquals(retrieved.getKey(), STUDY_REPORT_DATA_KEY.getKeyString());
+        assertEquals(retrieved.getDate(), "2015-02-10");
+        assertEquals(retrieved.getData().get("field1").asText(), "First");
+        assertEquals(retrieved.getData().get("field2").asText(), "Name");
         
         verify(mockReportIndexDao).addIndex(new ReportDataKey.Builder()
                 .withStudyIdentifier(TEST_STUDY)
@@ -317,11 +317,11 @@ public class ReportServiceTest {
 
         verify(mockReportDataDao).saveReportData(reportDataCaptor.capture());
         ReportData retrieved = reportDataCaptor.getValue();
-        assertEquals(someData, retrieved);
-        assertEquals(PARTICIPANT_REPORT_DATA_KEY.getKeyString(), retrieved.getKey());
-        assertEquals("2015-02-10", retrieved.getDate());
-        assertEquals("First", retrieved.getData().get("field1").asText());
-        assertEquals("Name", retrieved.getData().get("field2").asText());
+        assertEquals(retrieved, someData);
+        assertEquals(retrieved.getKey(), PARTICIPANT_REPORT_DATA_KEY.getKeyString());
+        assertEquals(retrieved.getDate(), "2015-02-10");
+        assertEquals(retrieved.getData().get("field1").asText(), "First");
+        assertEquals(retrieved.getData().get("field2").asText(), "Name");
         
         verify(mockReportIndexDao).addIndex(new ReportDataKey.Builder()
                 .withHealthCode(HEALTH_CODE)
@@ -364,8 +364,8 @@ public class ReportServiceTest {
         verifyNoMoreInteractions(mockReportDataDao);
         
         ReportDataKey key = reportDataKeyCaptor.getValue();
-        assertEquals(TEST_STUDY, key.getStudyId());
-        assertEquals(IDENTIFIER, key.getIdentifier());
+        assertEquals(key.getStudyId(), TEST_STUDY);
+        assertEquals(key.getIdentifier(), IDENTIFIER);
     }
     
     @Test
@@ -406,7 +406,7 @@ public class ReportServiceTest {
         }
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteStudyReportRecordValidatesDate() {
         service.deleteStudyReportRecord(TEST_STUDY, IDENTIFIER, "");
     }
@@ -435,7 +435,7 @@ public class ReportServiceTest {
         }
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteParticipantReportRecordValidatesDate() {
         service.deleteParticipantReportRecord(TEST_STUDY, IDENTIFIER, "", HEALTH_CODE);
     }
@@ -456,22 +456,22 @@ public class ReportServiceTest {
         }
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void startDateAfterEndDateParticipant() {
         service.getParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE, END_DATE, START_DATE);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void dateRangeTooWideParticipant() {
         service.getParticipantReport(TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_DATE, START_DATE.plusDays(46));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void startDateAfterEndDateStudy() {
         service.getStudyReport(TEST_STUDY, IDENTIFIER, END_DATE, START_DATE);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void dateRangeTooWideStudy() {
         service.getStudyReport(TEST_STUDY, IDENTIFIER, START_DATE, START_DATE.plusDays(46));
     }
@@ -590,8 +590,8 @@ public class ReportServiceTest {
 
         ReportTypeResourceList<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.STUDY);
         
-        assertEquals(IDENTIFIER, indices.getItems().get(0).getIdentifier());
-        assertEquals(ReportType.STUDY, indices.getRequestParams().get("reportType"));
+        assertEquals(indices.getItems().get(0).getIdentifier(), IDENTIFIER);
+        assertEquals(indices.getRequestParams().get("reportType"), ReportType.STUDY);
         verify(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.STUDY);
     }
     
@@ -606,8 +606,8 @@ public class ReportServiceTest {
 
         ReportTypeResourceList<? extends ReportIndex> indices = service.getReportIndices(TEST_STUDY, ReportType.PARTICIPANT);
         
-        assertEquals(IDENTIFIER, indices.getItems().get(0).getIdentifier());
-        assertEquals(ReportType.PARTICIPANT, indices.getRequestParams().get("reportType"));
+        assertEquals(indices.getItems().get(0).getIdentifier(), IDENTIFIER);
+        assertEquals(indices.getRequestParams().get("reportType"), ReportType.PARTICIPANT);
         verify(mockReportIndexDao).getIndices(TEST_STUDY, ReportType.PARTICIPANT);
     }
     
@@ -630,7 +630,7 @@ public class ReportServiceTest {
         verify(mockReportIndexDao).updateIndex(reportIndexCaptor.capture());
         
         ReportIndex captured = reportIndexCaptor.getValue();
-        assertEquals(IDENTIFIER, captured.getIdentifier());
+        assertEquals(captured.getIdentifier(), IDENTIFIER);
         assertTrue(captured.isPublic());
     }
     
@@ -651,11 +651,11 @@ public class ReportServiceTest {
         verify(mockReportIndexDao).updateIndex(reportIndexCaptor.capture());
         
         ReportIndex captured = reportIndexCaptor.getValue();
-        assertEquals(IDENTIFIER, captured.getIdentifier());
+        assertEquals(captured.getIdentifier(), IDENTIFIER);
         assertFalse(captured.isPublic());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateReportIndexValidates() throws Exception { 
         ReportIndex updatedIndex = ReportIndex.create();
         
@@ -670,19 +670,19 @@ public class ReportServiceTest {
                 eq(OFFSET_KEY), eq(PAGE_SIZE));
         
         ReportDataKey key = reportDataKeyCaptor.getValue();
-        assertEquals(HEALTH_CODE, key.getHealthCode());
-        assertEquals(TEST_STUDY, key.getStudyId());
-        assertEquals(ReportType.PARTICIPANT, key.getReportType());
-        assertEquals(IDENTIFIER, key.getIdentifier());
+        assertEquals(key.getHealthCode(), HEALTH_CODE);
+        assertEquals(key.getStudyId(), TEST_STUDY);
+        assertEquals(key.getReportType(), ReportType.PARTICIPANT);
+        assertEquals(key.getIdentifier(), IDENTIFIER);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getParticipantReportV4MinPageEnforced() {
         service.getParticipantReportV4(TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_TIME, END_TIME, OFFSET_KEY,
                 BridgeConstants.API_MINIMUM_PAGE_SIZE - 1);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getParticipantReportV4MaxPageEnforced() {
         service.getParticipantReportV4(TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_TIME, END_TIME, OFFSET_KEY,
                 BridgeConstants.API_MAXIMUM_PAGE_SIZE + 1);
@@ -696,24 +696,24 @@ public class ReportServiceTest {
                 eq(OFFSET_KEY), eq(PAGE_SIZE));
         
         ReportDataKey key = reportDataKeyCaptor.getValue();
-        assertEquals(TEST_STUDY, key.getStudyId());
-        assertEquals(ReportType.STUDY, key.getReportType());
-        assertEquals(IDENTIFIER, key.getIdentifier());
+        assertEquals(key.getStudyId(), TEST_STUDY);
+        assertEquals(key.getReportType(), ReportType.STUDY);
+        assertEquals(key.getIdentifier(), IDENTIFIER);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesPageSizeTooSmallV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, START_TIME, END_TIME, OFFSET_KEY,
                 BridgeConstants.API_MINIMUM_PAGE_SIZE - 1);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesPageSizeTooLargeV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, START_TIME, END_TIME, OFFSET_KEY,
                 BridgeConstants.API_MAXIMUM_PAGE_SIZE + 1);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesTimeZonesEqualV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, START_TIME, END_TIME.withZone(DateTimeZone.UTC), OFFSET_KEY,
                 BridgeConstants.API_DEFAULT_PAGE_SIZE);
@@ -731,26 +731,26 @@ public class ReportServiceTest {
         
         DateTime startTime = startTimeCaptor.getValue();
         DateTime endTime = endTimeCaptor.getValue();
-        assertEquals(now.minusDays(14).toString(), startTime.toString());
-        assertEquals(now.toString(), endTime.toString());
+        assertEquals(startTime.toString(), now.minusDays(14).toString());
+        assertEquals(endTime.toString(), now.toString());
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesStartTimeMissingV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, null, END_TIME, OFFSET_KEY, PAGE_SIZE);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesEndTimeMissingV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, START_TIME, null, OFFSET_KEY, PAGE_SIZE);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesStartTimeAfterEndTimeV4() throws Exception {
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, END_TIME, START_TIME, OFFSET_KEY, PAGE_SIZE);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesTimeZonesIdenticalV4() throws Exception {
         DateTimeZone zone = DateTimeZone.forOffsetHours(4);
         service.getStudyReportV4(TEST_STUDY, IDENTIFIER, END_TIME, START_TIME.withZone(zone), OFFSET_KEY, PAGE_SIZE);
@@ -768,7 +768,7 @@ public class ReportServiceTest {
         when(mockReportIndexDao.getIndex(STUDY_REPORT_DATA_KEY)).thenReturn(index);
         
         ReportIndex retrieved = service.getReportIndex(STUDY_REPORT_DATA_KEY);
-        assertEquals(index, retrieved);
+        assertEquals(retrieved, index);
     }
     
     private ReportIndex setupMismatchedSubstudies(ReportDataKey reportKey, 
@@ -786,21 +786,21 @@ public class ReportServiceTest {
         return index;
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void getStudyReportAuthorizes() {
         setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
         service.getStudyReport(TestConstants.TEST_STUDY, IDENTIFIER, START_DATE, END_DATE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void getParticipantReportAuthorizes() {
         setupMismatchedSubstudies(PARTICIPANT_REPORT_DATA_KEY);
         
         service.getParticipantReport(TestConstants.TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_DATE, END_DATE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void getParticipantReportV4Authorizes() {
         setupMismatchedSubstudies(PARTICIPANT_REPORT_DATA_KEY);
         
@@ -808,13 +808,13 @@ public class ReportServiceTest {
                 START_TIME, END_TIME, null, BridgeConstants.API_MINIMUM_PAGE_SIZE);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getParticipantReportV4VerifiesSameTimeZone() {
         service.getParticipantReportV4(TestConstants.TEST_STUDY, IDENTIFIER, HEALTH_CODE, START_TIME,
                 END_TIME.withZone(DateTimeZone.UTC), null, BridgeConstants.API_MINIMUM_PAGE_SIZE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void getStudyReportV4Authorizes() {
         setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
@@ -822,7 +822,7 @@ public class ReportServiceTest {
                 START_TIME, END_TIME, null, BridgeConstants.API_MINIMUM_PAGE_SIZE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void saveStudyReportAuthorizes() {
         setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
@@ -831,7 +831,7 @@ public class ReportServiceTest {
         service.saveStudyReport(TestConstants.TEST_STUDY, IDENTIFIER, data);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void saveParticipantReportAuthorizes() {
         setupMismatchedSubstudies(PARTICIPANT_REPORT_DATA_KEY);
         
@@ -840,28 +840,28 @@ public class ReportServiceTest {
         service.saveParticipantReport(TestConstants.TEST_STUDY, IDENTIFIER, HEALTH_CODE, data);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteStudyReportAuthorizes() {
         setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
         service.deleteStudyReport(TestConstants.TEST_STUDY, IDENTIFIER);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteStudyReportRecordAuthorizes() {
         setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
         service.deleteStudyReportRecord(TestConstants.TEST_STUDY, IDENTIFIER, START_DATE.toString());
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteParticipantReportAuthorizes() {
         setupMismatchedSubstudies(PARTICIPANT_REPORT_DATA_KEY);
         
         service.deleteParticipantReport(TestConstants.TEST_STUDY, IDENTIFIER, HEALTH_CODE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteParticipantReportRecordAuthorizes() {
         setupMismatchedSubstudies(PARTICIPANT_REPORT_DATA_KEY);
         
@@ -869,7 +869,7 @@ public class ReportServiceTest {
                 IDENTIFIER, START_DATE.toString(), HEALTH_CODE);
     }
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteParticipantReportIndexAuthorizes() {
         ReportDataKey key = new ReportDataKey.Builder()
                    .withHealthCode("dummy-value") 
@@ -881,7 +881,7 @@ public class ReportServiceTest {
         service.deleteParticipantReportIndex(TestConstants.TEST_STUDY, IDENTIFIER);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateReportIndexNotFound() {
         ReportIndex updatedIndex = ReportIndex.create();
         updatedIndex.setPublic(true);
@@ -892,7 +892,7 @@ public class ReportServiceTest {
     }
     
     
-    @Test(expected = UnauthorizedException.class)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void updateReportIndexAuthorizes() {
         ReportIndex index = setupMismatchedSubstudies(STUDY_REPORT_DATA_KEY);
         
@@ -913,8 +913,7 @@ public class ReportServiceTest {
         
         verify(mockReportIndexDao).updateIndex(reportIndexCaptor.capture());
         
-        assertEquals(ImmutableSet.of("substudyA", "substudyE"), 
-                reportIndexCaptor.getValue().getSubstudyIds());
+        assertEquals(reportIndexCaptor.getValue().getSubstudyIds(), ImmutableSet.of("substudyA", "substudyE"));
     }
     
     @Test
@@ -931,7 +930,7 @@ public class ReportServiceTest {
         
         verify(mockReportIndexDao).updateIndex(reportIndexCaptor.capture());
         
-        assertEquals(ImmutableSet.of("substudyA"), reportIndexCaptor.getValue().getSubstudyIds());
+        assertEquals(reportIndexCaptor.getValue().getSubstudyIds(), ImmutableSet.of("substudyA"));
     }
     
     private ReportIndex setupMismatchedSubstudies(ReportDataKey reportKey) {
@@ -944,7 +943,7 @@ public class ReportServiceTest {
         } catch(InvalidEntityException e) {
             verifyNoMoreInteractions(mockReportDataDao);
             String errorMsg = e.getErrors().get(fieldName).get(0);
-            assertEquals(fieldName + " " + message, errorMsg);
+            assertEquals(errorMsg, fieldName + " " + message);
             // Also verify that we didn't call the DAO
             verifyNoMoreInteractions(mockReportDataDao);
         }

--- a/src/test/java/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SchedulePlanServiceMockTest.java
@@ -1,10 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.eq;
@@ -13,14 +8,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.SchedulePlanDao;
@@ -55,7 +56,7 @@ public class SchedulePlanServiceMockTest {
     private SurveyService mockSurveyService;
     private SubstudyService mockSubstudyService;
     
-    @Before
+    @BeforeMethod
     public void before() {
         study = new DynamoStudy();
         study.setIdentifier(TEST_STUDY_IDENTIFIER);
@@ -94,9 +95,9 @@ public class SchedulePlanServiceMockTest {
         verify(mockSchedulePlanDao).createSchedulePlan(any(), spCaptor.capture());
         
         List<Activity> activities = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities();
-        assertEquals("identifier1", activities.get(0).getSurvey().getIdentifier());
+        assertEquals(activities.get(0).getSurvey().getIdentifier(), "identifier1");
         assertNotNull(activities.get(1).getTask());
-        assertEquals("identifier2", activities.get(2).getSurvey().getIdentifier());
+        assertEquals(activities.get(2).getSurvey().getIdentifier(), "identifier2");
     }
     
     @Test
@@ -114,9 +115,9 @@ public class SchedulePlanServiceMockTest {
         verify(mockSchedulePlanDao).updateSchedulePlan(any(), spCaptor.capture());
         
         List<Activity> activities = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities();
-        assertEquals("identifier1", activities.get(0).getSurvey().getIdentifier());
+        assertEquals(activities.get(0).getSurvey().getIdentifier(), "identifier1");
         assertNotNull(activities.get(1).getTask());
-        assertEquals("identifier2", activities.get(2).getSurvey().getIdentifier());
+        assertEquals(activities.get(2).getSurvey().getIdentifier(), "identifier2");
     }
 
     @Test
@@ -133,7 +134,7 @@ public class SchedulePlanServiceMockTest {
         // Verify that this was set.
         String identifier = plan.getStrategy().getAllPossibleSchedules().get(0).getActivities().get(0)
                 .getSurvey().getIdentifier();
-        assertEquals("junkIdentifier", identifier);
+        assertEquals(identifier, "junkIdentifier");
         
         ArgumentCaptor<SchedulePlan> spCaptor = ArgumentCaptor.forClass(SchedulePlan.class);
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
@@ -147,7 +148,7 @@ public class SchedulePlanServiceMockTest {
         // It was not used.
         identifier = spCaptor.getValue().getStrategy().getAllPossibleSchedules().get(0).getActivities().get(0)
                 .getSurvey().getIdentifier();
-        assertNotEquals("junkIdentifier", identifier);
+        assertNotEquals(identifier, "junkIdentifier");
         
     }
     
@@ -169,8 +170,8 @@ public class SchedulePlanServiceMockTest {
         verify(mockSchedulePlanDao).createSchedulePlan(any(), spCaptor.capture());
         
         SchedulePlan updatedPlan = spCaptor.getValue();
-        assertNotEquals("AAA", updatedPlan.getGuid());
-        assertNotEquals(new Long(2L), updatedPlan.getVersion());
+        assertNotEquals(updatedPlan.getGuid(), "AAA");
+        assertNotEquals(updatedPlan.getVersion(), new Long(2L));
         for (Schedule schedule : plan.getStrategy().getAllPossibleSchedules()) {
             for (Activity activity : schedule.getActivities()) {
                 assertFalse( existingActivityGUIDs.contains(activity.getGuid()) );
@@ -186,7 +187,7 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.createSchedulePlan(any(), any())).thenReturn(plan);
         
         plan = service.createSchedulePlan(anotherStudy, plan);
-        assertEquals("another-study", plan.getStudyKey());
+        assertEquals(plan.getStudyKey(), "another-study");
     }
     
     @Test
@@ -198,7 +199,7 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.updateSchedulePlan(any(), any())).thenReturn(plan);
         
         plan = service.updateSchedulePlan(anotherStudy, plan);
-        assertEquals("another-study", plan.getStudyKey());
+        assertEquals(plan.getStudyKey(), "another-study");
     }
     
     @Test
@@ -209,9 +210,13 @@ public class SchedulePlanServiceMockTest {
             service.createSchedulePlan(study, plan);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
-            assertEquals("strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA", e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0));
-            assertEquals("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds 'substudyD' is not in enumeration: <empty>", e.getErrors().get("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds").get(0));
+            assertEquals(
+                    e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0),
+                    "strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest");
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0),
+                    "strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA");
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds").get(0),
+                    "strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds 'substudyD' is not in enumeration: <empty>");
         }
     }
 
@@ -224,9 +229,13 @@ public class SchedulePlanServiceMockTest {
             service.updateSchedulePlan(study, plan);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest", e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0));
-            assertEquals("strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA", e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0));
-            assertEquals("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds 'substudyD' is not in enumeration: <empty>", e.getErrors().get("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds").get(0));
+            assertEquals(
+                    e.getErrors().get("strategy.scheduleCriteria[0].schedule.activities[0].task.identifier").get(0),
+                    "strategy.scheduleCriteria[0].schedule.activities[0].task.identifier 'DDD' is not in enumeration: taskGuid, CCC, tapTest");
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].criteria.allOfGroups").get(0),
+                    "strategy.scheduleCriteria[0].criteria.allOfGroups 'FFF' is not in enumeration: AAA");
+            assertEquals(e.getErrors().get("strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds").get(0),
+                    "strategy.scheduleCriteria[0].criteria.noneOfSubstudyIds 'substudyD' is not in enumeration: <empty>");
         }
     }
     
@@ -236,7 +245,7 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, false)).thenReturn(plans);
         
         List<SchedulePlan> returned = service.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, false);
-        assertEquals(plans, returned);
+        assertEquals(returned, plans);
         
         verify(mockSchedulePlanDao).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, false);
     }
@@ -247,7 +256,7 @@ public class SchedulePlanServiceMockTest {
         when(mockSchedulePlanDao.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, true)).thenReturn(plans);
         
         List<SchedulePlan> returned = service.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, true);
-        assertEquals(plans, returned);
+        assertEquals(returned, plans);
         
         verify(mockSchedulePlanDao).getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, TestConstants.TEST_STUDY, true);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceDuplicateTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -17,12 +17,11 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
@@ -46,7 +45,6 @@ import com.google.common.collect.Lists;
  * to verify de-duplication and the correct fix for any schedule that has no times in it (the time must be set to 
  * a standard time and midnight seems to work regardless of when the timestamp is).
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ScheduledActivityServiceDuplicateTest {
     //"studyKey (S)","guid (S)","label (S)","modifiedOn (N)","strategy (S)","version (N)"
     private static final String[][] SCHEDULE_PLAN_RECORDS = new String[][] {
@@ -160,8 +158,9 @@ public class ScheduledActivityServiceDuplicateTest {
     
     ScheduleContext.Builder contextBuilder;
     
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
         // This is the exact time that Erin contacted the server
         DateTimeUtils.setCurrentMillisFixed(ACTIVITIES_LAST_RETRIEVED_ON.getMillis());
         
@@ -180,7 +179,7 @@ public class ScheduledActivityServiceDuplicateTest {
                 .withUserId("6m7Yj31Pp41yjvoyU5y6RE");
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -278,9 +277,9 @@ public class ScheduledActivityServiceDuplicateTest {
         
         allWithinQueryWindow(activities, context);
         // With persisted tasks included, this finished task is not returned.
-        assertEquals(0, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size());
+        assertEquals(filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size(), 0);
+        assertEquals(filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size(), 1);
+        assertEquals(filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size(), 1);
         assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }
     
@@ -306,9 +305,9 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         
         allWithinQueryWindow(activities, context);
-        assertEquals(0, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size());
+        assertEquals(filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size(), 0);
+        assertEquals(filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size(), 1);
+        assertEquals(filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size(), 1);
         assertNotNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }
     
@@ -329,9 +328,9 @@ public class ScheduledActivityServiceDuplicateTest {
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
         // This one is there...
-        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size());
+        assertEquals(filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size(), 1);
+        assertEquals(filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size(), 1);
+        assertEquals(filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size(), 1);
         // This one hasn't been started, obviously
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }
@@ -352,14 +351,14 @@ public class ScheduledActivityServiceDuplicateTest {
         // There's only one of these and they are set to midnight UTC.
         verify(activityDao).getActivities(any(), any());
         verify(schedulePlanService).getSchedulePlans(any(), any(), eq(false));
-        assertEquals(1, filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size());
-        assertEquals(1, filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size());
-        assertEquals(1, filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size());
+        assertEquals(filterByGuid(activities, "bea8fd5d-7622-451f-a727-f9e37f00e1be").size(), 1);
+        assertEquals(filterByGuid(activities, "6966c3d7-0949-43a8-804e-efc25d0f83e2").size(), 1);
+        assertEquals(filterByGuid(activities, "79cf1788-a087-4fa3-92e4-92e43d9699a7").size(), 1);
         
         // It's adjusted, magically it's still 6/30 I haven't figured out why yet.
         List<ScheduledActivity> list = filterByLabel(activities, "Do Persistent Activity");
-        assertEquals(1, list.size());
-        assertEquals("21e97935-6d64-4cd5-ae70-653caad7b2f9:2016-06-30T12:43:07.951", list.get(0).getGuid());
+        assertEquals(list.size(), 1);
+        assertEquals(list.get(0).getGuid(), "21e97935-6d64-4cd5-ae70-653caad7b2f9:2016-06-30T12:43:07.951");
         // This one hasn't been started, obviously
         assertNull(filterByLabel(activities, "Training Session 1").get(0).getStartedOn());
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceMockTest.java
@@ -1,10 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -20,6 +16,10 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.services.ScheduledActivityService.V3_FILTER;
 import static org.sagebionetworks.bridge.validators.ScheduleContextValidator.MAX_DATE_RANGE_IN_DAYS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,16 +30,15 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
-import org.junit.After;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -77,7 +76,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ScheduledActivityServiceMockTest {
 
     private static final String TIME_PORTION = ":2017-02-23T10:00:00.000";
@@ -127,8 +125,10 @@ public class ScheduledActivityServiceMockTest {
     @Captor
     private ArgumentCaptor<List<ScheduledActivity>> scheduledActivityListCaptor;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         DateTimeUtils.setCurrentMillisFixed(NOW.getMillis());
         
         service = new ScheduledActivityService();
@@ -160,27 +160,27 @@ public class ScheduledActivityServiceMockTest {
         service.setAppConfigService(appConfigService);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityHistoryEnforcesMinPageSize() {
         service.getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, STARTS_ON, ENDS_ON, null, 2);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityHistoryEnforcesMaxPageSize() {
         service.getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, STARTS_ON, ENDS_ON, null, 200);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityHistoryEnforcesFullDateRangeWhenNoStart() {
         service.getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, null, ENDS_ON, null, 40);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityHistoryEnforcesFullDateRangeWhenNoEnd() {
         service.getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, STARTS_ON, null, null, 40);
     }
@@ -221,7 +221,7 @@ public class ScheduledActivityServiceMockTest {
         DateTimeUtils.setCurrentMillisSystem();
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityHistoryEnforcesDateRangeEndAfterStart() {
         service.getActivityHistory(HEALTH_CODE, ACTIVITY_GUID, ENDS_ON, STARTS_ON, null, 200);
     }
@@ -237,7 +237,7 @@ public class ScheduledActivityServiceMockTest {
                 ENDS_ON.withZone(otherTimeZone), null, 100);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void rejectsEndsOnBeforeNow() {
         service.getScheduledActivities(study, new ScheduleContext.Builder()
             .withStudyIdentifier(TEST_STUDY)
@@ -245,7 +245,7 @@ public class ScheduledActivityServiceMockTest {
             .withInitialTimeZone(DateTimeZone.UTC).withEndsOn(NOW.minusSeconds(1)).build());
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void rejectsEndsOnTooFarInFuture() {
         service.getScheduledActivities(study, new ScheduleContext.Builder()
             .withStudyIdentifier(TEST_STUDY)
@@ -254,7 +254,7 @@ public class ScheduledActivityServiceMockTest {
             .withEndsOn(NOW.plusDays(ScheduleContextValidator.MAX_DATE_RANGE_IN_DAYS).plusSeconds(1)).build());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void rejectsListOfActivitiesWithNullElement() {
         ScheduleContext context = createScheduleContext(ENDS_ON).build();
         List<ScheduledActivity> scheduledActivities = TestUtils.runSchedulerForActivities(context);
@@ -263,7 +263,7 @@ public class ScheduledActivityServiceMockTest {
         service.updateScheduledActivities("AAA", scheduledActivities);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void rejectsListOfActivitiesWithTaskThatLacksGUID() {
         ScheduleContext context = createScheduleContext(ENDS_ON).build();
         List<ScheduledActivity> scheduledActivities = TestUtils.runSchedulerForActivities(context);
@@ -289,7 +289,7 @@ public class ScheduledActivityServiceMockTest {
         service.updateScheduledActivities("AAA", scheduledActivities);
         
         verify(activityDao).updateActivities(eq("AAA"), scheduledActivityListCaptor.capture());
-        assertEquals(size, scheduledActivityListCaptor.getValue().size());
+        assertEquals(scheduledActivityListCaptor.getValue().size(), size);
     }
     
     @Test
@@ -320,8 +320,8 @@ public class ScheduledActivityServiceMockTest {
         //noinspection Convert2streamapi
         for (ScheduledActivity activity : activities) {
             if (activity.getActivity().getActivityType() == ActivityType.SURVEY) {
-                assertEquals(SURVEY_CREATED_ON.getMillis(),
-                        activity.getActivity().getSurvey().getCreatedOn().getMillis());
+                assertEquals(activity.getActivity().getSurvey().getCreatedOn().getMillis(),
+                        SURVEY_CREATED_ON.getMillis());
             }
         }
     }
@@ -350,22 +350,22 @@ public class ScheduledActivityServiceMockTest {
         verify(activityEventService, times(2)).publishActivityFinishedEvent(publishCapture.capture());
         
         List<DynamoScheduledActivity> dbActivities = (List<DynamoScheduledActivity>)updateCapture.getValue();
-        assertEquals(4, dbActivities.size());
+        assertEquals(dbActivities.size(), 4);
         
         // Correct saved activities
-        assertEquals(scheduledActivities.get(0).getGuid(), dbActivities.get(0).getGuid());
-        assertEquals(scheduledActivities.get(1).getGuid(), dbActivities.get(1).getGuid());
-        assertEquals(scheduledActivities.get(2).getGuid(), dbActivities.get(2).getGuid());
-        assertEquals(scheduledActivities.get(3).getClientData(), dbActivities.get(3).getClientData());
+        assertEquals(dbActivities.get(0).getGuid(), scheduledActivities.get(0).getGuid());
+        assertEquals(dbActivities.get(1).getGuid(), scheduledActivities.get(1).getGuid());
+        assertEquals(dbActivities.get(2).getGuid(), scheduledActivities.get(2).getGuid());
+        assertEquals(dbActivities.get(3).getClientData(), scheduledActivities.get(3).getClientData());
         
         // Correct published activities.
         ScheduledActivity publishedActivity2 = publishCapture.getAllValues().get(0);
-        assertEquals(scheduledActivities.get(2).getGuid(), publishedActivity2.getGuid());
+        assertEquals(publishedActivity2.getGuid(), scheduledActivities.get(2).getGuid());
         ScheduledActivity publishedActivity1 = publishCapture.getAllValues().get(1);
-        assertEquals(scheduledActivities.get(1).getGuid(), publishedActivity1.getGuid());
+        assertEquals(publishedActivity1.getGuid(), scheduledActivities.get(1).getGuid());
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityListsWithTooLargeClientDataRejected() throws Exception {
         JsonNode node = TestUtils.getClientData();
         ArrayNode array = JsonNodeFactory.instance.arrayNode();
@@ -380,7 +380,7 @@ public class ScheduledActivityServiceMockTest {
         service.updateScheduledActivities("BBB", activities);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityListWithNullsRejected() {
         ScheduleContext context = createScheduleContext(ENDS_ON).build();
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(context);
@@ -389,7 +389,7 @@ public class ScheduledActivityServiceMockTest {
         service.updateScheduledActivities("BBB", activities);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void activityListWithNullGuidRejected() {
         ScheduleContext context = createScheduleContext(ENDS_ON).build();
         List<ScheduledActivity> activities = TestUtils.runSchedulerForActivities(context);
@@ -412,12 +412,12 @@ public class ScheduledActivityServiceMockTest {
         verify(activityDao).deleteActivitiesForUser("AAA");
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void deleteActivitiesForUserRejectsBadValue() {
         service.deleteActivitiesForUser(null);
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void deleteActivitiesForSchedulePlanRejectsBadValue() {
         service.deleteActivitiesForUser("  ");
     }
@@ -610,8 +610,8 @@ public class ScheduledActivityServiceMockTest {
         when(activityDao.getActivities(eq(TIME_ZONE), any())).thenReturn(db);
         
         List<ScheduledActivity> returnedActivities = service.getScheduledActivities(study, createScheduleContext(NOW).build());
-        assertEquals(1, returnedActivities.size());
-        assertEquals(5678, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertEquals(returnedActivities.size(), 1);
+        assertEquals(returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis(), 5678);
         
         verify(activityDao).getActivities(eq(TIME_ZONE), any());
     }
@@ -640,8 +640,8 @@ public class ScheduledActivityServiceMockTest {
         when(activityDao.getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt())).thenReturn(page);
         
         List<ScheduledActivity> returnedActivities = service.getScheduledActivitiesV4(study, createScheduleContext(NOW).build());
-        assertEquals(1, returnedActivities.size());
-        assertEquals(5678, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertEquals(returnedActivities.size(), 1);
+        assertEquals(returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis(), 5678);
         
         verify(activityDao).getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt());
     }
@@ -671,8 +671,8 @@ public class ScheduledActivityServiceMockTest {
         when(activityDao.getActivities(eq(TIME_ZONE), any())).thenReturn(db);
         
         List<ScheduledActivity> returnedActivities = service.getScheduledActivities(study, createScheduleContext(NOW).build());
-        assertEquals(1, returnedActivities.size());
-        assertEquals(1234, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertEquals(returnedActivities.size(), 1);
+        assertEquals(returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis(), 1234);
         assertNotNull(returnedActivities.get(0).getClientData());
         
         verify(activityDao).getActivities(eq(TIME_ZONE), any());
@@ -705,8 +705,8 @@ public class ScheduledActivityServiceMockTest {
         when(activityDao.getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt())).thenReturn(page);
         
         List<ScheduledActivity> returnedActivities = service.getScheduledActivitiesV4(study, createScheduleContext(NOW).build());
-        assertEquals(1, returnedActivities.size());
-        assertEquals(1234, returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis());
+        assertEquals(returnedActivities.size(), 1);
+        assertEquals(returnedActivities.get(0).getActivity().getSurvey().getCreatedOn().getMillis(), 1234);
         assertNotNull(returnedActivities.get(0).getClientData());
         
         verify(activityDao).getActivityHistoryV2(any(), any(), any(), any(), any(), anyInt());
@@ -727,10 +727,10 @@ public class ScheduledActivityServiceMockTest {
         list.get(3).setLocalExpiresOn(NOW.toLocalDateTime().minusDays(1));
         
         List<ScheduledActivity> result = service.orderActivities(list, V3_FILTER);
-        assertEquals(3, result.size());
-        assertEquals(time1, result.get(0).getScheduledOn());
-        assertEquals(time2, result.get(1).getScheduledOn());
-        assertEquals(time4, result.get(2).getScheduledOn());
+        assertEquals(result.size(), 3);
+        assertEquals(result.get(0).getScheduledOn(), time1);
+        assertEquals(result.get(1).getScheduledOn(), time2);
+        assertEquals(result.get(2).getScheduledOn(), time4);
         
     }
     
@@ -759,7 +759,7 @@ public class ScheduledActivityServiceMockTest {
     // Verify in the next two tests that the v3 api is being validated the same way the v2 api is being validated.
     // They share the same code path so it isn't necessary to test every single validation.
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getActivityHistoryV3ValidatesPageSize() {
         DateTimeZone timeZone = DateTimeZone.forOffsetHours(-4);
         DateTime startsOn = DateTime.now(timeZone).minusDays(1);
@@ -768,7 +768,7 @@ public class ScheduledActivityServiceMockTest {
         service.getActivityHistory(HEALTH_CODE, ActivityType.SURVEY, "GUID", startsOn, endsOn, "offsetKey", 20000);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getActivityHistoryV3ValidatesDateRange() {
         DateTimeZone timeZone = DateTimeZone.forOffsetHours(-4);
         DateTime startsOn = DateTime.now(timeZone).minusDays(1);
@@ -808,8 +808,8 @@ public class ScheduledActivityServiceMockTest {
                 .thenReturn(oneTimeActivity);
         
         List<ScheduledActivity> scheduledActivities = service.getScheduledActivitiesV4(study, context);
-        assertEquals(1, scheduledActivities.size());
-        assertEquals(guid, scheduledActivities.get(0).getGuid());
+        assertEquals(scheduledActivities.size(), 1);
+        assertEquals(scheduledActivities.get(0).getGuid(), guid);
         assertNotNull(scheduledActivities.get(0).getStartedOn());
         assertNotNull(scheduledActivities.get(0).getFinishedOn());
         
@@ -829,7 +829,7 @@ public class ScheduledActivityServiceMockTest {
 
         Set<String> expectedGuids = Arrays.stream(guids).map(guid -> guid + TIME_PORTION).collect(toSet());
         
-        assertEquals(expectedGuids, activityGuids);
+        assertEquals(activityGuids, expectedGuids);
     }
     
     private SchedulePlan schedulePlan(String activityGuid) {
@@ -985,7 +985,7 @@ public class ScheduledActivityServiceMockTest {
         List<ScheduledActivity> schActivities = service.getScheduledActivities(study, context);
 
         // See BRIDGE-1603
-        assertEquals(6, schActivities.size());
+        assertEquals(schActivities.size(), 6);
         
         // Not a parkinson patient, get 1 task
         context = new ScheduleContext.Builder()
@@ -993,7 +993,7 @@ public class ScheduledActivityServiceMockTest {
                 .withUserDataGroups(Sets.newHashSet("test_user")).build();
         schActivities = service.getScheduledActivities(study, context);
         // See BRIDGE-1603
-        assertEquals(2, schActivities.size());
+        assertEquals(schActivities.size(), 2);
     }
     
     @Test
@@ -1033,7 +1033,7 @@ public class ScheduledActivityServiceMockTest {
         
         assertTrue(schActivities.size() > 1);
         for (ScheduledActivity act : schActivities) {
-            assertEquals("guid", act.getActivity().getSurvey().getGuid());
+            assertEquals(act.getActivity().getSurvey().getGuid(), "guid");
         }
         
         verify(surveyService, times(1)).getSurveyMostRecentlyPublishedVersion(any(), any(), eq(false));
@@ -1053,10 +1053,10 @@ public class ScheduledActivityServiceMockTest {
         schedule.addTimes("23:00");
         
         String timestamp = firstTimeStampFor(-8, -8, schedule);
-        assertEquals("2017-02-19T23:00:00.000-08:00", timestamp);
+        assertEquals(timestamp, "2017-02-19T23:00:00.000-08:00");
         
         timestamp = firstTimeStampFor(9, 9, schedule);
-        assertEquals("2017-02-20T23:00:00.000+09:00", timestamp);
+        assertEquals(timestamp, "2017-02-20T23:00:00.000+09:00");
     }
     
     // Scheduler is interpreting the event to the right local time. Examples:
@@ -1070,10 +1070,10 @@ public class ScheduledActivityServiceMockTest {
         schedule.setDelay(Period.parse("PT1H"));
         
         String timestamp = firstTimeStampFor(-8, -8, schedule);
-        assertEquals("2017-02-19T18:00:00.000-08:00", timestamp);
+        assertEquals(timestamp, "2017-02-19T18:00:00.000-08:00");
         
         timestamp = firstTimeStampFor(9, 9, schedule);
-        assertEquals("2017-02-20T11:00:00.000+09:00", timestamp);
+        assertEquals(timestamp, "2017-02-20T11:00:00.000+09:00");
     }
 
     // Local times having timezone correctly applied. Examples:
@@ -1087,10 +1087,10 @@ public class ScheduledActivityServiceMockTest {
         schedule.setDelay(Period.parse("PT1H"));
         
         String timestamp = firstTimeStampFor(-8, +9, schedule);
-        assertEquals("2017-02-19T18:00:00.000+09:00", timestamp);
+        assertEquals(timestamp, "2017-02-19T18:00:00.000+09:00");
         
         timestamp = firstTimeStampFor(9, -8, schedule);
-        assertEquals("2017-02-20T11:00:00.000-08:00", timestamp);
+        assertEquals(timestamp, "2017-02-20T11:00:00.000-08:00");
     }
     
     @Test
@@ -1161,7 +1161,7 @@ public class ScheduledActivityServiceMockTest {
         
         verify(activityDao).saveActivities(scheduledActivityListCaptor.capture());
         List<ScheduledActivity> activitiesOnSave = scheduledActivityListCaptor.getValue();
-        assertEquals(toGuids(activities), toGuids(activitiesOnSave));
+        assertEquals(toGuids(activitiesOnSave), toGuids(activities));
     }
     
     /** 
@@ -1190,7 +1190,7 @@ public class ScheduledActivityServiceMockTest {
         ScheduleContext context = createScheduleContext(ENDS_ON).build();
         List<ScheduledActivity> activities = service.getScheduledActivitiesV4(study, context);
 
-        assertEquals(ScheduledActivityStatus.AVAILABLE, activities.get(0).getStatus());
+        assertEquals(activities.get(0).getStatus(), ScheduledActivityStatus.AVAILABLE);
         
         List<ScheduledActivity> dbActivities = Lists.newArrayList();
         
@@ -1205,9 +1205,9 @@ public class ScheduledActivityServiceMockTest {
         context = createContextWithFinishedEvent(firstFinishedActivity);
         activities = service.getScheduledActivitiesV4(study, context);
         
-        assertEquals(2, activities.size());
-        assertEquals(firstFinishedActivity, activities.get(0));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, activities.get(1).getStatus());
+        assertEquals(activities.size(), 2);
+        assertEquals(activities.get(0), firstFinishedActivity);
+        assertEquals(activities.get(1).getStatus(), ScheduledActivityStatus.AVAILABLE);
 
         // finish this second task.
         ScheduledActivity secondFinishedActivity = activities.get(1);
@@ -1220,10 +1220,10 @@ public class ScheduledActivityServiceMockTest {
         context = createContextWithFinishedEvent(secondFinishedActivity);
         activities = service.getScheduledActivitiesV4(study, context);
 
-        assertEquals(3, activities.size());
-        assertEquals(firstFinishedActivity, activities.get(0));
-        assertEquals(secondFinishedActivity, activities.get(1));
-        assertEquals(ScheduledActivityStatus.AVAILABLE, activities.get(2).getStatus());
+        assertEquals(activities.size(), 3);
+        assertEquals(activities.get(0), firstFinishedActivity);
+        assertEquals(activities.get(1), secondFinishedActivity);
+        assertEquals(activities.get(2).getStatus(), ScheduledActivityStatus.AVAILABLE);
     }
 
     private ScheduleContext createContextWithFinishedEvent(ScheduledActivity finishedActivity) {
@@ -1261,7 +1261,7 @@ public class ScheduledActivityServiceMockTest {
         assertTrue(activitiesOnSave.isEmpty());
         
         // The returned list is the same as the db list we created earlier
-        assertEquals(toGuids(dbActivities), toGuids(activities));
+        assertEquals(toGuids(activities), toGuids(dbActivities));
     }
     
     // BRIDGE-1964. This test reproduces the stack trace in production. 

--- a/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.eq;
@@ -12,6 +9,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
@@ -19,8 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -65,7 +65,7 @@ public class ScheduledActivityServiceResolveLinksTest {
     private ScheduledActivityService scheduledActivityService;
     private AppConfigService appConfigService;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Mock compound activity definition service. This compound activity contains a schema ref with an unresolved
         // revision, and a survey reference with no createdOn (published survey).
@@ -194,8 +194,8 @@ public class ScheduledActivityServiceResolveLinksTest {
         List<ScheduledActivity> scheduledActivityList = scheduledActivityService.scheduleActivitiesForPlans(
                 SCHEDULE_CONTEXT);
         CompoundActivity compoundActivity = scheduledActivityList.get(0).getActivity().getCompoundActivity();
-        assertEquals("surveyRefId", compoundActivity.getSurveyList().get(0).getIdentifier());
-        assertEquals((Integer)3, compoundActivity.getSchemaList().get(0).getRevision());
+        assertEquals(compoundActivity.getSurveyList().get(0).getIdentifier(), "surveyRefId");
+        assertEquals(compoundActivity.getSchemaList().get(0).getRevision(), (Integer)3);
 
         // Validate backends. We only called compound activity, schema, and survey services once.
         verify(mockCompoundActivityDefinitionService, times(1)).getCompoundActivityDefinition(any(), any());
@@ -267,7 +267,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             CompoundActivity compoundActivity = oneScheduledActivity.getActivity().getCompoundActivity();
-            assertEquals(COMPOUND_ACTIVITY_REF_TASK_ID, compoundActivity.getTaskIdentifier());
+            assertEquals(compoundActivity.getTaskIdentifier(), COMPOUND_ACTIVITY_REF_TASK_ID);
             assertTrue(compoundActivity.getSchemaList().isEmpty());
             assertTrue(compoundActivity.getSurveyList().isEmpty());
         }
@@ -303,7 +303,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             CompoundActivity compoundActivity = oneScheduledActivity.getActivity().getCompoundActivity();
-            assertEquals(COMPOUND_ACTIVITY_REF_TASK_ID, compoundActivity.getTaskIdentifier());
+            assertEquals(compoundActivity.getTaskIdentifier(), COMPOUND_ACTIVITY_REF_TASK_ID);
             assertTrue(compoundActivity.getSchemaList().isEmpty());
             assertTrue(compoundActivity.getSurveyList().isEmpty());
         }
@@ -320,16 +320,16 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             CompoundActivity compoundActivity = oneScheduledActivity.getActivity().getCompoundActivity();
-            assertEquals(COMPOUND_ACTIVITY_REF_TASK_ID, compoundActivity.getTaskIdentifier());
+            assertEquals(compoundActivity.getTaskIdentifier(), COMPOUND_ACTIVITY_REF_TASK_ID);
 
-            assertEquals(1, compoundActivity.getSchemaList().size());
-            assertEquals(SCHEMA_ID, compoundActivity.getSchemaList().get(0).getId());
-            assertEquals(SCHEMA_REV, compoundActivity.getSchemaList().get(0).getRevision().intValue());
+            assertEquals(compoundActivity.getSchemaList().size(), 1);
+            assertEquals(compoundActivity.getSchemaList().get(0).getId(), SCHEMA_ID);
+            assertEquals(compoundActivity.getSchemaList().get(0).getRevision().intValue(), SCHEMA_REV);
 
-            assertEquals(1, compoundActivity.getSurveyList().size());
-            assertEquals(SURVEY_ID, compoundActivity.getSurveyList().get(0).getIdentifier());
-            assertEquals(SURVEY_GUID, compoundActivity.getSurveyList().get(0).getGuid());
-            assertEquals(SURVEY_CREATED_ON_MILLIS, compoundActivity.getSurveyList().get(0).getCreatedOn().getMillis());
+            assertEquals(compoundActivity.getSurveyList().size(), 1);
+            assertEquals(compoundActivity.getSurveyList().get(0).getIdentifier(), SURVEY_ID);
+            assertEquals(compoundActivity.getSurveyList().get(0).getGuid(), SURVEY_GUID);
+            assertEquals(compoundActivity.getSurveyList().get(0).getCreatedOn().getMillis(), SURVEY_CREATED_ON_MILLIS);
         }
     }
 
@@ -390,8 +390,8 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             SurveyReference surveyRef = oneScheduledActivity.getActivity().getSurvey();
-            assertEquals(SURVEY_ID, surveyRef.getIdentifier());
-            assertEquals(SURVEY_GUID, surveyRef.getGuid());
+            assertEquals(surveyRef.getIdentifier(), SURVEY_ID);
+            assertEquals(surveyRef.getGuid(), SURVEY_GUID);
             assertNull(surveyRef.getCreatedOn());
         }
 
@@ -407,9 +407,9 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             SurveyReference surveyRef = oneScheduledActivity.getActivity().getSurvey();
-            assertEquals(SURVEY_ID, surveyRef.getIdentifier());
-            assertEquals(SURVEY_GUID, surveyRef.getGuid());
-            assertEquals(SURVEY_CREATED_ON_MILLIS, surveyRef.getCreatedOn().getMillis());
+            assertEquals(surveyRef.getIdentifier(), SURVEY_ID);
+            assertEquals(surveyRef.getGuid(), SURVEY_GUID);
+            assertEquals(surveyRef.getCreatedOn().getMillis(), SURVEY_CREATED_ON_MILLIS);
         }
     }
 
@@ -474,7 +474,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             SchemaReference resolvedSchemaRef = oneScheduledActivity.getActivity().getTask().getSchema();
-            assertEquals(SCHEMA_ID, resolvedSchemaRef.getId());
+            assertEquals(resolvedSchemaRef.getId(), SCHEMA_ID);
             assertNull(resolvedSchemaRef.getRevision());
         }
 
@@ -490,8 +490,8 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             SchemaReference schemaRef = oneScheduledActivity.getActivity().getTask().getSchema();
-            assertEquals(SCHEMA_ID, schemaRef.getId());
-            assertEquals(SCHEMA_REV, schemaRef.getRevision().intValue());
+            assertEquals(schemaRef.getId(), SCHEMA_ID);
+            assertEquals(schemaRef.getRevision().intValue(), SCHEMA_REV);
         }
     }
 
@@ -510,7 +510,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         verifyActivityListSizeAndLabels(scheduledActivityList);
         for (ScheduledActivity oneScheduledActivity : scheduledActivityList) {
             TaskReference taskRef = oneScheduledActivity.getActivity().getTask();
-            assertEquals(TASK_ID, taskRef.getIdentifier());
+            assertEquals(taskRef.getIdentifier(), TASK_ID);
             assertNull(taskRef.getSchema());
         }
 
@@ -521,8 +521,8 @@ public class ScheduledActivityServiceResolveLinksTest {
     }
 
     private static void verifyActivityListSizeAndLabels(List<ScheduledActivity> scheduledActivityList) {
-        assertEquals(2, scheduledActivityList.size());
-        assertEquals(ACTIVITY_LABEL_PREFIX + "1", scheduledActivityList.get(0).getActivity().getLabel());
-        assertEquals(ACTIVITY_LABEL_PREFIX + "2", scheduledActivityList.get(1).getActivity().getLabel());
+        assertEquals(scheduledActivityList.size(), 2);
+        assertEquals(scheduledActivityList.get(0).getActivity().getLabel(), ACTIVITY_LABEL_PREFIX + "1");
+        assertEquals(scheduledActivityList.get(1).getActivity().getLabel(), ACTIVITY_LABEL_PREFIX + "2");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.FileInputStream;
 import java.util.List;
@@ -14,8 +14,6 @@ import java.util.List;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.simpleemail.model.MessageRejectedException;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -38,6 +36,8 @@ import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
 import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
 import com.google.common.base.Charsets;
 import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Set-up here for consent-specific tests is extensive, so tests for the participant roster
@@ -58,7 +58,7 @@ public class SendMailViaAmazonServiceConsentTest {
     private String consentBodyTemplate;
     private Subpopulation subpopulation;
     
-    @Before
+    @BeforeMethod
     public void setUp() throws Exception {
         consentBodyTemplate = IOUtils.toString(new FileInputStream(new ClassPathResource(
                 "conf/study-defaults/consent-page.xhtml").getFile()));
@@ -119,16 +119,16 @@ public class SendMailViaAmazonServiceConsentTest {
 
         // validate from
         SendRawEmailRequest req = argument.getValue();
-        assertEquals("Correct sender", FROM_STUDY_AS_FORMATTED, req.getSource());
+        assertEquals(req.getSource(), FROM_STUDY_AS_FORMATTED, "Correct sender");
 
         // validate to
         List<String> toList = req.getDestinations();
-        assertEquals("Correct number of recipients", 1, toList.size());
-        assertEquals("Correct recipient", "test-user@sagebase.org", toList.get(0));
+        assertEquals(toList.size(), 1, "Correct number of recipients");
+        assertEquals(toList.get(0), "test-user@sagebase.org", "Correct recipient");
 
         // Validate message content. MIME message must be ASCII
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.US_ASCII);
-        assertTrue("Contains consent content", rawMessage.contains("Body of Template"));
+        assertTrue(rawMessage.contains("Body of Template"), "Contains consent content");
     }
 
     @Test
@@ -161,23 +161,23 @@ public class SendMailViaAmazonServiceConsentTest {
 
         // validate from
         SendRawEmailRequest req = argument.getValue();
-        assertEquals("Correct sender", FROM_STUDY_AS_FORMATTED, req.getSource());
+        assertEquals(req.getSource(), FROM_STUDY_AS_FORMATTED, "Correct sender");
 
         // validate to
         List<String> toList = req.getDestinations();
-        assertEquals("Correct number of recipients", 1, toList.size());
-        assertEquals("Correct recipient", "test-user@sagebase.org", toList.get(0));
+        assertEquals(toList.size(), 1, "Correct number of recipients");
+        assertEquals(toList.get(0), "test-user@sagebase.org", "Correct recipient");
 
         // Validate message content. MIME message must be ASCII
         String rawMessage = new String(req.getRawMessage().getData().array(), Charsets.US_ASCII);
         // The  HTML
-        assertTrue("Contains body text", rawMessage.contains("Content-Type: text/html; charset=utf-8"));
-        assertTrue("Contains body template", rawMessage.contains("Body of Template"));
+        assertTrue(rawMessage.contains("Content-Type: text/html; charset=utf-8"), "Contains body text");
+        assertTrue(rawMessage.contains("Body of Template"), "Contains body template");
         
         // The PDF attachment
-        assertTrue("Contains PDF attachment", rawMessage.contains("Content-Type: application/pdf; name=consent.pdf"));
-        assertTrue("Contains correct disposition", rawMessage.contains("Content-Disposition: attachment; filename=consent.pdf"));
-        assertTrue("Contains base 64 encoded image", rawMessage.contains("JVBERi0xLjQKJeLjz9"));
+        assertTrue(rawMessage.contains("Content-Type: application/pdf; name=consent.pdf"), "Contains PDF attachment");
+        assertTrue(rawMessage.contains("Content-Disposition: attachment; filename=consent.pdf"), "Contains correct disposition");
+        assertTrue(rawMessage.contains("JVBERi0xLjQKJeLjz9"), "Contains base 64 encoded image");
     }
 
     @Test
@@ -209,7 +209,7 @@ public class SendMailViaAmazonServiceConsentTest {
         verify(emailClient).sendRawEmail(any());
     }
 
-    @Test(expected = BridgeServiceException.class)
+    @Test(expectedExceptions = BridgeServiceException.class)
     public void otherExceptionsPropagated() {
         // mock email client with exception
         when(emailClient.sendRawEmail(notNull())).thenThrow(AmazonServiceException.class);

--- a/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
@@ -1,15 +1,14 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
@@ -20,7 +19,6 @@ import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SendMailViaAmazonServiceTest {
 
     private static final String SUPPORT_EMAIL = "email@email.com";
@@ -39,8 +37,10 @@ public class SendMailViaAmazonServiceTest {
     @Mock
     private SendRawEmailResult result;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         study = Study.create();
         study.setName("Name");
         study.setSupportEmail(SUPPORT_EMAIL);
@@ -63,7 +63,7 @@ public class SendMailViaAmazonServiceTest {
             service.sendEmail(provider);
             fail("Should have thrown exception");
         } catch(BridgeServiceException e) {
-            assertEquals(SendMailViaAmazonService.UNVERIFIED_EMAIL_ERROR, e.getMessage());
+            assertEquals(e.getMessage(), SendMailViaAmazonService.UNVERIFIED_EMAIL_ERROR);
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID;
 import static org.sagebionetworks.bridge.models.accounts.SharingScope.ALL_QUALIFIED_RESEARCHERS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 import java.util.List;
 import java.util.Map;
@@ -16,11 +16,11 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -35,7 +35,6 @@ import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SessionUpdateServiceTest {
     private static final String HEALTH_CODE = "health-code";
     private static final StudyParticipant EMPTY_PARTICIPANT = new StudyParticipant.Builder()
@@ -61,8 +60,10 @@ public class SessionUpdateServiceTest {
     
     private SessionUpdateService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service = new SessionUpdateService();
         service.setConsentService(mockConsentService);
         service.setCacheProvider(mockCacheProvider);
@@ -77,7 +78,7 @@ public class SessionUpdateServiceTest {
         service.updateTimeZone(session, timeZone);
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(timeZone, session.getParticipant().getTimeZone());
+        assertEquals(session.getParticipant().getTimeZone(), timeZone);
     }
     
     @Test
@@ -101,8 +102,8 @@ public class SessionUpdateServiceTest {
 
         // Verify saved session.
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals("es", session.getParticipant().getLanguages().iterator().next());
-        assertSame(CONSENT_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getParticipant().getLanguages().iterator().next(), "es");
+        assertSame(session.getConsentStatuses(), CONSENT_STATUS_MAP);
 
         // Verify notification service.
         verify(mockNotificationTopicService).manageCriteriaBasedSubscriptions(API_STUDY_ID, context, HEALTH_CODE);
@@ -116,7 +117,7 @@ public class SessionUpdateServiceTest {
         service.updateExternalId(session, externalId);
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals("someExternalId", session.getParticipant().getExternalId());
+        assertEquals(session.getParticipant().getExternalId(), "someExternalId");
     }
     
     @Test
@@ -138,8 +139,8 @@ public class SessionUpdateServiceTest {
 
         // Verify saved session.
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(EMPTY_PARTICIPANT, session.getParticipant());
-        assertSame(CONSENT_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getParticipant(), EMPTY_PARTICIPANT);
+        assertSame(session.getConsentStatuses(), CONSENT_STATUS_MAP);
 
         // Verify notification service.
         verify(mockNotificationTopicService).manageCriteriaBasedSubscriptions(API_STUDY_ID, context, HEALTH_CODE);
@@ -157,8 +158,8 @@ public class SessionUpdateServiceTest {
         service.updateParticipant(session, context, participant);
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(participant, session.getParticipant());
-        assertEquals(statuses, session.getConsentStatuses());
+        assertEquals(session.getParticipant(), participant);
+        assertEquals(session.getConsentStatuses(), statuses);
     }
     
     @Test
@@ -183,8 +184,8 @@ public class SessionUpdateServiceTest {
 
         // Verify saved session.
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(dataGroups, session.getParticipant().getDataGroups());
-        assertSame(CONSENT_STATUS_MAP, session.getConsentStatuses());
+        assertEquals(session.getParticipant().getDataGroups(), dataGroups);
+        assertSame(session.getConsentStatuses(), CONSENT_STATUS_MAP);
 
         // Verify notification service.
         verify(mockNotificationTopicService).manageCriteriaBasedSubscriptions(API_STUDY_ID, context, HEALTH_CODE);
@@ -200,7 +201,7 @@ public class SessionUpdateServiceTest {
         service.updateStudy(session, newStudy);
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(newStudy, session.getStudyIdentifier());
+        assertEquals(session.getStudyIdentifier(), newStudy);
     }
     
     @Test
@@ -226,6 +227,6 @@ public class SessionUpdateServiceTest {
         service.updateSharingScope(session, ALL_QUALIFIED_RESEARCHERS);
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(ALL_QUALIFIED_RESEARCHERS, session.getParticipant().getSharingScope());
+        assertEquals(session.getParticipant().getSharingScope(), ALL_QUALIFIED_RESEARCHERS);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SharedModuleMetadataServiceTest.java
@@ -1,10 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -14,6 +9,11 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_STUDY_ID;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,14 +22,14 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dao.SharedModuleMetadataDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -39,7 +39,6 @@ import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
 import org.sagebionetworks.bridge.models.sharedmodules.SharedModuleMetadata;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SharedModuleMetadataServiceTest {
     private static final String MODULE_ID = "test-module";
     private static final String MODULE_NAME = "Test Module";
@@ -59,42 +58,44 @@ public class SharedModuleMetadataServiceTest {
     @Spy
     private SharedModuleMetadataService svc;
 
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         svc.setMetadataDao(mockDao);
         svc.setUploadSchemaService(mockUploadSchemaService);
         svc.setSurveyService(mockSurveyService);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createNullId() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         svcInputMetadata.setId(null);
         svc.createMetadata(svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createEmptyId() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         svcInputMetadata.setId("");
         svc.createMetadata(svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createBlankId() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         svcInputMetadata.setId("   ");
         svc.createMetadata(svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createNotFoundSchema() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         doThrow(EntityNotFoundException.class).when(mockUploadSchemaService).getUploadSchemaByIdAndRev(SHARED_STUDY_ID, SCHEMA_ID, SCHEMA_REV);
         svc.createMetadata(svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createNotFoundSurvey() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         svcInputMetadata.setSchemaId(null);
@@ -104,7 +105,7 @@ public class SharedModuleMetadataServiceTest {
         svc.createMetadata(svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createSurveyWithInvalidStudyId() {
         GuidCreatedOnVersionHolder holder = new GuidCreatedOnVersionHolderImpl("some-id", 1L);
         when(mockSurveyService.getSurvey(eq(new StudyIdentifierImpl("shared")), eq(holder), eq(false), eq(false))).thenReturn(null);
@@ -193,28 +194,28 @@ public class SharedModuleMetadataServiceTest {
 
         // Validate we set the version on the metadata we send do the dao.
         SharedModuleMetadata daoInputMetadata = daoInputMetadataCaptor.getValue();
-        assertEquals(expectedVersion, daoInputMetadata.getVersion());
+        assertEquals(daoInputMetadata.getVersion(), expectedVersion);
 
         // Validate DAO input is also svcOutput.
-        assertSame(daoOutputMetadata, svcOutputMetadata);
+        assertSame(svcOutputMetadata, daoOutputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsPermanentlyNullId() {
         svc.deleteMetadataByIdAllVersionsPermanently(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsPermanentlyEmptyId() {
         svc.deleteMetadataByIdAllVersionsPermanently("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsPermanentlyBlankId() {
         svc.deleteMetadataByIdAllVersionsPermanently("   ");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAllVersionsPermanentlyNotFound() {
         svc.deleteMetadataByIdAllVersionsPermanently(MODULE_ID);
     }
@@ -229,36 +230,36 @@ public class SharedModuleMetadataServiceTest {
         verify(mockDao).queryMetadata(eq("id=:id"), parametersCaptor.capture());
         verify(mockDao).deleteMetadataByIdAllVersionsPermanently(MODULE_ID);
         
-        assertEquals(1, parametersCaptor.getValue().size());
-        assertEquals(MODULE_ID, parametersCaptor.getValue().get("id"));
+        assertEquals(parametersCaptor.getValue().size(), 1);
+        assertEquals(parametersCaptor.getValue().get("id"), MODULE_ID);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionPermanentlyNullId() {
         svc.deleteMetadataByIdAndVersionPermanently(null, MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionPermanentlyEmptyId() {
         svc.deleteMetadataByIdAndVersionPermanently("", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionPermanentlyBlankId() {
         svc.deleteMetadataByIdAndVersionPermanently("   ", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionPermanentlyNegativeVersion() {
         svc.deleteMetadataByIdAndVersionPermanently(MODULE_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionPermanentlyZeroVersion() {
         svc.deleteMetadataByIdAndVersionPermanently(MODULE_ID, 0);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndVersionPermanentlyNotFound() {
         // mock dao to return null
         when(mockDao.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(null);
@@ -276,22 +277,22 @@ public class SharedModuleMetadataServiceTest {
         verify(mockDao).deleteMetadataByIdAndVersionPermanently(MODULE_ID, MODULE_VERSION);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsNullId() {
         svc.deleteMetadataByIdAllVersions(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsEmptyId() {
         svc.deleteMetadataByIdAllVersions("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAllVersionsBlankId() {
         svc.deleteMetadataByIdAllVersions("   ");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAllVersionsNotFound() {
         doReturn(ImmutableList.of()).when(svc).queryMetadataById(MODULE_ID, true, false, null, null, null, false);
         svc.deleteMetadataByIdAllVersions(MODULE_ID);
@@ -304,32 +305,32 @@ public class SharedModuleMetadataServiceTest {
         verify(mockDao).deleteMetadataByIdAllVersions(MODULE_ID);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionNullId() {
         svc.deleteMetadataByIdAndVersion(null, MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionEmptyId() {
         svc.deleteMetadataByIdAndVersion("", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionBlankId() {
         svc.deleteMetadataByIdAndVersion("   ", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionNegativeVersion() {
         svc.deleteMetadataByIdAndVersion(MODULE_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndVersionZeroVersion() {
         svc.deleteMetadataByIdAndVersion(MODULE_ID, 0);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndVersionNotFound() {
         // mock dao to return null
         when(mockDao.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(null);
@@ -337,7 +338,7 @@ public class SharedModuleMetadataServiceTest {
         svc.deleteMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndVersionAlreadyLogicallyDeleted() {
         // mock get
         SharedModuleMetadata metadata = makeValidMetadata();
@@ -357,32 +358,32 @@ public class SharedModuleMetadataServiceTest {
         verify(mockDao).deleteMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionNullId() {
         svc.getMetadataByIdAndVersion(null, MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionEmptyId() {
         svc.getMetadataByIdAndVersion("", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionBlankId() {
         svc.getMetadataByIdAndVersion("   ", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionNegativeVersion() {
         svc.getMetadataByIdAndVersion(MODULE_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionZeroVersion() {
         svc.getMetadataByIdAndVersion(MODULE_ID, 0);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void byIdAndVersionNotFound() {
         when(mockDao.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(null);
         svc.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
@@ -396,25 +397,25 @@ public class SharedModuleMetadataServiceTest {
 
         // execute and validate
         SharedModuleMetadata svcOutputMetadata = svc.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION);
-        assertSame(daoOutputMetadata, svcOutputMetadata);
+        assertSame(svcOutputMetadata, daoOutputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdLatestVersionNullId() {
         svc.getMetadataByIdLatestVersion(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdLatestVersionEmptyId() {
         svc.getMetadataByIdLatestVersion("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdLatestVersionBlankId() {
         svc.getMetadataByIdLatestVersion("   ");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void byIdLatestVersionNotFound() {
         doReturn(ImmutableList.of()).when(svc).queryMetadataById(MODULE_ID, true, false, null, null, null, false);
         svc.getMetadataByIdLatestVersion(MODULE_ID);
@@ -428,7 +429,7 @@ public class SharedModuleMetadataServiceTest {
 
         // execute and validate
         SharedModuleMetadata svcOutputMetadata = svc.getMetadataByIdLatestVersion(MODULE_ID);
-        assertSame(daoOutputMetadata, svcOutputMetadata);
+        assertSame(svcOutputMetadata, daoOutputMetadata);
     }
     
     @Test
@@ -459,7 +460,7 @@ public class SharedModuleMetadataServiceTest {
         verify(mockDao).queryMetadata("foo='bar' AND deleted!=true", null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void queryAllMostRecentWithWhere() {
         svc.queryAllMetadata(true, false, "foo='bar'", null, null, false);
     }
@@ -497,7 +498,7 @@ public class SharedModuleMetadataServiceTest {
 
         // execute and validate
         List<SharedModuleMetadata> svcOutputMetadataList = svc.queryAllMetadata(true, published, null, null, null, includeDeleted);
-        assertEquals(2, svcOutputMetadataList.size());
+        assertEquals(svcOutputMetadataList.size(), 2);
         assertTrue(svcOutputMetadataList.contains(moduleAVersion2));
         assertTrue(svcOutputMetadataList.contains(moduleBVersion4));
     }
@@ -530,7 +531,7 @@ public class SharedModuleMetadataServiceTest {
         // execute and validate
         List<SharedModuleMetadata> svcOutputMetadataList = svc.queryAllMetadata(false, published, inputWhereClause,
                 parameters, null, includeDeleted);
-        assertSame(daoOutputMetadataList, svcOutputMetadataList);
+        assertSame(svcOutputMetadataList, daoOutputMetadataList);
     }
 
     @Test
@@ -582,24 +583,24 @@ public class SharedModuleMetadataServiceTest {
 
         // execute and validate
         List<SharedModuleMetadata> svcOutputMetadataList = svc.queryAllMetadata(false, false, "foo='bar'", null, tags, false);
-        assertEquals(4, svcOutputMetadataList.size());
+        assertEquals(svcOutputMetadataList.size(), 4);
         assertTrue(svcOutputMetadataList.contains(metadata2));
         assertTrue(svcOutputMetadataList.contains(metadata3));
         assertTrue(svcOutputMetadataList.contains(metadata4));
         assertTrue(svcOutputMetadataList.contains(metadata5));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void queryByIdNullId() {
         svc.queryMetadataById(null, true, true, "foo='bar'", null, ImmutableSet.of("foo", "bar", "baz"), false);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void queryByIdEmptyId() {
         svc.queryMetadataById("", true, true, "foo='bar'", null, ImmutableSet.of("foo", "bar", "baz"), false);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void queryByIdBlankId() {
         svc.queryMetadataById("   ", true, true, "foo='bar'", null, ImmutableSet.of("foo", "bar", "baz"), false);
     }
@@ -632,37 +633,37 @@ public class SharedModuleMetadataServiceTest {
         // execute and validate
         List<SharedModuleMetadata> svcOutputMetadataList = svc.queryMetadataById("module-B", true, true, "foo='bar'",
                 null, tags, false);
-        assertEquals(2, svcOutputMetadataList.size());
+        assertEquals(svcOutputMetadataList.size(), 2);
         assertTrue(svcOutputMetadataList.contains(moduleBVersion3));
         assertTrue(svcOutputMetadataList.contains(moduleBVersion4));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateNullId() {
         svc.updateMetadata(null, MODULE_VERSION, makeValidMetadata());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateEmptyId() {
         svc.updateMetadata("", MODULE_VERSION, makeValidMetadata());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateBlankId() {
         svc.updateMetadata("   ", MODULE_VERSION, makeValidMetadata());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateNegativeVersion() {
         svc.updateMetadata(MODULE_ID, -1, makeValidMetadata());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateZeroVersion() {
         svc.updateMetadata(MODULE_ID, 0, makeValidMetadata());
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateNotFound() {
         // mock dao to return null
         when(mockDao.getMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION)).thenReturn(null);
@@ -670,7 +671,7 @@ public class SharedModuleMetadataServiceTest {
         svc.updateMetadata(MODULE_ID, MODULE_VERSION, makeValidMetadata());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateNotFoundSchema() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         when(mockDao.getMetadataByIdAndVersion(anyString(), anyInt())).thenReturn(svcInputMetadata);
@@ -679,7 +680,7 @@ public class SharedModuleMetadataServiceTest {
         svc.updateMetadata(MODULE_ID, MODULE_VERSION, svcInputMetadata);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateNotFoundSurvey() {
         SharedModuleMetadata svcInputMetadata = makeValidMetadata();
         when(mockDao.getMetadataByIdAndVersion(anyString(), anyInt())).thenReturn(svcInputMetadata);
@@ -756,7 +757,7 @@ public class SharedModuleMetadataServiceTest {
         assertFalse(metadataCaptor.getValue().isDeleted());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void cannotLogicallyDeleteLogicallyDeletedModuleMetadata() throws Exception {
         SharedModuleMetadata metadata = makeValidMetadata();
         metadata.setDeleted(true);
@@ -786,11 +787,11 @@ public class SharedModuleMetadataServiceTest {
 
         // Validate we set the ID and version before passing it to the DAO.
         SharedModuleMetadata daoInputMetadata = daoInputMetadataCaptor.getValue();
-        assertEquals(MODULE_ID, daoInputMetadata.getId());
-        assertEquals(MODULE_VERSION, daoInputMetadata.getVersion());
+        assertEquals(daoInputMetadata.getId(), MODULE_ID);
+        assertEquals(daoInputMetadata.getVersion(), MODULE_VERSION);
 
         // Validate DAO input is also svcOutput.
-        assertSame(daoOutputMetadata, svcOutputMetadata);
+        assertSame(svcOutputMetadata, daoOutputMetadata);
     }
 
     static SharedModuleMetadata makeValidMetadata() {

--- a/src/test/java/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SharedModuleServiceTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
@@ -45,7 +45,7 @@ public class SharedModuleServiceTest {
     private SurveyService mockSurveyService;
     private SharedModuleService moduleService;
 
-    @Before
+    @BeforeMethod
     public void before() {
         mockMetadataService = mock(SharedModuleMetadataService.class);
         mockSchemaService = mock(UploadSchemaService.class);
@@ -57,27 +57,27 @@ public class SharedModuleServiceTest {
         moduleService.setSurveyService(mockSurveyService);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionNullId() {
         moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, null, MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionEmptyId() {
         moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, "", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionBlankId() {
         moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, "   ", MODULE_VERSION);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionNegativeVersion() {
         moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void byIdAndVersionZeroVersion() {
         moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID, 0);
     }
@@ -99,13 +99,13 @@ public class SharedModuleServiceTest {
         // execute and validate import status
         SharedModuleImportStatus status = moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID,
                 MODULE_VERSION);
-        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
-        assertEquals(SCHEMA_ID, status.getSchemaId());
-        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+        assertEquals(status.getModuleType(), SharedModuleType.SCHEMA);
+        assertEquals(status.getSchemaId(), SCHEMA_ID);
+        assertEquals(status.getSchemaRevision().intValue(), SCHEMA_REV);
 
         UploadSchema modifiedSchema = schemaArgumentCaptor.getValue();
-        assertEquals(MODULE_ID, modifiedSchema.getModuleId());
-        assertEquals(MODULE_VERSION, modifiedSchema.getModuleVersion().intValue());
+        assertEquals(modifiedSchema.getModuleId(), MODULE_ID);
+        assertEquals(modifiedSchema.getModuleVersion().intValue(), MODULE_VERSION);
 
         // verify calls to create schema
         verify(mockSchemaService).createSchemaRevisionV4(TestConstants.TEST_STUDY, sharedSchema);
@@ -129,38 +129,38 @@ public class SharedModuleServiceTest {
         // execute and validate import status
         SharedModuleImportStatus status = moduleService.importModuleByIdAndVersion(TestConstants.TEST_STUDY, MODULE_ID,
                 MODULE_VERSION);
-        assertEquals(SharedModuleType.SURVEY, status.getModuleType());
-        assertEquals(LOCAL_SURVEY_CREATED_ON, status.getSurveyCreatedOn().longValue());
-        assertEquals(LOCAL_SURVEY_GUID, status.getSurveyGuid());
+        assertEquals(status.getModuleType(), SharedModuleType.SURVEY);
+        assertEquals(status.getSurveyCreatedOn().longValue(), LOCAL_SURVEY_CREATED_ON);
+        assertEquals(status.getSurveyGuid(), LOCAL_SURVEY_GUID);
 
         // Verify calls to create survey. Verify that we set the study ID.
         ArgumentCaptor<Survey> surveyToCreateCaptor = ArgumentCaptor.forClass(Survey.class);
         verify(mockSurveyService).createSurvey(surveyToCreateCaptor.capture());
         Survey surveyToCreate = surveyToCreateCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, surveyToCreate.getStudyIdentifier());
-        assertEquals(MODULE_ID, surveyToCreate.getModuleId());
-        assertEquals(MODULE_VERSION, surveyToCreate.getModuleVersion().intValue());
+        assertEquals(surveyToCreate.getStudyIdentifier(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(surveyToCreate.getModuleId(), MODULE_ID);
+        assertEquals(surveyToCreate.getModuleVersion().intValue(), MODULE_VERSION);
 
         // verify call to publish survey
         verify(mockSurveyService).publishSurvey(TestConstants.TEST_STUDY, LOCAL_SURVEY_KEY, true);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void latestPublishedNullId() {
         moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void latestPublishedEmptyId() {
         moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, "");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void latestPublishedBlankId() {
         moduleService.importModuleByIdLatestPublishedVersion(TestConstants.TEST_STUDY, "   ");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void latestPublishedNotFound() {
         // mock metadataService to return empty list
         when(mockMetadataService.queryMetadataById(MODULE_ID, true, true, null, null, null, false))
@@ -187,13 +187,13 @@ public class SharedModuleServiceTest {
         // execute and validate import status
         SharedModuleImportStatus status = moduleService.importModuleByIdLatestPublishedVersion(
                 TestConstants.TEST_STUDY, MODULE_ID);
-        assertEquals(SharedModuleType.SCHEMA, status.getModuleType());
-        assertEquals(SCHEMA_ID, status.getSchemaId());
-        assertEquals(SCHEMA_REV, status.getSchemaRevision().intValue());
+        assertEquals(status.getModuleType(), SharedModuleType.SCHEMA);
+        assertEquals(status.getSchemaId(), SCHEMA_ID);
+        assertEquals(status.getSchemaRevision().intValue(), SCHEMA_REV);
 
         UploadSchema modifiedSchema = schemaArgumentCaptor.getValue();
-        assertEquals(MODULE_ID, modifiedSchema.getModuleId());
-        assertEquals(MODULE_VERSION, modifiedSchema.getModuleVersion().intValue());
+        assertEquals(modifiedSchema.getModuleId(), MODULE_ID);
+        assertEquals(modifiedSchema.getModuleVersion().intValue(), MODULE_VERSION);
 
         // verify calls to create schema
         verify(mockSchemaService).createSchemaRevisionV4(TestConstants.TEST_STUDY, sharedSchema);

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyConsentServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyConsentServiceMockTest.java
@@ -6,8 +6,9 @@ import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dao.StudyConsentDao;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
@@ -20,7 +21,7 @@ public class StudyConsentServiceMockTest {
     private StudyConsentDao mockDao;
     private AmazonS3Client mockS3Client;
 
-    @Before
+    @BeforeMethod
     public void before() {
         mockDao = mock(StudyConsentDao.class);
         mockS3Client = mock(AmazonS3Client.class);

--- a/src/test/java/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -1,11 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
@@ -17,17 +11,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
@@ -55,7 +54,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SubpopulationServiceTest {
     
     private static final String SUBPOP_1 = "Subpop 1";
@@ -99,8 +97,10 @@ public class SubpopulationServiceTest {
     
     Subpopulation subpop;
     
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        
         service = new SubpopulationService();
         service.setSubpopulationDao(subpopDao);
         service.setStudyConsentService(studyConsentService);
@@ -127,14 +127,14 @@ public class SubpopulationServiceTest {
     }
     
     // The contents of this exception are tested in the validator tests.
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void creationIsValidated() {
         Subpopulation subpop = Subpopulation.create();
         service.createSubpopulation(study, subpop);
     }
     
     // The contents of this exception are tested in the validator tests.
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateIsValidated() {
         Subpopulation subpop = Subpopulation.create();
         service.createSubpopulation(study, subpop);
@@ -152,11 +152,11 @@ public class SubpopulationServiceTest {
         when(subpopDao.createSubpopulation(any())).thenReturn(subpop);
         
         Subpopulation result = service.createSubpopulation(study, subpop);
-        assertEquals("Name", result.getName());
+        assertEquals(result.getName(), "Name");
         assertNotNull(result.getGuidString());
-        assertNotEquals("cannot-set-guid", result.getGuidString());
+        assertNotEquals(result.getGuidString(), "cannot-set-guid");
         assertFalse(result.isDeleted());
-        assertEquals(TEST_STUDY_IDENTIFIER, result.getStudyIdentifier());
+        assertEquals(result.getStudyIdentifier(), TEST_STUDY_IDENTIFIER);
         
         verify(subpopDao).createSubpopulation(subpop);
         verify(studyConsentService).addConsent(eq(result.getGuid()), any());
@@ -184,10 +184,10 @@ public class SubpopulationServiceTest {
         Subpopulation returnValue = service.createDefaultSubpopulation(study);
         verify(studyConsentService).addConsent(any(), captor.capture());
         verify(studyConsentService).publishConsent(eq(study), eq(subpop), any(Long.class));
-        assertEquals(subpop, returnValue);
+        assertEquals(returnValue, subpop);
         
         // This used the default document.
-        assertEquals(form, captor.getValue());
+        assertEquals(captor.getValue(), form);
     }
     
     @Test
@@ -201,7 +201,7 @@ public class SubpopulationServiceTest {
         when(subpopDao.createDefaultSubpopulation(study.getStudyIdentifier())).thenReturn(subpop);
         
         Subpopulation returnValue = service.createDefaultSubpopulation(study);
-        assertEquals(subpop, returnValue);
+        assertEquals(returnValue, subpop);
         
         // Consents exist... don't add any
         verify(studyConsentService, never()).addConsent(any(), any());
@@ -221,9 +221,9 @@ public class SubpopulationServiceTest {
         when(subpopDao.getSubpopulation(any(), any())).thenReturn(subpop);
         
         Subpopulation result = service.updateSubpopulation(study, subpop);
-        assertEquals("Name", result.getName());
-        assertEquals("guid", result.getGuidString());
-        assertEquals(TEST_STUDY_IDENTIFIER, result.getStudyIdentifier());
+        assertEquals(result.getName(), "Name");
+        assertEquals(result.getGuidString(), "guid");
+        assertEquals(result.getStudyIdentifier(), TEST_STUDY_IDENTIFIER);
         
         verify(subpopDao).updateSubpopulation(subpop);
         verify(substudyService).getSubstudyIds(TEST_STUDY);
@@ -242,7 +242,7 @@ public class SubpopulationServiceTest {
             service.updateSubpopulation(study, subpop);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
-            assertEquals("StudyConsent not found.", e.getMessage());
+            assertEquals(e.getMessage(), "StudyConsent not found.");
         }
     }
     
@@ -260,7 +260,7 @@ public class SubpopulationServiceTest {
         when(subpopDao.getSubpopulation(any(), any())).thenReturn(existing);
         
         Subpopulation updated = service.updateSubpopulation(study, subpop);
-        assertEquals(1000L, updated.getPublishedConsentCreatedOn());
+        assertEquals(updated.getPublishedConsentCreatedOn(), 1000L);
     }
     
     @Test
@@ -273,9 +273,9 @@ public class SubpopulationServiceTest {
         when(subpopDao.getSubpopulations(TEST_STUDY, true, false)).thenReturn(ImmutableList.of(subpop1, subpop2));
         
         List<Subpopulation> results = service.getSubpopulations(TEST_STUDY, false);
-        assertEquals(2, results.size());
-        assertEquals(subpop1, results.get(0));
-        assertEquals(subpop2, results.get(1));
+        assertEquals(results.size(), 2);
+        assertEquals(results.get(0), subpop1);
+        assertEquals(results.get(1), subpop2);
         verify(subpopDao).getSubpopulations(TEST_STUDY, true, false);
     }
     
@@ -287,7 +287,7 @@ public class SubpopulationServiceTest {
         when(subpopDao.getSubpopulation(TEST_STUDY, SUBPOP_GUID)).thenReturn(subpop);
 
         Subpopulation result = service.getSubpopulation(TEST_STUDY, SUBPOP_GUID);
-        assertEquals(subpop, result);
+        assertEquals(result, subpop);
         verify(subpopDao).getSubpopulation(TEST_STUDY, SUBPOP_GUID);
     }
 
@@ -322,7 +322,7 @@ public class SubpopulationServiceTest {
         List<Subpopulation> subpops = service.getSubpopulationsForUser(context);
         Subpopulation retrieved = subpops.get(0);
         Criteria criteria = retrieved.getCriteria();
-        assertEquals(CRITERIA, criteria);
+        assertEquals(criteria, CRITERIA);
         
         verify(subpopDao).getSubpopulations(TEST_STUDY, true, false);
     }
@@ -351,19 +351,19 @@ public class SubpopulationServiceTest {
         
         // version 12, no tags == Subpop 4
         List<Subpopulation> results = service.getSubpopulationsForUser(criteriaContext(12, null));
-        assertEquals(ImmutableSet.of(subpop4), Sets.newHashSet(results));
+        assertEquals(Sets.newHashSet(results), ImmutableSet.of(subpop4));
         
         // version 12, tag group1 == Subpops 3, 4
         results = service.getSubpopulationsForUser(criteriaContext(12, "group1"));
-        assertEquals(ImmutableSet.of(subpop3, subpop4), Sets.newHashSet(results));
+        assertEquals(Sets.newHashSet(results), ImmutableSet.of(subpop3, subpop4));
         
         // version 4, no tag == Subpops 2, 4
         results = service.getSubpopulationsForUser(criteriaContext(4, null));
-        assertEquals(ImmutableSet.of(subpop2, subpop4), Sets.newHashSet(results));
+        assertEquals(Sets.newHashSet(results), ImmutableSet.of(subpop2, subpop4));
         
         // version 4, tag group1 == Subpops 1,2,3,4, returns 1 in this case (most specific)
         results = service.getSubpopulationsForUser(criteriaContext(4, "group1"));
-        assertEquals(ImmutableSet.of(subpop1, subpop2, subpop3, subpop4), Sets.newHashSet(results));
+        assertEquals(Sets.newHashSet(results), ImmutableSet.of(subpop1, subpop2, subpop3, subpop4));
     }
     
     @Test
@@ -378,8 +378,8 @@ public class SubpopulationServiceTest {
                 .build();
         List<Subpopulation> results = service.getSubpopulationsForUser(context);
 
-        assertEquals(1, results.size());
-        assertEquals("Subpop 1", results.get(0).getName());
+        assertEquals(results.size(), 1);
+        assertEquals(results.get(0).getName(), "Subpop 1");
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
@@ -1,26 +1,26 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SubstudyDao;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
@@ -31,7 +31,6 @@ import org.sagebionetworks.bridge.models.substudies.Substudy;
 
 import com.google.common.collect.ImmutableList;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SubstudyServiceTest {
     private static final List<Substudy> SUBSTUDIES = ImmutableList.of(Substudy.create(), Substudy.create());
     private static final VersionHolder VERSION_HOLDER = new VersionHolder(1L);
@@ -44,8 +43,10 @@ public class SubstudyServiceTest {
     
     private SubstudyService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service = new SubstudyService();
         service.setSubstudyDao(substudyDao);
     }
@@ -56,7 +57,7 @@ public class SubstudyServiceTest {
         when(substudyDao.getSubstudy(TestConstants.TEST_STUDY, "id")).thenReturn(substudy);
         
         Substudy returnedValue = service.getSubstudy(TestConstants.TEST_STUDY, "id", true);
-        assertEquals(substudy, returnedValue);
+        assertEquals(returnedValue, substudy);
         
         verify(substudyDao).getSubstudy(TestConstants.TEST_STUDY, "id");
     }
@@ -73,10 +74,10 @@ public class SubstudyServiceTest {
         when(substudyDao.getSubstudies(TestConstants.TEST_STUDY, false)).thenReturn(substudies);
         
         Set<String> substudyIds = service.getSubstudyIds(TestConstants.TEST_STUDY);
-        assertEquals(TestConstants.USER_SUBSTUDY_IDS, substudyIds);
+        assertEquals(substudyIds, TestConstants.USER_SUBSTUDY_IDS);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSubstudyNotFoundThrowingException() {
         service.getSubstudy(TestConstants.TEST_STUDY, "id", true);
     }
@@ -92,7 +93,7 @@ public class SubstudyServiceTest {
         when(substudyDao.getSubstudies(TestConstants.TEST_STUDY, true)).thenReturn(SUBSTUDIES);
         
         List<Substudy> returnedValue = service.getSubstudies(TestConstants.TEST_STUDY, true);
-        assertEquals(SUBSTUDIES, returnedValue);
+        assertEquals(returnedValue, SUBSTUDIES);
         
         verify(substudyDao).getSubstudies(TestConstants.TEST_STUDY, true);
     }
@@ -102,7 +103,7 @@ public class SubstudyServiceTest {
         when(substudyDao.getSubstudies(TestConstants.TEST_STUDY, false)).thenReturn(SUBSTUDIES);
         
         List<Substudy> returnedValue = service.getSubstudies(TestConstants.TEST_STUDY, false);
-        assertEquals(SUBSTUDIES, returnedValue);
+        assertEquals(returnedValue, SUBSTUDIES);
         
         verify(substudyDao).getSubstudies(TestConstants.TEST_STUDY, false);
     }
@@ -122,26 +123,26 @@ public class SubstudyServiceTest {
         when(substudyDao.createSubstudy(any())).thenReturn(VERSION_HOLDER);
         
         VersionHolder returnedValue = service.createSubstudy(TestConstants.TEST_STUDY, substudy);
-        assertEquals(VERSION_HOLDER, returnedValue);
+        assertEquals(returnedValue, VERSION_HOLDER);
         
         verify(substudyDao).createSubstudy(substudyCaptor.capture());
         
         Substudy persisted = substudyCaptor.getValue();
-        assertEquals("oneId", persisted.getId());
-        assertEquals("oneName", persisted.getName());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, persisted.getStudyId());
+        assertEquals(persisted.getId(), "oneId");
+        assertEquals(persisted.getName(), "oneName");
+        assertEquals(persisted.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
         assertNull(persisted.getVersion());
         assertFalse(persisted.isDeleted());
-        assertNotEquals(timestamp, persisted.getCreatedOn());
-        assertNotEquals(timestamp, persisted.getModifiedOn());
+        assertNotEquals(persisted.getCreatedOn(), timestamp);
+        assertNotEquals(persisted.getModifiedOn(), timestamp);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createSubstudyInvalidSubstudy() {
         service.createSubstudy(TestConstants.TEST_STUDY, Substudy.create());
     }
     
-    @Test(expected = EntityAlreadyExistsException.class)
+    @Test(expectedExceptions = EntityAlreadyExistsException.class)
     public void createSubstudyAlreadyExists() {
         Substudy substudy = Substudy.create();
         substudy.setId("oneId");
@@ -167,24 +168,24 @@ public class SubstudyServiceTest {
         substudy.setName("newName");
         
         VersionHolder versionHolder = service.updateSubstudy(TestConstants.TEST_STUDY, substudy);
-        assertEquals(VERSION_HOLDER, versionHolder);
+        assertEquals(versionHolder, VERSION_HOLDER);
         
         verify(substudyDao).updateSubstudy(substudyCaptor.capture());
         
         Substudy returnedValue = substudyCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, returnedValue.getStudyId());
-        assertEquals("oneId", returnedValue.getId());
-        assertEquals("newName", returnedValue.getName());
+        assertEquals(returnedValue.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(returnedValue.getId(), "oneId");
+        assertEquals(returnedValue.getName(), "newName");
         assertNotNull(returnedValue.getCreatedOn());
         assertNotNull(returnedValue.getModifiedOn());
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void updateSubstudyInvalidSubstudy() {
         service.updateSubstudy(TestConstants.TEST_STUDY, Substudy.create());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateSubstudyEntityNotFound() {
         Substudy substudy = Substudy.create();
         substudy.setId("oneId");
@@ -194,7 +195,7 @@ public class SubstudyServiceTest {
         service.updateSubstudy(TestConstants.TEST_STUDY, substudy);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateSubstudyEntityDeleted() {
         Substudy existing = Substudy.create();
         existing.setDeleted(true);
@@ -220,7 +221,7 @@ public class SubstudyServiceTest {
         assertNotNull(persisted.getModifiedOn());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteSubstudyNotFound() {
         service.deleteSubstudy(TestConstants.TEST_STUDY, "id");
     }
@@ -234,7 +235,7 @@ public class SubstudyServiceTest {
         verify(substudyDao).deleteSubstudyPermanently(TestConstants.TEST_STUDY, "id");
     }    
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteSubstudyPermanentlyNotFound() {
         service.deleteSubstudyPermanently(TestConstants.TEST_STUDY, "id");
     }    

--- a/src/test/java/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SurveyServiceMockTest.java
@@ -1,12 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
@@ -17,6 +10,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.services.SharedModuleMetadataServiceTest.makeValidMetadata;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -25,13 +25,13 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.SurveyDao;
@@ -60,7 +60,6 @@ import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
 import org.sagebionetworks.bridge.models.surveys.TestSurvey;
 import org.sagebionetworks.bridge.validators.SurveyPublishValidator;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SurveyServiceMockTest {
 
     private static final StudyIdentifier OTHER_STUDY = new StudyIdentifierImpl("other-study");
@@ -99,8 +98,9 @@ public class SurveyServiceMockTest {
     
     SurveyService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
         // Mock dependencies.
         when(mockStudyService.getStudy(TestConstants.TEST_STUDY_IDENTIFIER)).thenReturn(TestUtils.getValidStudy(
                 SurveyServiceMockTest.class));
@@ -123,7 +123,7 @@ public class SurveyServiceMockTest {
 
         // Execute and verify.
         Survey returnedSurvey = service.createSurvey(survey);
-        assertSame(survey, returnedSurvey);
+        assertSame(returnedSurvey, survey);
         assertNotNull(survey.getGuid());
         assertFalse(survey.getElements().isEmpty());
 
@@ -135,7 +135,7 @@ public class SurveyServiceMockTest {
         verify(mockSurveyDao).createSurvey(survey);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void createSurvey_InvalidSurvey() {
         // Create invalid survey. A survey without an identifier is invalid.
         Survey survey = makeSurveyWithElements();
@@ -158,10 +158,10 @@ public class SurveyServiceMockTest {
             service.createSurvey(survey);
             fail("expected exception");
         } catch (EntityAlreadyExistsException ex) {
-            assertEquals("Survey", ex.getEntityClass());
-            assertEquals("Survey identifier " + SURVEY_ID + " is already used by survey " + SURVEY_GUID,
-                    ex.getMessage());
-            assertEquals(SURVEY_ID, ex.getEntityKeys().get(SurveyService.KEY_IDENTIFIER));
+            assertEquals(ex.getEntityClass(), "Survey");
+            assertEquals(ex.getMessage(),
+                    "Survey identifier " + SURVEY_ID + " is already used by survey " + SURVEY_GUID);
+            assertEquals(ex.getEntityKeys().get(SurveyService.KEY_IDENTIFIER), SURVEY_ID);
         }
 
         // Verify DAO.
@@ -206,10 +206,10 @@ public class SurveyServiceMockTest {
 
         // execute and validate
         Survey retval = service.publishSurvey(TEST_STUDY, SURVEY_KEYS, true);
-        assertSame(survey, retval);
+        assertSame(retval, survey);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void publishSurveyDeleted() {
         
         Survey survey = new DynamoSurvey();
@@ -219,7 +219,7 @@ public class SurveyServiceMockTest {
         service.publishSurvey(TEST_STUDY, SURVEY_KEYS, true);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void publishSurveyDoesNotExist() {
         when(mockSurveyDao.getSurvey(SURVEY_KEYS, true)).thenReturn(null);
         
@@ -245,13 +245,13 @@ public class SurveyServiceMockTest {
                 paramsCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("surveyGuid=:surveyGuid AND surveyCreatedOn=:surveyCreatedOn", queryStr);
+        assertEquals(queryStr, "surveyGuid=:surveyGuid AND surveyCreatedOn=:surveyCreatedOn");
 
-        assertEquals(survey.getGuid(), paramsCaptor.getValue().get("surveyGuid"));
-        assertEquals(survey.getCreatedOn(), paramsCaptor.getValue().get("surveyCreatedOn"));        
+        assertEquals(paramsCaptor.getValue().get("surveyGuid"), survey.getGuid());
+        assertEquals(paramsCaptor.getValue().get("surveyCreatedOn"), survey.getCreatedOn());        
         
         verify(mockSurveyDao).deleteSurvey(surveyCaptor.capture());
-        assertEquals(survey, surveyCaptor.getValue());
+        assertEquals(surveyCaptor.getValue(), survey);
     }
     
     @Test
@@ -274,15 +274,15 @@ public class SurveyServiceMockTest {
                 paramsCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("surveyGuid=:surveyGuid AND surveyCreatedOn=:surveyCreatedOn", queryStr);
-        assertEquals(survey.getGuid(), paramsCaptor.getValue().get("surveyGuid"));
-        assertEquals(survey.getCreatedOn(), paramsCaptor.getValue().get("surveyCreatedOn"));
+        assertEquals(queryStr, "surveyGuid=:surveyGuid AND surveyCreatedOn=:surveyCreatedOn");
+        assertEquals(paramsCaptor.getValue().get("surveyGuid"), survey.getGuid());
+        assertEquals(paramsCaptor.getValue().get("surveyCreatedOn"), survey.getCreatedOn());
         
         verify(mockSurveyDao).deleteSurveyPermanently(keysCaptor.capture());
-        assertEquals(survey, keysCaptor.getValue());
+        assertEquals(keysCaptor.getValue(), survey);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void logicallyDeleteSurveyNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -293,7 +293,7 @@ public class SurveyServiceMockTest {
         service.deleteSurvey(TestConstants.TEST_STUDY, survey);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void physicallyDeleteSurveyNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -357,11 +357,11 @@ public class SurveyServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
-            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
-            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
-            assertEquals("Survey", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), SCHEDULE_PLAN_GUID);
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("guid"), SURVEY_GUID);
+            assertEquals(e.getEntityKeys().get("createdOn"), SURVEY_CREATED_ON.toString());
+            assertEquals(e.getEntityKeys().get("type"), "Survey");
         }
     }
     
@@ -383,11 +383,11 @@ public class SurveyServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
-            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
-            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
-            assertEquals("Survey", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), SCHEDULE_PLAN_GUID);
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("guid"), SURVEY_GUID);
+            assertEquals(e.getEntityKeys().get("createdOn"), SURVEY_CREATED_ON.toString());
+            assertEquals(e.getEntityKeys().get("type"), "Survey");
         }
     }
 
@@ -407,11 +407,11 @@ public class SurveyServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
-            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
-            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
-            assertEquals("Survey", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), SCHEDULE_PLAN_GUID);
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("guid"), SURVEY_GUID);
+            assertEquals(e.getEntityKeys().get("createdOn"), SURVEY_CREATED_ON.toString());
+            assertEquals(e.getEntityKeys().get("type"), "Survey");
         }
     }
     
@@ -461,11 +461,11 @@ public class SurveyServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
-            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
-            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
-            assertEquals("Survey", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), SCHEDULE_PLAN_GUID);
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("guid"), SURVEY_GUID);
+            assertEquals(e.getEntityKeys().get("createdOn"), SURVEY_CREATED_ON.toString());
+            assertEquals(e.getEntityKeys().get("type"), "Survey");
         }
     }
     
@@ -487,11 +487,11 @@ public class SurveyServiceMockTest {
             fail("Should have thrown exception");
         } catch(ConstraintViolationException e) {
             assertTrue(e.getMessage().contains("Cannot delete survey: it is referenced by a schedule plan that is still accessible through the API"));
-            assertEquals(SCHEDULE_PLAN_GUID, e.getReferrerKeys().get("guid"));
-            assertEquals("SchedulePlan", e.getReferrerKeys().get("type"));
-            assertEquals(SURVEY_GUID, e.getEntityKeys().get("guid"));
-            assertEquals(SURVEY_CREATED_ON.toString(), e.getEntityKeys().get("createdOn"));
-            assertEquals("Survey", e.getEntityKeys().get("type"));
+            assertEquals(e.getReferrerKeys().get("guid"), SCHEDULE_PLAN_GUID);
+            assertEquals(e.getReferrerKeys().get("type"), "SchedulePlan");
+            assertEquals(e.getEntityKeys().get("guid"), SURVEY_GUID);
+            assertEquals(e.getEntityKeys().get("createdOn"), SURVEY_CREATED_ON.toString());
+            assertEquals(e.getEntityKeys().get("type"), "Survey");
         }
     }
     
@@ -507,7 +507,7 @@ public class SurveyServiceMockTest {
         service.deleteSurveyPermanently(TEST_STUDY, survey);
     }   
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateSurveyFailsOnDeletedSurvey() throws Exception {
         Survey existing = Survey.create();
         existing.setDeleted(true);
@@ -520,7 +520,7 @@ public class SurveyServiceMockTest {
         service.updateSurvey(TestConstants.TEST_STUDY, update);
     }
     
-    @Test(expected=EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateSurveyFailsOnMissingSurvey() throws Exception {
         when(mockSurveyDao.getSurvey(any(), anyBoolean())).thenReturn(null);
         
@@ -530,7 +530,7 @@ public class SurveyServiceMockTest {
         service.updateSurvey(TestConstants.TEST_STUDY, update);
     }
     
-    @Test(expected = PublishedSurveyException.class)
+    @Test(expectedExceptions = PublishedSurveyException.class)
     public void updateSurveyAlreadyPublishedThrowsException() {
         Survey existing = Survey.create();
         existing.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -566,7 +566,7 @@ public class SurveyServiceMockTest {
         assertFalse(surveyCaptor.getValue().isDeleted());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void versionSurveyFailsOnDeletedSurvey() throws Exception {
         Survey survey = Survey.create();
         survey.setDeleted(true);
@@ -576,26 +576,26 @@ public class SurveyServiceMockTest {
         service.versionSurvey(TestConstants.TEST_STUDY, SURVEY_KEYS);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void versionSurveyFailsOnMissingSurvey() throws Exception {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(null);
         
         service.versionSurvey(TestConstants.TEST_STUDY, SURVEY_KEYS);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteSurveyPermanentlyFailsOnMissingSurvey() {
         when(mockSurveyDao.getSurvey(any(), eq(false))).thenReturn(null);
         
         service.deleteSurveyPermanently(TEST_STUDY, SURVEY_KEYS);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyAllVersionsThrowsException() {
         service.getSurveyAllVersions(TestConstants.TEST_STUDY, "GUID", true);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyInOtherStudyThrowsException() {
         Survey survey = Survey.create();
         survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -616,7 +616,7 @@ public class SurveyServiceMockTest {
         verify(mockSurveyDao).getSurvey(SURVEY_KEYS, false);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyThrowsException() {
         service.getSurvey(TestConstants.TEST_STUDY, SURVEY_KEYS, false, true);
     }
@@ -700,7 +700,7 @@ public class SurveyServiceMockTest {
         verify(mockSurveyDao, never()).deleteSurveyPermanently(any());
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyMostRecentlyPublishedVersionInOtherStudy() {
         Survey survey = Survey.create();
         survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -720,12 +720,12 @@ public class SurveyServiceMockTest {
         service.getSurvey(null, SURVEY_KEYS, true, true);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyMostRecentlyPublishedVersionMissingSurvey() {
         service.getSurveyMostRecentlyPublishedVersion(OTHER_STUDY, SURVEY_GUID, true);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyMostRecentVersionInOtherStudy() {
         Survey survey = Survey.create();
         survey.setStudyIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
@@ -734,7 +734,7 @@ public class SurveyServiceMockTest {
         service.getSurveyMostRecentVersion(OTHER_STUDY, SURVEY_GUID);    
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSurveyMostRecentVersionMissingSurvey() {
         service.getSurveyMostRecentVersion(OTHER_STUDY, SURVEY_GUID);    
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
@@ -1,12 +1,12 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -18,14 +18,14 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.cache.LoadingCache;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import org.sagebionetworks.bridge.crypto.BcCmsEncryptor;
 import org.sagebionetworks.bridge.crypto.CmsEncryptor;
 import org.sagebionetworks.bridge.crypto.PemUtils;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 @SuppressWarnings("unchecked")
 public class UploadArchiveServiceTest {
@@ -65,22 +65,22 @@ public class UploadArchiveServiceTest {
         assertTrue(encryptedData.length > 0);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void encryptNullStudyId() {
         archiveService.encrypt(null, PLAIN_TEXT_DATA);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void encryptEmptyStudyId() {
         archiveService.encrypt("", PLAIN_TEXT_DATA);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void encryptBlankStudyId() {
         archiveService.encrypt("   ", PLAIN_TEXT_DATA);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void encryptNullBytes() {
         archiveService.encrypt("test-study", null);
     }
@@ -88,58 +88,58 @@ public class UploadArchiveServiceTest {
     @Test
     public void decryptSuccess() {
         byte[] decryptedData = archiveService.decrypt("test-study", encryptedData);
-        assertArrayEquals(PLAIN_TEXT_DATA, decryptedData);
+        assertArrayEquals(decryptedData, PLAIN_TEXT_DATA);
     }
 
-    @Test(expected = BridgeServiceException.class)
+    @Test(expectedExceptions = BridgeServiceException.class)
     public void decryptGarbageData() {
         String garbageStr = "This is not encrypted data.";
         byte[] garbageData = garbageStr.getBytes(Charsets.UTF_8);
         archiveService.decrypt("test-study", garbageData);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void decryptBytesNullStudyId() {
         archiveService.decrypt(null, encryptedData);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void decryptBytesEmptyStudyId() {
         archiveService.decrypt("", encryptedData);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void decryptBytesBlankStudyId() {
         archiveService.decrypt("   ", encryptedData);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void decryptBytesNullBytes() {
         archiveService.decrypt("test-study", (byte[]) null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void decryptStreamNullStudyId() throws Exception {
         try (InputStream encryptedInputStream = new ByteArrayInputStream(encryptedData)) {
             archiveService.decrypt(null, encryptedInputStream);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void decryptStreamEmptyStudyId() throws Exception {
         try (InputStream encryptedInputStream = new ByteArrayInputStream(encryptedData)) {
             archiveService.decrypt("", encryptedInputStream);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void decryptStreamBlankStudyId() throws Exception {
         try (InputStream encryptedInputStream = new ByteArrayInputStream(encryptedData)) {
             archiveService.decrypt("   ", encryptedInputStream);
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void decryptStreamNullBytes() {
         archiveService.decrypt("test-study", (InputStream) null);
     }
@@ -157,7 +157,7 @@ public class UploadArchiveServiceTest {
 
         // unzip
         Map<String, byte[]> unzippedData = archiveService.unzip(decryptedData);
-        assertEquals(3, unzippedData.size());
+        assertEquals(unzippedData.size(), 3);
         for (byte[] oneData : unzippedData.values()) {
             assertNotNull(oneData);
             assertTrue(oneData.length > 0);

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadArchiveServiceTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.when;
@@ -88,7 +87,7 @@ public class UploadArchiveServiceTest {
     @Test
     public void decryptSuccess() {
         byte[] decryptedData = archiveService.decrypt("test-study", encryptedData);
-        assertArrayEquals(decryptedData, PLAIN_TEXT_DATA);
+        assertEquals(decryptedData, PLAIN_TEXT_DATA);
     }
 
     @Test(expectedExceptions = BridgeServiceException.class)

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadCertificateServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadCertificateServiceMockTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.eq;
@@ -9,11 +8,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
 
 import com.amazonaws.services.s3.AmazonS3;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
@@ -27,7 +27,7 @@ public class UploadCertificateServiceMockTest {
     private AmazonS3 mockS3client;
     private UploadCertificateService svc;
 
-    @Before
+    @BeforeMethod
     public void before() {
         // Mock S3 client. We'll fill in the details during the test.
         mockS3client = mock(AmazonS3.class);

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceFromSurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceFromSurveyTest.java
@@ -1,18 +1,18 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.UploadSchemaDao;
@@ -40,7 +40,7 @@ public class UploadSchemaServiceFromSurveyTest {
     private UploadSchemaService svc;
     private UploadSchemaDao dao;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         dao = mock(UploadSchemaDao.class);
         svc = new UploadSchemaService();
@@ -62,9 +62,8 @@ public class UploadSchemaServiceFromSurveyTest {
             svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("Survey with identifier " + SURVEY_ID +
-                            " conflicts with schema with the same ID. Please use a different survey identifier.",
-                    ex.getMessage());
+            assertEquals(ex.getMessage(), "Survey with identifier " + SURVEY_ID
+                    + " conflicts with schema with the same ID. Please use a different survey identifier.");
         }
 
         // verify calls (or lack thereof)
@@ -87,9 +86,8 @@ public class UploadSchemaServiceFromSurveyTest {
             svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("Survey with identifier " + SURVEY_ID +
-                            " conflicts with schema with the same ID. Please use a different survey identifier.",
-                    ex.getMessage());
+            assertEquals(ex.getMessage(), "Survey with identifier " + SURVEY_ID +
+                    " conflicts with schema with the same ID. Please use a different survey identifier.");
         }
 
         // verify calls (or lack thereof)
@@ -114,7 +112,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).updateSchemaRevision(any());
@@ -136,7 +134,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).updateSchemaRevision(any());
@@ -164,7 +162,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, true);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).updateSchemaRevision(any());
@@ -192,7 +190,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).createSchemaRevision(any());
@@ -241,7 +239,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).createSchemaRevision(any());
@@ -284,7 +282,7 @@ public class UploadSchemaServiceFromSurveyTest {
 
         // set up test dao and execute
         UploadSchema svcOutputSchema = svc.createUploadSchemaFromSurvey(TestConstants.TEST_STUDY, survey, false);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
 
         // verify calls
         verify(dao, never()).updateSchemaRevision(any());
@@ -342,11 +340,11 @@ public class UploadSchemaServiceFromSurveyTest {
     }
 
     private static void assertSchema(UploadSchema schema, UploadFieldDefinition... expectedFieldDefVarargs) {
-        assertEquals(ImmutableList.copyOf(expectedFieldDefVarargs), schema.getFieldDefinitions());
-        assertEquals(SURVEY_NAME, schema.getName());
-        assertEquals(SURVEY_ID, schema.getSchemaId());
-        assertEquals(UploadSchemaType.IOS_SURVEY, schema.getSchemaType());
-        assertEquals(SURVEY_GUID, schema.getSurveyGuid());
-        assertEquals(SURVEY_CREATED_ON, schema.getSurveyCreatedOn().longValue());
+        assertEquals(schema.getFieldDefinitions(), ImmutableList.copyOf(expectedFieldDefVarargs));
+        assertEquals(schema.getName(), SURVEY_NAME);
+        assertEquals(schema.getSchemaId(), SURVEY_ID);
+        assertEquals(schema.getSchemaType(), UploadSchemaType.IOS_SURVEY);
+        assertEquals(schema.getSurveyGuid(), SURVEY_GUID);
+        assertEquals(schema.getSurveyCreatedOn().longValue(), SURVEY_CREATED_ON);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -1,11 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
@@ -15,6 +9,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.services.SharedModuleMetadataServiceTest.makeValidMetadata;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -22,12 +22,12 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.UploadSchemaDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -40,7 +40,6 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UploadSchemaServiceTest {
     private static final UploadFieldDefinition FIELD_DEF = new UploadFieldDefinition.Builder().withName("field")
             .withType(UploadFieldType.STRING).build();
@@ -61,8 +60,10 @@ public class UploadSchemaServiceTest {
     @Captor
     ArgumentCaptor<Map<String,Object>> paramCaptor;
     
-    @Before
+    @BeforeMethod
     public void setup() {
+        MockitoAnnotations.initMocks(this);
+        
         svcInputSchema = makeSimpleSchema();
         dao = mock(UploadSchemaDao.class);
         mockSharedModuleMetadataService = mock(SharedModuleMetadataService.class);
@@ -71,19 +72,19 @@ public class UploadSchemaServiceTest {
         svc.setSharedModuleMetadataService(mockSharedModuleMetadataService);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createV4NullSchemaId() {
         svcInputSchema.setSchemaId(null);
         svc.createSchemaRevisionV4(TestConstants.TEST_STUDY, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createV4EmptySchemaId() {
         svcInputSchema.setSchemaId("");
         svc.createSchemaRevisionV4(TestConstants.TEST_STUDY, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createV4BlankSchemaId() {
         svcInputSchema.setSchemaId("   ");
         svc.createSchemaRevisionV4(TestConstants.TEST_STUDY, svcInputSchema);
@@ -134,26 +135,26 @@ public class UploadSchemaServiceTest {
 
         // Validate we set key parameters when passing the schema to the DAO, including study ID and rev.
         UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInputSchema.getStudyId());
-        assertEquals(expectedRev, daoInputSchema.getRevision());
+        assertEquals(daoInputSchema.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(daoInputSchema.getRevision(), expectedRev);
 
         // Validate DAO input is also svcOutput.
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createOrUpdateNullSchemaId() {
         svcInputSchema.setSchemaId(null);
         svc.createOrUpdateUploadSchema(TestConstants.TEST_STUDY, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createOrUpdateEmptySchemaId() {
         svcInputSchema.setSchemaId("");
         svc.createOrUpdateUploadSchema(TestConstants.TEST_STUDY, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void createOrUpdateBlankSchemaId() {
         svcInputSchema.setSchemaId("   ");
         svc.createOrUpdateUploadSchema(TestConstants.TEST_STUDY, svcInputSchema);
@@ -218,55 +219,55 @@ public class UploadSchemaServiceTest {
 
             // Validate we set key parameters when passing the schema to the DAO, including study ID and rev.
             UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-            assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInputSchema.getStudyId());
-            assertEquals(expectedRev.intValue(), daoInputSchema.getRevision());
+            assertEquals(daoInputSchema.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+            assertEquals(daoInputSchema.getRevision(), expectedRev.intValue());
 
             // Validate DAO input is also svcOutput.
-            assertSame(daoOutputSchema, svcOutputSchema);
+            assertSame(svcOutputSchema, daoOutputSchema);
         }
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdNullId() {
         svc.deleteUploadSchemaById(TestConstants.TEST_STUDY, null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdPermanentlyNullId() {
         svc.deleteUploadSchemaByIdPermanently(TestConstants.TEST_STUDY, null);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdEmptyId() {
         svc.deleteUploadSchemaById(TestConstants.TEST_STUDY, "");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdPermanentlyEmptyId() {
         svc.deleteUploadSchemaByIdPermanently(TestConstants.TEST_STUDY, "");
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdBlankId() {
         svc.deleteUploadSchemaById(TestConstants.TEST_STUDY, "   ");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdPermanentlyBlankId() {
         svc.deleteUploadSchemaByIdPermanently(TestConstants.TEST_STUDY, "   ");
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdNotFound() {
         svc.deleteUploadSchemaById(TestConstants.TEST_STUDY, SCHEMA_ID);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdPermanentlyNotFound() {
         svc.deleteUploadSchemaByIdPermanently(TestConstants.TEST_STUDY, SCHEMA_ID);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -275,7 +276,7 @@ public class UploadSchemaServiceTest {
         svc.deleteUploadSchemaById(TestConstants.TEST_STUDY, SCHEMA_ID);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdPermanentlyNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -299,9 +300,9 @@ public class UploadSchemaServiceTest {
                 paramCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("schemaId=:schemaId AND schemaRevision IN :schemaRevisions", queryStr);
-        assertEquals(SCHEMA_ID, (String)paramCaptor.getValue().get("schemaId"));
-        assertEquals(Lists.newArrayList(0), paramCaptor.getValue().get("schemaRevisions"));
+        assertEquals(queryStr, "schemaId=:schemaId AND schemaRevision IN :schemaRevisions");
+        assertEquals((String)paramCaptor.getValue().get("schemaId"), SCHEMA_ID);
+        assertEquals(paramCaptor.getValue().get("schemaRevisions"), Lists.newArrayList(0));
     }
 
     @Test
@@ -320,57 +321,57 @@ public class UploadSchemaServiceTest {
                 paramCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("schemaId=:schemaId AND schemaRevision IN :schemaRevisions", queryStr);
-        assertEquals(SCHEMA_ID, (String)paramCaptor.getValue().get("schemaId"));
-        assertEquals(Lists.newArrayList(0), paramCaptor.getValue().get("schemaRevisions"));
+        assertEquals(queryStr, "schemaId=:schemaId AND schemaRevision IN :schemaRevisions");
+        assertEquals((String)paramCaptor.getValue().get("schemaId"), SCHEMA_ID);
+        assertEquals(paramCaptor.getValue().get("schemaRevisions"), Lists.newArrayList(0));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevNullId() {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, null, SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyNullId() {
         svc.deleteUploadSchemaByIdAndRevisionPermanently(TestConstants.TEST_STUDY, null, SCHEMA_REV);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyEmptyId() {
         svc.deleteUploadSchemaByIdAndRevisionPermanently(TestConstants.TEST_STUDY, "", SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevBlankId() {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, "   ", SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyBlankId() {
         svc.deleteUploadSchemaByIdAndRevisionPermanently(TestConstants.TEST_STUDY, "   ", SCHEMA_REV);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevNegativeRev() {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyNegativeRev() {
         svc.deleteUploadSchemaByIdAndRevisionPermanently(TestConstants.TEST_STUDY, SCHEMA_ID, -1);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevZeroRev() {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, 0);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyZeroRev() {
         svc.deleteUploadSchemaByIdAndRevisionPermanently(TestConstants.TEST_STUDY, SCHEMA_ID, 0);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndRevNotFound() {
         // mock dao to return null
         when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(null);
@@ -378,7 +379,7 @@ public class UploadSchemaServiceTest {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV);
     }
     
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndRevOfLogicallyDeletedSchema() {
         // mock dao to return logically deleted schema
         UploadSchema schema = makeSimpleSchema();
@@ -388,7 +389,7 @@ public class UploadSchemaServiceTest {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteByIdAndRevPermanentlyNotFound() {
         // mock dao to return null
         when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(null);
@@ -407,7 +408,7 @@ public class UploadSchemaServiceTest {
         verify(dao).deleteUploadSchemasPermanently(ImmutableList.of(schema));
     }    
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -417,7 +418,7 @@ public class UploadSchemaServiceTest {
         svc.deleteUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void deleteByIdAndRevPermanentlyNotEmptySharedModules() {
         when(mockSharedModuleMetadataService.queryAllMetadata(anyBoolean(), anyBoolean(), anyString(), any(),
                 any(), anyBoolean())).thenReturn(ImmutableList.of(makeValidMetadata()));
@@ -443,9 +444,9 @@ public class UploadSchemaServiceTest {
                 paramCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("schemaId=:schemaId AND schemaRevision=:schemaRevision", queryStr);
-        assertEquals(SCHEMA_ID, paramCaptor.getValue().get("schemaId"));
-        assertEquals(SCHEMA_REV, paramCaptor.getValue().get("schemaRevision"));
+        assertEquals(queryStr, "schemaId=:schemaId AND schemaRevision=:schemaRevision");
+        assertEquals(paramCaptor.getValue().get("schemaId"), SCHEMA_ID);
+        assertEquals(paramCaptor.getValue().get("schemaRevision"), SCHEMA_REV);
     }
 
     @Test
@@ -464,9 +465,9 @@ public class UploadSchemaServiceTest {
                 paramCaptor.capture(), eq(null), eq(true));
 
         String queryStr = queryCaptor.getValue();
-        assertEquals("schemaId=:schemaId AND schemaRevision=:schemaRevision", queryStr);
-        assertEquals(SCHEMA_ID, paramCaptor.getValue().get("schemaId"));
-        assertEquals(SCHEMA_REV, paramCaptor.getValue().get("schemaRevision"));
+        assertEquals(queryStr, "schemaId=:schemaId AND schemaRevision=:schemaRevision");
+        assertEquals(paramCaptor.getValue().get("schemaId"), SCHEMA_ID);
+        assertEquals(paramCaptor.getValue().get("schemaRevision"), SCHEMA_REV);
     }
     
     @Test
@@ -477,7 +478,7 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         List<UploadSchema> svcOutputSchemaList = svc.getAllUploadSchemasAllRevisions(TestConstants.TEST_STUDY, false);
-        assertSame(daoOutputSchemaList, svcOutputSchemaList);
+        assertSame(svcOutputSchemaList, daoOutputSchemaList);
     }
 
     @Test
@@ -504,32 +505,32 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         List<UploadSchema> svcOutputSchemaList = svc.getUploadSchemasForStudy(TestConstants.TEST_STUDY, false);
-        assertEquals(2, svcOutputSchemaList.size());
+        assertEquals(svcOutputSchemaList.size(), 2);
 
         // List might be in any order, so convert it to a map.
         Map<String, UploadSchema> svcOutputSchemasById = Maps.uniqueIndex(svcOutputSchemaList,
                 UploadSchema::getSchemaId);
-        assertEquals(2, svcOutputSchemasById.size());
-        assertEquals(2, svcOutputSchemasById.get("schema-A").getRevision());
-        assertEquals(4, svcOutputSchemasById.get("schema-B").getRevision());
+        assertEquals(svcOutputSchemasById.size(), 2);
+        assertEquals(svcOutputSchemasById.get("schema-A").getRevision(), 2);
+        assertEquals(svcOutputSchemasById.get("schema-B").getRevision(), 4);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getUploadSchemaNullId() {
         svc.getUploadSchema(TestConstants.TEST_STUDY, null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getUploadSchemaEmptyId() {
         svc.getUploadSchema(TestConstants.TEST_STUDY, "");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getUploadSchemaBlankId() {
         svc.getUploadSchema(TestConstants.TEST_STUDY, "   ");
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getUploadSchemaNotFound() {
         // mock dao to return null
         when(dao.getUploadSchemaLatestRevisionById(TestConstants.TEST_STUDY, SCHEMA_ID)).thenReturn(null);
@@ -545,25 +546,25 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         UploadSchema svcOutputSchema = svc.getUploadSchema(TestConstants.TEST_STUDY, SCHEMA_ID);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getSchemaAllRevisionsNullId() {
         svc.getUploadSchemaAllRevisions(TestConstants.TEST_STUDY, null, false);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getSchemaAllRevisionsEmptyId() {
         svc.getUploadSchemaAllRevisions(TestConstants.TEST_STUDY, "", false);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getSchemaAllRevisionsBlankId() {
         svc.getUploadSchemaAllRevisions(TestConstants.TEST_STUDY, "   ", false);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getSchemaAllRevisionsNotFound() {
         // mock dao to return empty list
         when(dao.getUploadSchemaAllRevisionsById(TestConstants.TEST_STUDY, SCHEMA_ID, false)).thenReturn(ImmutableList.of());
@@ -579,7 +580,7 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         List<UploadSchema> svcOutputSchemaList = svc.getUploadSchemaAllRevisions(TestConstants.TEST_STUDY, SCHEMA_ID, false);
-        assertSame(daoOutputSchemaList, svcOutputSchemaList);
+        assertSame(svcOutputSchemaList, daoOutputSchemaList);
     }
 
     @Test
@@ -590,35 +591,35 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         List<UploadSchema> svcOutputSchemaList = svc.getUploadSchemaAllRevisions(TestConstants.TEST_STUDY, SCHEMA_ID, true);
-        assertSame(daoOutputSchemaList, svcOutputSchemaList);
+        assertSame(svcOutputSchemaList, daoOutputSchemaList);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getByIdAndRevNullId() {
         svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, null, SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getByIdAndRevEmptyId() {
         svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "", SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getByIdAndRevBlankId() {
         svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, "   ", SCHEMA_REV);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getByIdAndRevNegativeRev() {
         svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, -1);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getByIdAndRevZeroRev() {
         svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, 0);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void getByIdAndRevNotFound() {
         // mock dao to return null
         when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(null);
@@ -635,20 +636,20 @@ public class UploadSchemaServiceTest {
 
         // execute and validate
         UploadSchema svcOutputSchema = svc.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV);
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getLatestNullId() {
         svc.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, null, ClientInfo.UNKNOWN_CLIENT);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getLatestEmptyId() {
         svc.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, "", ClientInfo.UNKNOWN_CLIENT);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getLatestBlankId() {
         svc.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, "   ", ClientInfo.UNKNOWN_CLIENT);
     }
@@ -663,7 +664,7 @@ public class UploadSchemaServiceTest {
         // execute and validate
         UploadSchema retval = svc.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, SCHEMA_ID,
                 clientInfo);
-        assertEquals(2, retval.getRevision());
+        assertEquals(retval.getRevision(), 2);
     }
 
     @Test
@@ -676,7 +677,7 @@ public class UploadSchemaServiceTest {
         // execute and validate
         UploadSchema retval = svc.getLatestUploadSchemaRevisionForAppVersion(TestConstants.TEST_STUDY, SCHEMA_ID,
                 clientInfo);
-        assertEquals(1, retval.getRevision());
+        assertEquals(retval.getRevision(), 1);
     }
 
     @Test
@@ -740,36 +741,36 @@ public class UploadSchemaServiceTest {
 
             // execute and validate
             boolean retval = UploadSchemaService.isSchemaAvailableForClientInfo(schema, clientInfo);
-            assertEquals(expected, retval);
+            assertEquals(retval, expected);
         }
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateV4NullId() {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, null, SCHEMA_REV, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateV4EmptyId() {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, "", SCHEMA_REV, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateV4BlankId() {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, "   ", SCHEMA_REV, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateV4NegativeRev() {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, -1, svcInputSchema);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void updateV4ZeroRev() {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, 0, svcInputSchema);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateV4NotFound() {
         // mock dao to return null
         when(dao.getUploadSchemaByIdAndRevision(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(null);
@@ -777,7 +778,7 @@ public class UploadSchemaServiceTest {
         svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, svcInputSchema);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateV4LogicallyDeleted() {
         UploadSchema schema = makeSimpleSchema();
         schema.setDeleted(true);
@@ -829,8 +830,8 @@ public class UploadSchemaServiceTest {
             svc.updateSchemaRevisionV4(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV, svcInputSchema);
             fail("expected exception");
         } catch (BadRequestException ex) {
-            assertEquals("Schema " + SCHEMA_ID + " was imported from a shared module and cannot be modified.",
-                    ex.getMessage());
+            assertEquals(ex.getMessage(),
+                    "Schema " + SCHEMA_ID + " was imported from a shared module and cannot be modified.");
         }
     }
 
@@ -951,12 +952,12 @@ public class UploadSchemaServiceTest {
 
         // Validate we set key parameters when passing the schema to the DAO, including study ID, schema ID, and rev.
         UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, daoInputSchema.getStudyId());
-        assertEquals(SCHEMA_ID, daoInputSchema.getSchemaId());
-        assertEquals(SCHEMA_REV, daoInputSchema.getRevision());
+        assertEquals(daoInputSchema.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(daoInputSchema.getSchemaId(), SCHEMA_ID);
+        assertEquals(daoInputSchema.getRevision(), SCHEMA_REV);
 
         // Validate DAO input is also svcOutput.
-        assertSame(daoOutputSchema, svcOutputSchema);
+        assertSame(svcOutputSchema, daoOutputSchema);
     }
 
     private static UploadSchema makeSimpleSchema() {
@@ -980,11 +981,9 @@ public class UploadSchemaServiceTest {
 
     // Validate that the errors throw for a schema made from makeInvalidSchema()
     private static void assertSchemaValidationException(InvalidEntityException ex) {
-        assertEquals("name is required", ex.getErrors().get("name").get(0));
-        assertEquals("schemaType is required", ex.getErrors().get("schemaType").get(0));
-        assertEquals("fieldDefinitions[0].name is required", ex.getErrors().get("fieldDefinitions[0].name")
-                .get(0));
-        assertEquals("fieldDefinitions[0].type is required", ex.getErrors().get("fieldDefinitions[0].type")
-                .get(0));
+        assertEquals(ex.getErrors().get("name").get(0), "name is required");
+        assertEquals(ex.getErrors().get("schemaType").get(0), "schemaType is required");
+        assertEquals(ex.getErrors().get("fieldDefinitions[0].name").get(0), "fieldDefinitions[0].name is required");
+        assertEquals(ex.getErrors().get("fieldDefinitions[0].type").get(0), "fieldDefinitions[0].type is required");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceCreateUploadMockTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -9,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
 
 import java.net.URL;
 
@@ -20,10 +20,10 @@ import com.google.common.collect.ImmutableList;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -73,7 +73,7 @@ public class UploadServiceCreateUploadMockTest {
     private UploadRequest uploadRequest;
     private UploadService svc;
 
-    @Before
+    @BeforeMethod
     public void setup() throws Exception {
         // mock now
         DateTimeUtils.setCurrentMillisFixed(TEST_UPLOAD_REQUESTED_ON.getMillis());
@@ -112,7 +112,7 @@ public class UploadServiceCreateUploadMockTest {
         svc.setS3UploadClient(mockS3UploadClient);
     }
 
-    @After
+    @AfterMethod
     public void cleanup() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -242,17 +242,17 @@ public class UploadServiceCreateUploadMockTest {
     private void testUpload(String expectedUploadId) {
         // execute and validate
         UploadSession uploadSession = svc.createUpload(TestConstants.TEST_STUDY, TEST_USER, uploadRequest);
-        assertEquals(expectedUploadId, uploadSession.getId());
-        assertEquals(TEST_PRESIGNED_URL, uploadSession.getUrl());
+        assertEquals(uploadSession.getId(), expectedUploadId);
+        assertEquals(uploadSession.getUrl(), TEST_PRESIGNED_URL);
 
         // Verify pre-signed URL args
         // This is already tested thoroughly in UploadServiceTest, so just test basic data flow that aren't constants
         // or config, namely Upload ID, MD5, and Content Type.
         GeneratePresignedUrlRequest presignedUrlRequest = presignedUrlRequestArgumentCaptor.getValue();
-        assertEquals(TEST_BUCKET, presignedUrlRequest.getBucketName());
-        assertEquals(TEST_UPLOAD_MD5, presignedUrlRequest.getContentMd5());
-        assertEquals(TEST_CONTENT_TYPE, presignedUrlRequest.getContentType());
-        assertEquals(expectedUploadId, presignedUrlRequest.getKey());
+        assertEquals(presignedUrlRequest.getBucketName(), TEST_BUCKET);
+        assertEquals(presignedUrlRequest.getContentMd5(), TEST_UPLOAD_MD5);
+        assertEquals(presignedUrlRequest.getContentType(), TEST_CONTENT_TYPE);
+        assertEquals(presignedUrlRequest.getKey(), expectedUploadId);
 
         // Expiration is computed using Java Date instead of Joda Date, which is messy, so we're not going to test that
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceMockTest.java
@@ -1,9 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -14,17 +10,20 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.UploadDao;
@@ -39,7 +38,6 @@ import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 
 @SuppressWarnings("ConstantConditions")
-@RunWith(MockitoJUnitRunner.class)
 public class UploadServiceMockTest {
     
     private static final DateTime START_TIME = DateTime.parse("2016-04-02T10:00:00.000Z");
@@ -66,19 +64,21 @@ public class UploadServiceMockTest {
 
     private UploadService svc;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         svc = new UploadService();
         svc.setUploadDao(mockDao);
         svc.setHealthDataService(mockHealthDataService);
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getNullUploadId() {
         svc.getUpload(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getEmptyUploadId() {
         svc.getUpload("");
     }
@@ -94,15 +94,15 @@ public class UploadServiceMockTest {
 
         // execute and validate
         Upload retVal = svc.getUpload("test-upload-id");
-        assertSame(mockUpload, retVal);
+        assertSame(retVal, mockUpload);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getStatusNullUploadId() {
         svc.getUploadValidationStatus(null);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void getStatusEmptyUploadId() {
         svc.getUploadValidationStatus("");
     }
@@ -120,12 +120,12 @@ public class UploadServiceMockTest {
 
         // execute and validate
         UploadValidationStatus status = svc.getUploadValidationStatus("no-record-id");
-        assertEquals("no-record-id", status.getId());
-        assertEquals(UploadStatus.VALIDATION_FAILED, status.getStatus());
+        assertEquals(status.getId(), "no-record-id");
+        assertEquals(status.getStatus(), UploadStatus.VALIDATION_FAILED);
         assertNull(status.getRecord());
 
-        assertEquals(1, status.getMessageList().size());
-        assertEquals("getStatus - message", status.getMessageList().get(0));
+        assertEquals(status.getMessageList().size(), 1);
+        assertEquals(status.getMessageList().get(0), "getStatus - message");
     }
 
     @Test
@@ -146,12 +146,12 @@ public class UploadServiceMockTest {
 
         // execute and validate
         UploadValidationStatus status = svc.getUploadValidationStatus("with-record-id");
-        assertEquals("with-record-id", status.getId());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
-        assertSame(dummyRecord, status.getRecord());
+        assertEquals(status.getId(), "with-record-id");
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
+        assertSame(status.getRecord(), dummyRecord);
 
-        assertEquals(1, status.getMessageList().size());
-        assertEquals("getStatusWithRecord - message", status.getMessageList().get(0));
+        assertEquals(status.getMessageList().size(), 1);
+        assertEquals(status.getMessageList().get(0), "getStatusWithRecord - message");
     }
 
     // branch coverage
@@ -172,12 +172,12 @@ public class UploadServiceMockTest {
 
         // execute and validate
         UploadValidationStatus status = svc.getUploadValidationStatus("with-record-id");
-        assertEquals("with-record-id", status.getId());
-        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
+        assertEquals(status.getId(), "with-record-id");
+        assertEquals(status.getStatus(), UploadStatus.SUCCEEDED);
         assertNull(status.getRecord());
 
-        assertEquals(1, status.getMessageList().size());
-        assertEquals("getStatusRecordIdWithNoRecord - message", status.getMessageList().get(0));
+        assertEquals(status.getMessageList().size(), 1);
+        assertEquals(status.getMessageList().get(0), "getStatusRecordIdWithNoRecord - message");
     }
     
     @Test
@@ -194,9 +194,9 @@ public class UploadServiceMockTest {
 
         // execute and validate
         UploadView uploadView = svc.getUploadView("with-record-id");
-        assertEquals("test-record-id", uploadView.getUpload().getRecordId());
-        assertEquals("with-record-id", uploadView.getUpload().getUploadId());
-        assertEquals("schema-id", uploadView.getHealthData().getSchemaId());
+        assertEquals(uploadView.getUpload().getRecordId(), "test-record-id");
+        assertEquals(uploadView.getUpload().getUploadId(), "with-record-id");
+        assertEquals(uploadView.getHealthData().getSchemaId(), "schema-id");
     }
     
     private void setupUploadMocks() {
@@ -271,30 +271,30 @@ public class UploadServiceMockTest {
         verifyNoMoreInteractions(mockHealthDataService);
 
         List<? extends UploadView> uploadList = returned.getItems();
-        assertEquals(3, uploadList.size());
+        assertEquals(uploadList.size(), 3);
 
-        assertEquals(API_MAXIMUM_PAGE_SIZE, returned.getRequestParams().get("pageSize"));
-        assertEquals(expectedOffsetKey, returned.getNextPageOffsetKey());
+        assertEquals(returned.getRequestParams().get("pageSize"), API_MAXIMUM_PAGE_SIZE);
+        assertEquals(returned.getNextPageOffsetKey(), expectedOffsetKey);
 
         // The two sources of information are combined in the view.
         UploadView view = uploadList.get(0);
-        assertEquals(UploadStatus.SUCCEEDED, view.getUpload().getStatus());
-        assertEquals("record-id", view.getUpload().getRecordId());
-        assertEquals("schema-id", view.getSchemaId());
-        assertEquals(new Integer(10), view.getSchemaRevision());
-        assertEquals(HealthDataRecord.ExporterStatus.SUCCEEDED, view.getHealthRecordExporterStatus());
+        assertEquals(view.getUpload().getStatus(), UploadStatus.SUCCEEDED);
+        assertEquals(view.getUpload().getRecordId(), "record-id");
+        assertEquals(view.getSchemaId(), "schema-id");
+        assertEquals(view.getSchemaRevision(), new Integer(10));
+        assertEquals(view.getHealthRecordExporterStatus(), HealthDataRecord.ExporterStatus.SUCCEEDED);
         assertNull(view.getHealthData());
 
         UploadView failedView = uploadList.get(1);
-        assertEquals(UploadStatus.REQUESTED, failedView.getUpload().getStatus());
+        assertEquals(failedView.getUpload().getStatus(), UploadStatus.REQUESTED);
         assertNull(failedView.getUpload().getRecordId());
         assertNull(failedView.getSchemaId());
         assertNull(failedView.getSchemaRevision());
         assertNull(failedView.getHealthRecordExporterStatus());
 
         UploadView viewWithNoRecord = uploadList.get(2);
-        assertEquals(UploadStatus.SUCCEEDED, viewWithNoRecord.getUpload().getStatus());
-        assertEquals("missing-record-id", viewWithNoRecord.getUpload().getRecordId());
+        assertEquals(viewWithNoRecord.getUpload().getStatus(), UploadStatus.SUCCEEDED);
+        assertEquals(viewWithNoRecord.getUpload().getRecordId(), "missing-record-id");
         assertNull(viewWithNoRecord.getSchemaId());
         assertNull(viewWithNoRecord.getSchemaRevision());
         assertNull(viewWithNoRecord.getHealthRecordExporterStatus());
@@ -329,10 +329,10 @@ public class UploadServiceMockTest {
         
         DateTime actualStart = start.getValue();
         DateTime actualEnd = end.getValue();
-        assertEquals(actualStart.plusDays(1), actualEnd);
+        assertEquals(actualEnd, actualStart.plusDays(1));
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void verifiesEndTimeNotBeforeStartTime() {
         svc.getUploads("ABC", END_TIME, START_TIME, 0, null);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServicePollStatusTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServicePollStatusTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
@@ -20,7 +21,7 @@ public class UploadServicePollStatusTest {
 
     private UploadService svc;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Spy service, so we can mock a call to getValidationStatus() instead of tightly coupling to that logic.
         svc = spy(new UploadService());
@@ -34,7 +35,7 @@ public class UploadServicePollStatusTest {
     public void firstTry() {
         doReturn(makeValidationStatus(UploadStatus.SUCCEEDED)).when(svc).getUploadValidationStatus(UPLOAD_ID);
         UploadValidationStatus validationStatus = svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
-        assertEquals(UploadStatus.SUCCEEDED, validationStatus.getStatus());
+        assertEquals(validationStatus.getStatus(), UploadStatus.SUCCEEDED);
         verify(svc, times(1)).getUploadValidationStatus(UPLOAD_ID);
     }
 
@@ -45,7 +46,7 @@ public class UploadServicePollStatusTest {
 
         doReturn(inProgressStatus).doReturn(succeededStatus).when(svc).getUploadValidationStatus(UPLOAD_ID);
         UploadValidationStatus validationStatus = svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
-        assertEquals(UploadStatus.SUCCEEDED, validationStatus.getStatus());
+        assertEquals(validationStatus.getStatus(), UploadStatus.SUCCEEDED);
         verify(svc, times(2)).getUploadValidationStatus(UPLOAD_ID);
     }
 
@@ -58,7 +59,7 @@ public class UploadServicePollStatusTest {
             svc.pollUploadValidationStatusUntilComplete(UPLOAD_ID);
             fail("expected exception");
         } catch (BridgeServiceException ex) {
-            assertEquals("Timeout polling validation status for upload " + UPLOAD_ID, ex.getMessage());
+            assertEquals(ex.getMessage(), "Timeout polling validation status for upload " + UPLOAD_ID);
         }
         verify(svc, times(2)).getUploadValidationStatus(UPLOAD_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteMockTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -11,13 +9,16 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.models.upload.UploadCompletionClient.APP;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -40,7 +41,7 @@ public class UploadServiceUploadCompleteMockTest {
     private UploadValidationService mockUploadValidationService;
     private UploadService svc;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // mock config
         BridgeConfig mockConfig = mock(BridgeConfig.class);

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadValidationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadValidationServiceTest.java
@@ -6,7 +6,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.models.studies.Study;

--- a/src/test/java/org/sagebionetworks/bridge/services/UrlShortenerServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UrlShortenerServiceTest.java
@@ -1,24 +1,23 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UrlShortenerServiceTest {
 
     private static final String WEBSERVICES_URL = BridgeConfigFactory.getConfig().get("webservices.url");
@@ -34,8 +33,10 @@ public class UrlShortenerServiceTest {
     @Spy
     private UrlShortenerService service;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service.setCacheProvider(cacheProvider);
         when(service.getToken()).thenReturn(TOKEN, NEXT_TOKEN);
     }
@@ -44,7 +45,7 @@ public class UrlShortenerServiceTest {
     public void newUrl() {
         // nothing in the cache
         String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
-        assertEquals(WEBSERVICES_URL+"/r/"+TOKEN, shortenedUrl);
+        assertEquals(shortenedUrl, WEBSERVICES_URL+"/r/"+TOKEN);
 
         verify(cacheProvider).setObject(CacheKey.shortenUrl(TOKEN), LONG_URL, EXPIRES_IN);
     }
@@ -55,7 +56,7 @@ public class UrlShortenerServiceTest {
         when(cacheProvider.getObject(key, String.class)).thenReturn(ANOTHER_LONG_URL);
         
         String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
-        assertEquals(WEBSERVICES_URL+"/r/"+NEXT_TOKEN, shortenedUrl);
+        assertEquals(shortenedUrl, WEBSERVICES_URL+"/r/"+NEXT_TOKEN);
         
         verify(cacheProvider).setObject(CacheKey.shortenUrl(NEXT_TOKEN), LONG_URL, EXPIRES_IN);
     }
@@ -66,7 +67,7 @@ public class UrlShortenerServiceTest {
         when(cacheProvider.getObject(key, String.class)).thenReturn(LONG_URL);
         
         String shortenedUrl = service.shortenUrl(LONG_URL, EXPIRES_IN);
-        assertEquals(WEBSERVICES_URL+"/r/"+TOKEN, shortenedUrl);
+        assertEquals(shortenedUrl, WEBSERVICES_URL+"/r/"+TOKEN);
         
         verify(cacheProvider, never()).setObject(any(), any(), anyInt());
     }
@@ -77,7 +78,7 @@ public class UrlShortenerServiceTest {
         when(cacheProvider.getObject(key, String.class)).thenReturn(LONG_URL);
         
         String longUrl = service.retrieveUrl(TOKEN);
-        assertEquals(LONG_URL, longUrl);
+        assertEquals(longUrl, LONG_URL);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
@@ -9,18 +8,19 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
@@ -45,7 +45,6 @@ import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UserAdminServiceMockTest {
     
     @Mock
@@ -97,8 +96,10 @@ public class UserAdminServiceMockTest {
     
     private Map<SubpopulationGuid,ConsentStatus> statuses;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         service = new UserAdminService();
         service.setAuthenticationService(authenticationService);
         service.setConsentService(consentService);
@@ -130,7 +131,7 @@ public class UserAdminServiceMockTest {
                 anyString(), anyBoolean());
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
     }
@@ -161,7 +162,7 @@ public class UserAdminServiceMockTest {
         verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
-        assertEquals(study.getStudyIdentifier(), context.getStudyIdentifier());
+        assertEquals(context.getStudyIdentifier(), study.getStudyIdentifier());
         
         verify(consentService).consentToResearch(eq(study), eq(SubpopulationGuid.create("foo1")), any(StudyParticipant.class), any(),
                 eq(SharingScope.NO_SHARING), eq(false));
@@ -169,8 +170,8 @@ public class UserAdminServiceMockTest {
                 eq(SharingScope.NO_SHARING), eq(false));
 
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(participant.getEmail(), signIn.getEmail());
-        assertEquals(participant.getPassword(), signIn.getPassword());
+        assertEquals(signIn.getEmail(), participant.getEmail());
+        assertEquals(signIn.getPassword(), participant.getPassword());
         
         verify(consentService).getConsentStatuses(context);
     }
@@ -190,16 +191,16 @@ public class UserAdminServiceMockTest {
         verify(authenticationService).signIn(eq(study), contextCaptor.capture(), signInCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
-        assertEquals(study.getStudyIdentifier(), context.getStudyIdentifier());
+        assertEquals(context.getStudyIdentifier(), study.getStudyIdentifier());
         
         SignIn signIn = signInCaptor.getValue();
-        assertEquals(participant.getPhone(), signIn.getPhone());
-        assertEquals(participant.getPassword(), signIn.getPassword());
+        assertEquals(signIn.getPhone(), participant.getPhone());
+        assertEquals(signIn.getPassword(), participant.getPassword());
         
         verify(consentService).getConsentStatuses(context);
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void creatingUserWithoutEmailOrPhoneProhibited() {
         Study study = TestUtils.getValidStudy(UserAdminServiceMockTest.class);
         StudyParticipant participant = new StudyParticipant.Builder().withPassword("password").build();
@@ -263,7 +264,7 @@ public class UserAdminServiceMockTest {
         verify(externalIdService).unassignExternalId(accountCaptor.capture(), eq("subBextId"));
         verify(accountDao).deleteAccount(accountId);
         
-        assertEquals("healthCode", accountCaptor.getValue().getHealthCode());
+        assertEquals(accountCaptor.getValue().getHealthCode(), "healthCode");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UserDataDownloadViaSqsServiceTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -13,14 +12,15 @@ import static org.sagebionetworks.bridge.services.UserDataDownloadViaSqsService.
 import static org.sagebionetworks.bridge.services.UserDataDownloadViaSqsService.REQUEST_KEY_STUDY_ID;
 import static org.sagebionetworks.bridge.services.UserDataDownloadViaSqsService.REQUEST_KEY_USER_ID;
 import static org.sagebionetworks.bridge.services.UserDataDownloadViaSqsService.UDD_SERVICE_TITLE;
+import static org.testng.Assert.assertEquals;
 
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.LocalDate;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -73,9 +73,9 @@ public class UserDataDownloadViaSqsServiceTest {
         JsonNode msgBody = sqsMessageNode.path(REQUEST_KEY_BODY);
         assertEquals(msgBody.size(), 4);
 
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, msgBody.get(REQUEST_KEY_STUDY_ID).textValue());
-        assertEquals(USER_ID, msgBody.get(REQUEST_KEY_USER_ID).textValue());
-        assertEquals(START_DATE, msgBody.get(REQUEST_KEY_START_DATE).textValue());
-        assertEquals(END_DATE, msgBody.get(REQUEST_KEY_END_DATE).textValue());
+        assertEquals(msgBody.get(REQUEST_KEY_STUDY_ID).textValue(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(msgBody.get(REQUEST_KEY_USER_ID).textValue(), USER_ID);
+        assertEquals(msgBody.get(REQUEST_KEY_START_DATE).textValue(), START_DATE);
+        assertEquals(msgBody.get(REQUEST_KEY_END_DATE).textValue(), END_DATE);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/backfill/AsyncBackfillTemplateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/backfill/AsyncBackfillTemplateTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -31,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
 
 public class AsyncBackfillTemplateTest {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncBackfillTemplateTest.class);

--- a/src/test/java/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/backfill/BackfillRecordFactoryTest.java
@@ -1,16 +1,17 @@
 package org.sagebionetworks.bridge.services.backfill;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dao.BackfillDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.backfill.BackfillRecord;
@@ -48,11 +49,11 @@ public class BackfillRecordFactoryTest {
         when(task.getId()).thenReturn(taskId);
         final String message = "this is a message";
         BackfillRecord record = recordFactory.createOnly(task, message);
-        assertEquals(taskId, record.getTaskId());
+        assertEquals(record.getTaskId(), taskId);
         assertTrue(record.getTimestamp() <= DateTime.now(DateTimeZone.UTC).getMillis());
         JsonNode node = record.toJsonNode();
         assertNotNull(node);
-        assertEquals(message, node.asText());
+        assertEquals(node.asText(), message);
     }
 
     @Test
@@ -69,12 +70,12 @@ public class BackfillRecordFactoryTest {
         when(account.getId()).thenReturn(accountId);
         final String message = "message";
         BackfillRecord record = recordFactory.createOnly(task, study, account, message);
-        assertEquals(taskId, record.getTaskId());
+        assertEquals(record.getTaskId(), taskId);
         assertTrue(record.getTimestamp() <= DateTime.now(DateTimeZone.UTC).getMillis());
         JsonNode node = record.toJsonNode();
         assertNotNull(node);
-        assertEquals(studyId, node.get("study").asText());
-        assertEquals(accountId, node.get("account").asText());
-        assertEquals(message, node.get("message").asText());
+        assertEquals(node.get("study").asText(), studyId);
+        assertEquals(node.get("account").asText(), accountId);
+        assertEquals(node.get("message").asText(), message);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/backfill/SchemaSurveyGuidBackfillTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/backfill/SchemaSurveyGuidBackfillTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.services.backfill;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doNothing;
@@ -10,11 +9,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -56,7 +56,7 @@ public class SchemaSurveyGuidBackfillTest {
     private SurveyService surveyService;
     private UploadSchemaService uploadSchemaService;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Mock dependencies. Behavior will be set up in individual tests.
         studyService = mock(StudyService.class);
@@ -127,29 +127,29 @@ public class SchemaSurveyGuidBackfillTest {
         verify(uploadSchemaService).updateSchemaRevisionV4(eq(study1Id), eq("survey-1a"), eq(11),
                 schema1aCaptor.capture());
         UploadSchema schema1a = schema1aCaptor.getValue();
-        assertEquals("guid-1a", schema1a.getSurveyGuid());
-        assertEquals(0x1a, schema1a.getSurveyCreatedOn().longValue());
+        assertEquals(schema1a.getSurveyGuid(), "guid-1a");
+        assertEquals(schema1a.getSurveyCreatedOn().longValue(), 0x1a);
 
         ArgumentCaptor<UploadSchema> schema1bCaptor = ArgumentCaptor.forClass(UploadSchema.class);
         verify(uploadSchemaService).updateSchemaRevisionV4(eq(study1Id), eq("survey-1b"), eq(12),
                 schema1bCaptor.capture());
         UploadSchema schema1b = schema1bCaptor.getValue();
-        assertEquals("guid-1b", schema1b.getSurveyGuid());
-        assertEquals(0x1b, schema1b.getSurveyCreatedOn().longValue());
+        assertEquals(schema1b.getSurveyGuid(), "guid-1b");
+        assertEquals(schema1b.getSurveyCreatedOn().longValue(), 0x1b);
 
         ArgumentCaptor<UploadSchema> schema2aCaptor = ArgumentCaptor.forClass(UploadSchema.class);
         verify(uploadSchemaService).updateSchemaRevisionV4(eq(study2Id), eq("survey-2a"), eq(21),
                 schema2aCaptor.capture());
         UploadSchema schema2a = schema2aCaptor.getValue();
-        assertEquals("guid-2a", schema2a.getSurveyGuid());
-        assertEquals(0x2a, schema2a.getSurveyCreatedOn().longValue());
+        assertEquals(schema2a.getSurveyGuid(), "guid-2a");
+        assertEquals(schema2a.getSurveyCreatedOn().longValue(), 0x2a);
 
         ArgumentCaptor<UploadSchema> schema2bCaptor = ArgumentCaptor.forClass(UploadSchema.class);
         verify(uploadSchemaService).updateSchemaRevisionV4(eq(study2Id), eq("survey-2b"), eq(22),
                 schema2bCaptor.capture());
         UploadSchema schema2b = schema2bCaptor.getValue();
-        assertEquals("guid-2b", schema2b.getSurveyGuid());
-        assertEquals(0x2b, schema2b.getSurveyCreatedOn().longValue());
+        assertEquals(schema2b.getSurveyGuid(), "guid-2b");
+        assertEquals(schema2b.getSurveyCreatedOn().longValue(), 0x2b);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.io.InputStream;
 import java.util.Map;
@@ -10,7 +10,8 @@ import javax.mail.Part;
 import javax.mail.internet.MimeBodyPart;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -46,21 +47,21 @@ public class BasicEmailProviderTest {
             .build();
 
         // Check provider attributes
-        assertEquals("Name <support@email.com>", provider.getFormattedSenderEmail());
-        assertEquals(EmailType.EMAIL_SIGN_IN, provider.getType());
+        assertEquals(provider.getFormattedSenderEmail(), "Name <support@email.com>");
+        assertEquals(provider.getType(), EmailType.EMAIL_SIGN_IN);
 
         // Check email
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals("Subject some-url", email.getSubject());
-        assertEquals("\"Name\" <support@email.com>", email.getSenderAddress());
-        assertEquals(Sets.newHashSet("recipient@recipient.com", "recipient2@recipient.com"),
-                Sets.newHashSet(email.getRecipientAddresses()));
-        assertEquals(EmailType.EMAIL_SIGN_IN, email.getType());
+        assertEquals(email.getSubject(), "Subject some-url");
+        assertEquals(email.getSenderAddress(), "\"Name\" <support@email.com>");
+        assertEquals(Sets.newHashSet(email.getRecipientAddresses()),
+                Sets.newHashSet("recipient@recipient.com", "recipient2@recipient.com"));
+        assertEquals(email.getType(), EmailType.EMAIL_SIGN_IN);
 
         MimeBodyPart body = email.getMessageParts().get(0);
         String bodyString = (String)body.getContent();
-        assertEquals("Name ShortName id SponsorName support@email.com tech@email.com consent@email.com some-url 1 hour", 
-                bodyString);
+        assertEquals(bodyString,
+                "Name ShortName id SponsorName support@email.com tech@email.com consent@email.com some-url 1 hour");
     }
 
     @Test
@@ -77,7 +78,7 @@ public class BasicEmailProviderTest {
                 .withOverrideSenderEmail("example@example.com").withStudy(study).build();
 
         // Check provider attributes
-        assertEquals("example@example.com", provider.getPlainSenderEmail());
+        assertEquals(provider.getPlainSenderEmail(), "example@example.com");
     }
     
     @Test
@@ -108,9 +109,9 @@ public class BasicEmailProviderTest {
         MimeBodyPart attachment = email.getMessageParts().get(1);
         
         String bodyContent = IOUtils.toString((InputStream)attachment.getContent()); 
-        assertEquals("content.pdf", attachment.getFileName());
-        assertEquals("some data", bodyContent);
-        assertEquals(Part.ATTACHMENT, attachment.getDisposition());
+        assertEquals(attachment.getFileName(), "content.pdf");
+        assertEquals(bodyContent, "some data");
+        assertEquals(attachment.getDisposition(), Part.ATTACHMENT);
         // the mime type isn't changed because headers are not updated until you call
         // MimeMessage.saveChanges(), and these objects do not include the final 
         // Java Mail MimeMessage object.

--- a/src/test/java/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.net.URLEncoder;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
@@ -45,10 +45,10 @@ public class EmailSignInEmailProviderTest {
         String finalBody = String.format("Click here to sign in: <a href=\"%s\">%s</a>", url, url);
         
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals("\"Study name\" <support@email.com>", email.getSenderAddress());
-        assertEquals(RECIPIENT_EMAIL, email.getRecipientAddresses().get(0));
-        assertEquals("Study name sign in link", email.getSubject());
-        assertEquals(finalBody, email.getMessageParts().get(0).getContent());
+        assertEquals(email.getSenderAddress(), "\"Study name\" <support@email.com>");
+        assertEquals(email.getRecipientAddresses().get(0), RECIPIENT_EMAIL);
+        assertEquals(email.getSubject(), "Study name sign in link");
+        assertEquals(email.getMessageParts().get(0).getContent(), finalBody);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/email/MimeTypeEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/MimeTypeEmailProviderTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import javax.mail.MessagingException;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.studies.Study;
 
@@ -26,8 +26,8 @@ public class MimeTypeEmailProviderTest {
         
         MimeTypeEmailProvider provider = new MimeTypeEmailProviderImpl(study);
         
-        assertEquals("support@support.com", provider.getPlainSenderEmail());
-        assertEquals("Very Useful Study 🐶 <support@support.com>", provider.getFormattedSenderEmail());
+        assertEquals(provider.getPlainSenderEmail(), "support@support.com");
+        assertEquals(provider.getFormattedSenderEmail(), "Very Useful Study 🐶 <support@support.com>");
     }
     
     @Test
@@ -38,7 +38,7 @@ public class MimeTypeEmailProviderTest {
         
         MimeTypeEmailProvider provider = new MimeTypeEmailProviderImpl(study);
         
-        assertEquals("support@support.com", provider.getPlainSenderEmail());
-        assertEquals("Very Useful Study 🐶 <support@support.com>", provider.getFormattedSenderEmail());
+        assertEquals(provider.getPlainSenderEmail(), "support@support.com");
+        assertEquals(provider.getFormattedSenderEmail(), "Very Useful Study 🐶 <support@support.com>");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/email/MimeTypeEmailTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/MimeTypeEmailTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -9,7 +9,8 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 public class MimeTypeEmailTest {
     private static final String SUBJECT = "subject";
@@ -35,53 +36,53 @@ public class MimeTypeEmailTest {
     @Test
     public void testAttributes() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("test@example.com");
-        assertEquals(SUBJECT, email.getSubject());
-        assertEquals(EmailType.EMAIL_SIGN_IN, email.getType());
+        assertEquals(email.getSubject(), SUBJECT);
+        assertEquals(email.getType(), EmailType.EMAIL_SIGN_IN);
 
-        assertEquals(1, email.getMessageParts().size());
-        assertEquals("dummy content", email.getMessageParts().get(0).getContent());
+        assertEquals(email.getMessageParts().size(), 1);
+        assertEquals(email.getMessageParts().get(0).getContent(), "dummy content");
     }
 
     @Test
     public void senderUnadornedEmailNotChanged() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("test@test.com");
-        assertEquals("test@test.com", email.getSenderAddress());
+        assertEquals(email.getSenderAddress(), "test@test.com");
     }
     
     @Test
     public void senderOddlyFormattedButLegal() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("<test@test.com>");
-        assertEquals("<test@test.com>", email.getSenderAddress());
+        assertEquals(email.getSenderAddress(), "<test@test.com>");
     }
     
     @Test
     public void senderAddressWithNameQuoted() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("A, B, and C <test@test.com>");
-        assertEquals("\"A, B, and C\" <test@test.com>", email.getSenderAddress());
+        assertEquals(email.getSenderAddress(), "\"A, B, and C\" <test@test.com>");
     }
     
     @Test
     public void senderAddressWithNameWithQuotesItsAllQuoted() throws Exception {
         MimeTypeEmail email = makeEmailWithSender("The \"Fun Guys\" at UofW <test@test.com>");
-        assertEquals("\"The \\\"Fun Guys\\\" at UofW\" <test@test.com>", email.getSenderAddress());
+        assertEquals(email.getSenderAddress(), "\"The \\\"Fun Guys\\\" at UofW\" <test@test.com>");
     }
 
     @Test
     public void recipientUnadornedEmailNotChanged() throws Exception {
         MimeTypeEmail email = makeEmailWithRecipient("test@test.com");
-        assertEquals("test@test.com", email.getRecipientAddresses().get(0));
+        assertEquals(email.getRecipientAddresses().get(0), "test@test.com");
     }
     
     @Test
     public void recipientAddressWithNameQuoted() throws Exception {
         MimeTypeEmail email = makeEmailWithRecipient("A, B, and C <test@test.com>");
-        assertEquals("\"A, B, and C\" <test@test.com>", email.getRecipientAddresses().get(0));
+        assertEquals(email.getRecipientAddresses().get(0), "\"A, B, and C\" <test@test.com>");
     }
     
     @Test
     public void recipientAddressWithNameWithQuotesItsAllQuoted() throws Exception {
         MimeTypeEmail email = makeEmailWithRecipient("The \"Fun Guys\" at UofW <test@test.com>");
-        assertEquals("\"The \\\"Fun Guys\\\" at UofW\" <test@test.com>", email.getRecipientAddresses().get(0));
+        assertEquals(email.getRecipientAddresses().get(0), "\"The \\\"Fun Guys\\\" at UofW\" <test@test.com>");
     }
 
     @Test
@@ -91,10 +92,10 @@ public class MimeTypeEmailTest {
         MimeTypeEmail email = new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
                 .withRecipients(recipientList).withMessageParts(makeBodyPart("dummy content"))
                 .withType(EmailType.EMAIL_SIGN_IN).build();
-        assertEquals(recipientList, email.getRecipientAddresses());
+        assertEquals(email.getRecipientAddresses(), recipientList);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void filterOutNullMessagePartVarargs() {
         // This will throw an IllegalArgumentException, since we don't allow null message parts list.
         new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
@@ -110,9 +111,9 @@ public class MimeTypeEmailTest {
                 .withType(EmailType.EMAIL_SIGN_IN).build();
 
         List<MimeBodyPart> partList = email.getMessageParts();
-        assertEquals(2, partList.size());
-        assertEquals("foo", partList.get(0).getContent());
-        assertEquals("bar", partList.get(1).getContent());
+        assertEquals(partList.size(), 2);
+        assertEquals(partList.get(0).getContent(), "foo");
+        assertEquals(partList.get(1).getContent(), "bar");
     }
 
     @Test
@@ -120,6 +121,6 @@ public class MimeTypeEmailTest {
         MimeTypeEmail email = new MimeTypeEmailBuilder().withSubject(SUBJECT).withSender("sender@example.com")
                 .withRecipient("recipient@example.com").withMessageParts(makeBodyPart("dummy content"))
                 .withType(null).build();
-        assertEquals(EmailType.UNKNOWN, email.getType());
+        assertEquals(email.getType(), EmailType.UNKNOWN);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/WithdrawConsentEmailProviderTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.services.email;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
 import javax.mail.internet.MimeBodyPart;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
@@ -25,7 +25,7 @@ public class WithdrawConsentEmailProviderTest {
     private Study study;
     private Account account;
     
-    @Before
+    @BeforeMethod
     public void before() {
         study = mock(Study.class);
         
@@ -44,19 +44,20 @@ public class WithdrawConsentEmailProviderTest {
 
         provider = new WithdrawConsentEmailProvider(study, account, new Withdrawal(null), UNIX_TIMESTAMP);
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals(EmailType.WITHDRAW_CONSENT, email.getType());
+        assertEquals(email.getType(), EmailType.WITHDRAW_CONSENT);
         
         List<String> recipients = email.getRecipientAddresses();
-        assertEquals(1, recipients.size());
-        assertEquals("a@a.com", recipients.get(0));
+        assertEquals(recipients.size(), 1);
+        assertEquals(recipients.get(0), "a@a.com");
         
         String sender = email.getSenderAddress();
-        assertEquals("\"Study Name\" <c@c.com>", sender);
+        assertEquals(sender, "\"Study Name\" <c@c.com>");
         
-        assertEquals("Notification of consent withdrawal for Study Name", email.getSubject());
+        assertEquals(email.getSubject(), "Notification of consent withdrawal for Study Name");
         
         MimeBodyPart body = email.getMessageParts().get(0);
-        assertEquals("<p>User   &lt;d@d.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p><i>No reason given.</i></p>", body.getContent());
+        assertEquals(body.getContent(),
+                "<p>User   &lt;d@d.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p><i>No reason given.</i></p>");
     }
 
     @Test
@@ -70,20 +71,21 @@ public class WithdrawConsentEmailProviderTest {
 
         provider = new WithdrawConsentEmailProvider(study, account, WITHDRAWAL, UNIX_TIMESTAMP);
         MimeTypeEmail email = provider.getMimeTypeEmail();
-        assertEquals(EmailType.WITHDRAW_CONSENT, email.getType());
+        assertEquals(email.getType(), EmailType.WITHDRAW_CONSENT);
 
         List<String> recipients = email.getRecipientAddresses();
-        assertEquals(2, recipients.size());
-        assertEquals("a@a.com", recipients.get(0));
-        assertEquals("b@b.com", recipients.get(1));
+        assertEquals(recipients.size(), 2);
+        assertEquals(recipients.get(0), "a@a.com");
+        assertEquals(recipients.get(1), "b@b.com");
         
         String sender = email.getSenderAddress();
-        assertEquals("\"Study Name\" <c@c.com>", sender);
+        assertEquals(sender, "\"Study Name\" <c@c.com>");
         
-        assertEquals("Notification of consent withdrawal for Study Name", email.getSubject());
+        assertEquals(email.getSubject(), "Notification of consent withdrawal for Study Name");
         
         MimeBodyPart body = email.getMessageParts().get(0);
-        assertEquals("<p>User Jack Aubrey &lt;d@d.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>Because, reasons.</p>", body.getContent());
+        assertEquals(body.getContent(),
+                "<p>User Jack Aubrey &lt;d@d.com&gt; withdrew from the study on October 28, 2015. </p><p>Reason:</p><p>Because, reasons.</p>");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.sms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.sms.SmsType;
@@ -38,28 +39,28 @@ public class SmsMessageProviderTest {
             .withTransactionType()
             .withExpirationPeriod("expirationPeriod", 60*60*4) // 4 hours
             .withToken("url", "some-url").build();
-        assertEquals("Transactional", provider.getSmsType());
-        assertEquals(SmsType.TRANSACTIONAL, provider.getSmsTypeEnum());
-        assertEquals(expectedMessage, provider.getFormattedMessage());
+        assertEquals(provider.getSmsType(), "Transactional");
+        assertEquals(provider.getSmsTypeEnum(), SmsType.TRANSACTIONAL);
+        assertEquals(provider.getFormattedMessage(), expectedMessage);
 
         // Check email
         PublishRequest request = provider.getSmsRequest();
-        assertEquals(expectedMessage, request.getMessage());
-        assertEquals(study.getShortName(),
-                request.getMessageAttributes().get(BridgeConstants.AWS_SMS_SENDER_ID).getStringValue());
-        assertEquals("Transactional",
-                request.getMessageAttributes().get(BridgeConstants.AWS_SMS_TYPE).getStringValue());
+        assertEquals(request.getMessage(), expectedMessage);
+        assertEquals(request.getMessageAttributes().get(BridgeConstants.AWS_SMS_SENDER_ID).getStringValue(),
+                study.getShortName());
+        assertEquals(request.getMessageAttributes().get(BridgeConstants.AWS_SMS_TYPE).getStringValue(),
+                "Transactional");
         
-        assertEquals("some-url", provider.getTokenMap().get("url"));
-        assertEquals("4 hours", provider.getTokenMap().get("expirationPeriod"));
+        assertEquals(provider.getTokenMap().get("url"), "some-url");
+        assertEquals(provider.getTokenMap().get("expirationPeriod"), "4 hours");
         // BridgeUtils.studyTemplateVariables() has been called
-        assertEquals("Name", provider.getTokenMap().get("studyName"));
-        assertEquals("ShortName", provider.getTokenMap().get("studyShortName"));
-        assertEquals("id", provider.getTokenMap().get("studyId"));
-        assertEquals("SponsorName", provider.getTokenMap().get("sponsorName"));
-        assertEquals("support@email.com", provider.getTokenMap().get("supportEmail"));
-        assertEquals("tech@email.com", provider.getTokenMap().get("technicalEmail"));
-        assertEquals("consent@email.com", provider.getTokenMap().get("consentEmail"));
+        assertEquals(provider.getTokenMap().get("studyName"), "Name");
+        assertEquals(provider.getTokenMap().get("studyShortName"), "ShortName");
+        assertEquals(provider.getTokenMap().get("studyId"), "id");
+        assertEquals(provider.getTokenMap().get("sponsorName"), "SponsorName");
+        assertEquals(provider.getTokenMap().get("supportEmail"), "support@email.com");
+        assertEquals(provider.getTokenMap().get("technicalEmail"), "tech@email.com");
+        assertEquals(provider.getTokenMap().get("consentEmail"), "consent@email.com");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -15,8 +15,8 @@ import java.io.InputStream;
 import com.google.common.base.Charsets;
 
 import com.google.common.io.ByteStreams;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
@@ -58,12 +58,12 @@ public class DecryptHandlerTest {
         // execute and validate
         handler.handle(ctx);
         byte[] decryptedContent = fileHelper.getBytes(ctx.getDecryptedDataFile());
-        assertEquals("decrypted test data", new String(decryptedContent, Charsets.UTF_8));
+        assertEquals(new String(decryptedContent, Charsets.UTF_8), "decrypted test data");
 
         // Verify the correct file data was passed into the decryptor.
         ArgumentCaptor<InputStream> encryptedInputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
         verify(mockSvc).decrypt(eq(study.getIdentifier()), encryptedInputStreamCaptor.capture());
         InputStream encryptedInputStream = encryptedInputStreamCaptor.getValue();
-        assertArrayEquals(dataFileContent, ByteStreams.toByteArray(encryptedInputStream));
+        assertArrayEquals(ByteStreams.toByteArray(encryptedInputStream), dataFileContent);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.upload;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -64,6 +63,6 @@ public class DecryptHandlerTest {
         ArgumentCaptor<InputStream> encryptedInputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
         verify(mockSvc).decrypt(eq(study.getIdentifier()), encryptedInputStreamCaptor.capture());
         InputStream encryptedInputStream = encryptedInputStreamCaptor.getValue();
-        assertArrayEquals(ByteStreams.toByteArray(encryptedInputStream), dataFileContent);
+        assertEquals(ByteStreams.toByteArray(encryptedInputStream), dataFileContent);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerCreatedOnTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerCreatedOnTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -44,12 +44,12 @@ public class GenericUploadFormatHandlerCreatedOnTest {
         GenericUploadFormatHandler.parseCreatedOnToRecord(context, infoJsonNode, record);
 
         // createdOn is MOCK_NOW_MILLIS with no timezone
-        assertEquals(MOCK_NOW_MILLIS, record.getCreatedOn().longValue());
+        assertEquals(record.getCreatedOn().longValue(), MOCK_NOW_MILLIS);
         assertNull(record.getCreatedOnTimeZone());
 
         // one message
-        assertEquals(1, context.getMessageList().size());
-        assertEquals("Upload has no createdOn; using current time.", context.getMessageList().get(0));
+        assertEquals(context.getMessageList().size(), 1);
+        assertEquals(context.getMessageList().get(0), "Upload has no createdOn; using current time.");
     }
 
     @Test
@@ -66,13 +66,13 @@ public class GenericUploadFormatHandlerCreatedOnTest {
         GenericUploadFormatHandler.parseCreatedOnToRecord(context, infoJsonNode, record);
 
         // createdOn is MOCK_NOW_MILLIS with no timezone
-        assertEquals(MOCK_NOW_MILLIS, record.getCreatedOn().longValue());
+        assertEquals(record.getCreatedOn().longValue(), MOCK_NOW_MILLIS);
         assertNull(record.getCreatedOnTimeZone());
 
         // two messages
-        assertEquals(2, context.getMessageList().size());
-        assertEquals("Invalid date-time: Tuesday morning", context.getMessageList().get(0));
-        assertEquals("Upload has no createdOn; using current time.", context.getMessageList().get(1));
+        assertEquals(context.getMessageList().size(), 2);
+        assertEquals(context.getMessageList().get(0), "Invalid date-time: Tuesday morning");
+        assertEquals(context.getMessageList().get(1), "Upload has no createdOn; using current time.");
     }
 
     @Test
@@ -89,8 +89,8 @@ public class GenericUploadFormatHandlerCreatedOnTest {
         GenericUploadFormatHandler.parseCreatedOnToRecord(context, infoJsonNode, record);
 
         // validate createdOn and timeZone
-        assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
-        assertEquals(CREATED_ON_TIMEZONE, record.getCreatedOnTimeZone());
+        assertEquals(record.getCreatedOn().longValue(), CREATED_ON_MILLIS);
+        assertEquals(record.getCreatedOnTimeZone(), CREATED_ON_TIMEZONE);
 
         // no messages
         assertTrue(context.getMessageList().isEmpty());

--- a/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerGetSchemaTest.java
@@ -1,14 +1,15 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -32,7 +33,7 @@ public class GenericUploadFormatHandlerGetSchemaTest {
     private GenericUploadFormatHandler handler;
     private SurveyService mockSurveyService;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         UploadSchemaService mockSchemaService = mock(UploadSchemaService.class);
         when(mockSchemaService.getUploadSchemaByIdAndRev(TestConstants.TEST_STUDY, SCHEMA_ID, SCHEMA_REV)).thenReturn(
@@ -62,7 +63,7 @@ public class GenericUploadFormatHandlerGetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJsonNode);
-        assertSame(DUMMY_SCHEMA, retVal);
+        assertSame(retVal, DUMMY_SCHEMA);
     }
 
     @Test
@@ -86,8 +87,8 @@ public class GenericUploadFormatHandlerGetSchemaTest {
             handler.getUploadSchema(TestConstants.TEST_STUDY, infoJsonNode);
             fail("expected exception");
         } catch (UploadValidationException ex) {
-            assertEquals("Schema not found for survey " + SURVEY_GUID + ":" + SURVEY_CREATED_ON_MILLIS,
-                    ex.getMessage());
+            assertEquals(ex.getMessage(),
+                    "Schema not found for survey " + SURVEY_GUID + ":" + SURVEY_CREATED_ON_MILLIS);
         }
     }
 
@@ -100,7 +101,7 @@ public class GenericUploadFormatHandlerGetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TestConstants.TEST_STUDY, infoJsonNode);
-        assertSame(DUMMY_SCHEMA, retVal);
+        assertSame(retVal, DUMMY_SCHEMA);
     }
 
     @Test
@@ -113,8 +114,8 @@ public class GenericUploadFormatHandlerGetSchemaTest {
             handler.getUploadSchema(TestConstants.TEST_STUDY, infoJsonNode);
             fail("expected exception");
         } catch (UploadValidationException ex) {
-            assertEquals("info.json must contain either item and schemaRevision or surveyGuid and surveyCreatedOn",
-                    ex.getMessage());
+            assertEquals(ex.getMessage(),
+                    "info.json must contain either item and schemaRevision or surveyGuid and surveyCreatedOn");
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/GenericUploadFormatHandlerTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -10,6 +7,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.util.Map;
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
@@ -55,7 +55,7 @@ public class GenericUploadFormatHandlerTest {
     private UploadSchemaService mockSchemaService;
     private File tmpDir;
 
-    @Before
+    @BeforeMethod
     public void setup() throws Exception {
         // Set up InMemoryFileHelper with tmp dir
         inMemoryFileHelper = new InMemoryFileHelper();
@@ -100,16 +100,16 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(1, dataMap.size());
-        assertEquals(ATTACHMENT_ID, dataMap.get("sanitize____attachment.txt").textValue());
+        assertEquals(dataMap.size(), 1);
+        assertEquals(dataMap.get("sanitize____attachment.txt").textValue(), ATTACHMENT_ID);
 
         ArgumentCaptor<Map> sanitizedFileMapCaptor = ArgumentCaptor.forClass(Map.class);
         verify(mockUploadFileHelper).findValueForField(eq(UPLOAD_ID), sanitizedFileMapCaptor.capture(),
                 eq(sanitizeAttachmentTxtField), any());
 
         Map<String, File> sanitizedFileMap = sanitizedFileMapCaptor.getValue();
-        assertEquals(1, sanitizedFileMap.size());
-        assertSame(sanitizeAttachmentTxtFile, sanitizedFileMap.get("sanitize____attachment.txt"));
+        assertEquals(sanitizedFileMap.size(), 1);
+        assertSame(sanitizedFileMap.get("sanitize____attachment.txt"), sanitizeAttachmentTxtFile);
     }
 
     @Test
@@ -153,10 +153,10 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(3, dataMap.size());
-        assertEquals("foo-value", dataMap.get("foo").textValue());
-        assertEquals("data-file-attachment-id", dataMap.get("bar").textValue());
-        assertEquals(ATTACHMENT_ID, dataMap.get("sanitize____attachment.txt").textValue());
+        assertEquals(dataMap.size(), 3);
+        assertEquals(dataMap.get("foo").textValue(), "foo-value");
+        assertEquals(dataMap.get("bar").textValue(), "data-file-attachment-id");
+        assertEquals(dataMap.get("sanitize____attachment.txt").textValue(), ATTACHMENT_ID);
 
         // Verify calls to UploadFileHelper.
         verify(mockUploadFileHelper).uploadJsonNodeAsAttachment(TextNode.valueOf("bar is an attachment"), UPLOAD_ID,
@@ -167,9 +167,9 @@ public class GenericUploadFormatHandlerTest {
                 eq(sanitizeAttachmentTxtField), any());
 
         Map<String, File> sanitizedFileMap = sanitizedFileMapCaptor.getValue();
-        assertEquals(2, sanitizedFileMap.size());
-        assertSame(recordJsonFile, sanitizedFileMap.get("record.json"));
-        assertSame(sanitizeAttachmentTxtFile, sanitizedFileMap.get("sanitize____attachment.txt"));
+        assertEquals(sanitizedFileMap.size(), 2);
+        assertSame(sanitizedFileMap.get("record.json"), recordJsonFile);
+        assertSame(sanitizedFileMap.get("sanitize____attachment.txt"), sanitizeAttachmentTxtFile);
 
         // We don't call mockUploadFileHelper for any other field.
         verifyNoMoreInteractions(mockUploadFileHelper);
@@ -210,7 +210,7 @@ public class GenericUploadFormatHandlerTest {
 
         // Data map is empty.
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(0, dataMap.size());
+        assertEquals(dataMap.size(), 0);
 
         // Since we skipped the data file (too large), we asked the file helper (which didn't find any results).
         verify(mockUploadFileHelper).findValueForField(eq(UPLOAD_ID), any(), eq(fooFieldDef), any());
@@ -248,8 +248,8 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(1, dataMap.size());
-        assertEquals("answers-attachment-id", dataMap.get(UploadUtil.FIELD_ANSWERS).textValue());
+        assertEquals(dataMap.size(), 1);
+        assertEquals(dataMap.get(UploadUtil.FIELD_ANSWERS).textValue(), "answers-attachment-id");
 
         // Verify answers attachment.
         ArgumentCaptor<JsonNode> answersNodeCaptor = ArgumentCaptor.forClass(JsonNode.class);
@@ -257,9 +257,9 @@ public class GenericUploadFormatHandlerTest {
                 eq(UploadUtil.FIELD_ANSWERS));
 
         JsonNode answersNode = answersNodeCaptor.getValue();
-        assertEquals(2, answersNode.size());
-        assertEquals("foo-value", answersNode.get("foo").textValue());
-        assertEquals("bar-value", answersNode.get("bar").textValue());
+        assertEquals(answersNode.size(), 2);
+        assertEquals(answersNode.get("foo").textValue(), "foo-value");
+        assertEquals(answersNode.get("bar").textValue(), "bar-value");
     }
 
     @Test
@@ -290,12 +290,12 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(1, dataMap.size());
+        assertEquals(dataMap.size(), 1);
 
         JsonNode answersNode = dataMap.get(UploadUtil.FIELD_ANSWERS);
-        assertEquals(2, answersNode.size());
-        assertEquals("foo-value", answersNode.get("foo").textValue());
-        assertEquals("bar-value", answersNode.get("bar").textValue());
+        assertEquals(answersNode.size(), 2);
+        assertEquals(answersNode.get("foo").textValue(), "foo-value");
+        assertEquals(answersNode.get("bar").textValue(), "bar-value");
 
         // We don't upload anything.
         verify(mockUploadFileHelper, never()).uploadJsonNodeAsAttachment(any(), any(), any());
@@ -319,7 +319,7 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(0, dataMap.size());
+        assertEquals(dataMap.size(), 0);
 
         // We don't upload anything.
         verify(mockUploadFileHelper, never()).uploadJsonNodeAsAttachment(any(), any(), any());
@@ -356,8 +356,8 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(1, dataMap.size());
-        assertEquals("answers-attachment-id", dataMap.get(UploadUtil.FIELD_ANSWERS).textValue());
+        assertEquals(dataMap.size(), 1);
+        assertEquals(dataMap.get(UploadUtil.FIELD_ANSWERS).textValue(), "answers-attachment-id");
 
         // Verify answers attachment.
         ArgumentCaptor<JsonNode> answersNodeCaptor = ArgumentCaptor.forClass(JsonNode.class);
@@ -365,9 +365,9 @@ public class GenericUploadFormatHandlerTest {
                 eq(UploadUtil.FIELD_ANSWERS));
 
         JsonNode answersNode = answersNodeCaptor.getValue();
-        assertEquals(2, answersNode.size());
-        assertEquals("overriden foo", answersNode.get("foo").textValue());
-        assertEquals("overriden bar", answersNode.get("bar").textValue());
+        assertEquals(answersNode.size(), 2);
+        assertEquals(answersNode.get("foo").textValue(), "overriden foo");
+        assertEquals(answersNode.get("bar").textValue(), "overriden bar");
     }
 
     @Test
@@ -400,8 +400,8 @@ public class GenericUploadFormatHandlerTest {
         validateCommonProps(context);
 
         JsonNode dataMap = context.getHealthDataRecord().getData();
-        assertEquals(1, dataMap.size());
-        assertEquals(ATTACHMENT_ID, dataMap.get(UploadUtil.FIELD_ANSWERS).textValue());
+        assertEquals(dataMap.size(), 1);
+        assertEquals(dataMap.get(UploadUtil.FIELD_ANSWERS).textValue(), ATTACHMENT_ID);
 
         // Verify call to findValueForField. This passes in both "answers" and "record.json".
         ArgumentCaptor<Map> sanitizedFileMapCaptor = ArgumentCaptor.forClass(Map.class);
@@ -409,9 +409,9 @@ public class GenericUploadFormatHandlerTest {
                 eq(UploadUtil.ANSWERS_FIELD_DEF), any());
 
         Map<String, File> sanitizedFileMap = sanitizedFileMapCaptor.getValue();
-        assertEquals(2, sanitizedFileMap.size());
-        assertSame(answersFile, sanitizedFileMap.get(UploadUtil.FIELD_ANSWERS));
-        assertSame(recordJsonFile, sanitizedFileMap.get("record.json"));
+        assertEquals(sanitizedFileMap.size(), 2);
+        assertSame(sanitizedFileMap.get(UploadUtil.FIELD_ANSWERS), answersFile);
+        assertSame(sanitizedFileMap.get("record.json"), recordJsonFile);
 
         // We don't upload anything.
         verify(mockUploadFileHelper, never()).uploadJsonNodeAsAttachment(any(), any(), any());
@@ -464,10 +464,10 @@ public class GenericUploadFormatHandlerTest {
     private static void validateCommonProps(UploadValidationContext context) {
         // Validate common health data record props.
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
-        assertEquals(CREATED_ON_TIMEZONE, record.getCreatedOnTimeZone());
-        assertEquals(SCHEMA_ID, record.getSchemaId());
-        assertEquals(SCHEMA_REV, record.getSchemaRevision());
+        assertEquals(record.getCreatedOn().longValue(), CREATED_ON_MILLIS);
+        assertEquals(record.getCreatedOnTimeZone(), CREATED_ON_TIMEZONE);
+        assertEquals(record.getSchemaId(), SCHEMA_ID);
+        assertEquals(record.getSchemaRevision(), SCHEMA_REV);
 
         // No messages.
         assertTrue(context.getMessageList().isEmpty());

--- a/src/test/java/org/sagebionetworks/bridge/upload/InitRecordHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/InitRecordHandlerTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.util.Map;
@@ -17,10 +17,10 @@ import com.google.common.collect.Maps;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.LocalDate;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
@@ -50,7 +50,7 @@ public class InitRecordHandlerTest {
         DateTimeUtils.setCurrentMillisSystem();
     }
 
-    @Before
+    @BeforeMethod
     public void before() {
         // Init fileHelper and tmpDir
         inMemoryFileHelper = new InMemoryFileHelper();
@@ -107,7 +107,7 @@ public class InitRecordHandlerTest {
             handler.handle(context);
             fail("expected exception");
         } catch (UploadValidationException ex) {
-            assertEquals("upload ID " + UPLOAD_ID + " does not contain info.json file", ex.getMessage());
+            assertEquals(ex.getMessage(), "upload ID " + UPLOAD_ID + " does not contain info.json file");
         }
     }
 
@@ -128,7 +128,7 @@ public class InitRecordHandlerTest {
         validateCommonContextAttributes(context);
 
         // user metadata should match.
-        assertEquals(metadataJsonNode, context.getHealthDataRecord().getUserMetadata());
+        assertEquals(context.getHealthDataRecord().getUserMetadata(), metadataJsonNode);
 
         // No messages.
         assertTrue(context.getMessageList().isEmpty());
@@ -137,17 +137,17 @@ public class InitRecordHandlerTest {
     private static void validateCommonContextAttributes(UploadValidationContext context) {
         // Validate health data record props.
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(APP_VERSION, record.getAppVersion());
-        assertEquals(HEALTH_CODE, record.getHealthCode());
-        assertEquals(PHONE_INFO, record.getPhoneInfo());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, record.getStudyId());
-        assertEquals(MOCK_NOW_DATE, record.getUploadDate());
-        assertEquals(UPLOAD_ID, record.getUploadId());
-        assertEquals(MOCK_NOW_MILLIS, record.getUploadedOn().longValue());
+        assertEquals(record.getAppVersion(), APP_VERSION);
+        assertEquals(record.getHealthCode(), HEALTH_CODE);
+        assertEquals(record.getPhoneInfo(), PHONE_INFO);
+        assertEquals(record.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(record.getUploadDate(), MOCK_NOW_DATE);
+        assertEquals(record.getUploadId(), UPLOAD_ID);
+        assertEquals(record.getUploadedOn().longValue(), MOCK_NOW_MILLIS);
 
         // Record contains an empty object node.
         assertTrue(record.getData().isObject());
-        assertEquals(0, record.getData().size());
+        assertEquals(record.getData().size(), 0);
 
         // Don't validate inside metadata. If it exists, that's all that matters.
         assertNotNull(record.getMetadata());
@@ -203,8 +203,8 @@ public class InitRecordHandlerTest {
     public void parseJsonSuccess() {
         Map<String, File> fileMap = makeInfoJsonFileMapWithContent("{\"my-key\":\"my-value\"}");
         JsonNode result = handler.parseFileAsJson(fileMap, UploadUtil.FILENAME_INFO_JSON);
-        assertEquals(1, result.size());
-        assertEquals("my-value", result.get("my-key").textValue());
+        assertEquals(result.size(), 1);
+        assertEquals(result.get("my-key").textValue(), "my-value");
     }
 
     private Map<String, File> makeInfoJsonFileMapWithContent(String content) {

--- a/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2GetSchemaTest.java
@@ -1,18 +1,19 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertSame;
 
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.GuidCreatedOnVersionHolderImpl;
@@ -59,11 +60,11 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TEST_STUDY, infoJson);
-        assertSame(dummySchema, retVal);
+        assertSame(retVal, dummySchema);
     }
 
     // branch coverage: survey with no identifier
-    @Test(expected = UploadValidationException.class)
+    @Test(expectedExceptions = UploadValidationException.class)
     public void surveyWithNoIdentifier() throws Exception {
         // mock survey service
         DynamoSurvey survey = new DynamoSurvey();
@@ -89,7 +90,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
     }
 
     // branch coverage: survey with no schema rev
-    @Test(expected = UploadValidationException.class)
+    @Test(expectedExceptions = UploadValidationException.class)
     public void surveyWithNoSchemaRev() throws Exception {
         // mock survey service
         DynamoSurvey survey = new DynamoSurvey();
@@ -133,7 +134,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TEST_STUDY, infoJson);
-        assertSame(dummySchema, retVal);
+        assertSame(retVal, dummySchema);
     }
 
     @Test
@@ -155,7 +156,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TEST_STUDY, infoJson);
-        assertSame(dummySchema, retVal);
+        assertSame(retVal, dummySchema);
     }
 
     @Test
@@ -178,7 +179,7 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TEST_STUDY, infoJson);
-        assertSame(dummySchema, retVal);
+        assertSame(retVal, dummySchema);
     }
 
     @Test
@@ -200,11 +201,11 @@ public class IosSchemaValidationHandler2GetSchemaTest {
 
         // execute and validate
         UploadSchema retVal = handler.getUploadSchema(TEST_STUDY, infoJson);
-        assertSame(dummySchema, retVal);
+        assertSame(retVal, dummySchema);
     }
 
     // branch coverage: no item or survey
-    @Test(expected = UploadValidationException.class)
+    @Test(expectedExceptions = UploadValidationException.class)
     public void missingItemOrSurvey() throws Exception {
         new IosSchemaValidationHandler2().getUploadSchema(TEST_STUDY,
                 BridgeObjectMapper.get().createObjectNode());

--- a/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
@@ -22,10 +22,10 @@ import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.LocalDate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
@@ -57,7 +57,7 @@ public class IosSchemaValidationHandler2Test {
     private InMemoryFileHelper inMemoryFileHelper;
     private File tmpDir;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         DateTimeUtils.setCurrentMillisFixed(MOCK_NOW.getMillis());
 
@@ -149,7 +149,7 @@ public class IosSchemaValidationHandler2Test {
         handler.setUploadFileHelper(mockUploadFileHelper);
     }
 
-    @After
+    @AfterMethod
     public void cleanup() {
         DateTimeUtils.setCurrentMillisSystem();
     }
@@ -303,29 +303,28 @@ public class IosSchemaValidationHandler2Test {
 
         // validate
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(DateTime.parse("2015-04-02T03:27:09-07:00").getMillis(),
-                record.getCreatedOn().longValue());
-        assertEquals("-0700", record.getCreatedOnTimeZone());
-        assertEquals("test-survey", record.getSchemaId());
-        assertEquals(1, record.getSchemaRevision());
+        assertEquals(record.getCreatedOn().longValue(), DateTime.parse("2015-04-02T03:27:09-07:00").getMillis());
+        assertEquals(record.getCreatedOnTimeZone(), "-0700");
+        assertEquals(record.getSchemaId(), "test-survey");
+        assertEquals(record.getSchemaRevision(), 1);
 
         JsonNode dataNode = record.getData();
-        assertEquals(10, dataNode.size());
-        assertEquals("foo answer", dataNode.get("foo").textValue());
-        assertEquals(42, dataNode.get("bar").intValue());
-        assertEquals("lb", dataNode.get("bar_unit").textValue());
-        assertEquals("2017-01-31", dataNode.get("calendar-date").textValue());
-        assertEquals("16:42:52.256", dataNode.get("time-without-date").textValue());
-        assertEquals("2017-01-31T16:42:52.256-0800", dataNode.get("legacy-date-time").textValue());
-        assertEquals("2017-02-02T09:13:27.212-0800", dataNode.get("new-date-time").textValue());
-        assertEquals("1337", dataNode.get("int-as-string").textValue());
-        assertEquals("2015-12-25", dataNode.get("timestamp-as-date").textValue());
+        assertEquals(dataNode.size(), 10);
+        assertEquals(dataNode.get("foo").textValue(), "foo answer");
+        assertEquals(dataNode.get("bar").intValue(), 42);
+        assertEquals(dataNode.get("bar_unit").textValue(), "lb");
+        assertEquals(dataNode.get("calendar-date").textValue(), "2017-01-31");
+        assertEquals(dataNode.get("time-without-date").textValue(), "16:42:52.256");
+        assertEquals(dataNode.get("legacy-date-time").textValue(), "2017-01-31T16:42:52.256-0800");
+        assertEquals(dataNode.get("new-date-time").textValue(), "2017-02-02T09:13:27.212-0800");
+        assertEquals(dataNode.get("int-as-string").textValue(), "1337");
+        assertEquals(dataNode.get("timestamp-as-date").textValue(), "2015-12-25");
 
         JsonNode inlineJsonBlobNode = dataNode.get("inline-json-blob");
-        assertEquals(3, inlineJsonBlobNode.size());
-        assertEquals("inline", inlineJsonBlobNode.get(0).textValue());
-        assertEquals("json", inlineJsonBlobNode.get(1).textValue());
-        assertEquals("blob", inlineJsonBlobNode.get(2).textValue());
+        assertEquals(inlineJsonBlobNode.size(), 3);
+        assertEquals(inlineJsonBlobNode.get(0).textValue(), "inline");
+        assertEquals(inlineJsonBlobNode.get(1).textValue(), "json");
+        assertEquals(inlineJsonBlobNode.get(2).textValue(), "blob");
 
         // "baz" attachment.
         ArgumentCaptor<JsonNode> blobNodeCaptor = ArgumentCaptor.forClass(JsonNode.class);
@@ -333,9 +332,9 @@ public class IosSchemaValidationHandler2Test {
                 eq("baz"));
 
         JsonNode blobNode = blobNodeCaptor.getValue();
-        assertEquals(2, blobNode.size());
-        assertEquals("survey", blobNode.get(0).textValue());
-        assertEquals("blob", blobNode.get(1).textValue());
+        assertEquals(blobNode.size(), 2);
+        assertEquals(blobNode.get(0).textValue(), "survey");
+        assertEquals(blobNode.get(1).textValue(), "blob");
 
         // Survey "answers" attachment. Note that "answers" is not completely identical to dataNode. This is the raw
         // key-value pairing, so it includes attachments and doesn't canonicalize strings. This is fine, because the
@@ -345,18 +344,18 @@ public class IosSchemaValidationHandler2Test {
                 eq(UploadUtil.FIELD_ANSWERS));
 
         JsonNode answersNode = answersNodeCaptor.getValue();
-        assertEquals(11, answersNode.size());
-        assertEquals("foo answer", answersNode.get("foo").textValue());
-        assertEquals(42, answersNode.get("bar").intValue());
-        assertEquals("lb", answersNode.get("bar_unit").textValue());
-        assertEquals(blobNode, answersNode.get("baz"));
-        assertEquals("2017-01-31", answersNode.get("calendar-date").textValue());
-        assertEquals("16:42:52.256", answersNode.get("time-without-date").textValue());
-        assertEquals("2017-01-31T16:42:52.256-0800", answersNode.get("legacy-date-time").textValue());
-        assertEquals("2017-02-02T09:13:27.212-0800", answersNode.get("new-date-time").textValue());
-        assertEquals(1337, answersNode.get("int-as-string").intValue());
-        assertEquals("2015-12-25T14:41-0800", answersNode.get("timestamp-as-date").textValue());
-        assertEquals(inlineJsonBlobNode, answersNode.get("inline-json-blob"));
+        assertEquals(answersNode.size(), 11);
+        assertEquals(answersNode.get("foo").textValue(), "foo answer");
+        assertEquals(answersNode.get("bar").intValue(), 42);
+        assertEquals(answersNode.get("bar_unit").textValue(), "lb");
+        assertEquals(answersNode.get("baz"), blobNode);
+        assertEquals(answersNode.get("calendar-date").textValue(), "2017-01-31");
+        assertEquals(answersNode.get("time-without-date").textValue(), "16:42:52.256");
+        assertEquals(answersNode.get("legacy-date-time").textValue(), "2017-01-31T16:42:52.256-0800");
+        assertEquals(answersNode.get("new-date-time").textValue(), "2017-02-02T09:13:27.212-0800");
+        assertEquals(answersNode.get("int-as-string").intValue(), 1337);
+        assertEquals(answersNode.get("timestamp-as-date").textValue(), "2015-12-25T14:41-0800");
+        assertEquals(answersNode.get("inline-json-blob"), inlineJsonBlobNode);
 
         // We should have no messages.
         assertTrue(context.getMessageList().isEmpty());
@@ -392,14 +391,14 @@ public class IosSchemaValidationHandler2Test {
 
         // validate
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(DateTime.parse("2015-04-13T18:47:41-07:00").getMillis(), record.getCreatedOn().longValue());
-        assertEquals("-0700", record.getCreatedOnTimeZone());
-        assertEquals("non-survey", record.getSchemaId());
-        assertEquals(1, record.getSchemaRevision());
+        assertEquals(record.getCreatedOn().longValue(), DateTime.parse("2015-04-13T18:47:41-07:00").getMillis());
+        assertEquals(record.getCreatedOnTimeZone(), "-0700");
+        assertEquals(record.getSchemaId(), "non-survey");
+        assertEquals(record.getSchemaRevision(), 1);
 
         JsonNode dataNode = record.getData();
-        assertEquals(1, dataNode.size());
-        assertEquals("dummy-attachment-id", dataNode.get("sanitize____attachment.txt").textValue());
+        assertEquals(dataNode.size(), 1);
+        assertEquals(dataNode.get("sanitize____attachment.txt").textValue(), "dummy-attachment-id");
 
         // Verify call to Upload File Helper
         ArgumentCaptor<Map> sanizitedFileMapCaptor = ArgumentCaptor.forClass(Map.class);
@@ -408,12 +407,12 @@ public class IosSchemaValidationHandler2Test {
                 fieldDefCaptor.capture(), any());
 
         Map<String, File> sanitizedFileMap = sanizitedFileMapCaptor.getValue();
-        assertEquals(1, sanitizedFileMap.size());
+        assertEquals(sanitizedFileMap.size(), 1);
         assertTrue(sanitizedFileMap.containsKey("sanitize____attachment.txt"));
-        assertEquals(fileMap.get("sanitize!@#$attachment.txt"), sanitizedFileMap.get("sanitize____attachment.txt"));
+        assertEquals(sanitizedFileMap.get("sanitize____attachment.txt"), fileMap.get("sanitize!@#$attachment.txt"));
 
         UploadFieldDefinition fieldDef = fieldDefCaptor.getValue();
-        assertEquals("sanitize____attachment.txt", fieldDef.getName());
+        assertEquals(fieldDef.getName(), "sanitize____attachment.txt");
 
         // We should have no messages.
         assertTrue(context.getMessageList().isEmpty());
@@ -443,7 +442,7 @@ public class IosSchemaValidationHandler2Test {
 
         // validate
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(MOCK_NOW.getMillis(), record.getCreatedOn().longValue());
+        assertEquals(record.getCreatedOn().longValue(), MOCK_NOW.getMillis());
         assertNull(record.getCreatedOnTimeZone());
     }
 
@@ -476,8 +475,8 @@ public class IosSchemaValidationHandler2Test {
 
         // validate
         HealthDataRecord record = context.getHealthDataRecord();
-        assertEquals(createdOnMillis, record.getCreatedOn().longValue());
-        assertEquals("+0900", record.getCreatedOnTimeZone());
+        assertEquals(record.getCreatedOn().longValue(), createdOnMillis);
+        assertEquals(record.getCreatedOnTimeZone(), "+0900");
     }
 
     private void addFileToMap(Map<String, File> fileMap, String name, String content) {

--- a/src/test/java/org/sagebionetworks/bridge/upload/S3DownloadHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/S3DownloadHandlerTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 
 import com.google.common.base.Charsets;
-import org.junit.Test;
+
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
@@ -50,6 +51,6 @@ public class S3DownloadHandlerTest {
         // execute and validate
         handler.handle(ctx);
         byte[] dataFileContent = inMemoryFileHelper.getBytes(ctx.getDataFile());
-        assertEquals("test data", new String(dataFileContent, Charsets.UTF_8));
+        assertEquals(new String(dataFileContent, Charsets.UTF_8), "test data");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/StrictValidationHandlerGetValidationStrictnessTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/StrictValidationHandlerGetValidationStrictnessTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -16,7 +16,7 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
     private StrictValidationHandler handler;
     private StudyService mockStudyService;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         mockStudyService = mock(StudyService.class);
         handler = new StrictValidationHandler();
@@ -33,7 +33,7 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
 
         // execute and validate
         UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
-        assertEquals(UploadValidationStrictness.STRICT, retVal);
+        assertEquals(retVal, UploadValidationStrictness.STRICT);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
 
         // execute and validate
         UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
-        assertEquals(UploadValidationStrictness.REPORT, retVal);
+        assertEquals(retVal, UploadValidationStrictness.REPORT);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
 
         // execute and validate
         UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
-        assertEquals(UploadValidationStrictness.WARNING, retVal);
+        assertEquals(retVal, UploadValidationStrictness.WARNING);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
 
         // execute and validate
         UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
-        assertEquals(UploadValidationStrictness.STRICT, retVal);
+        assertEquals(retVal, UploadValidationStrictness.STRICT);
     }
 
     @Test
@@ -85,6 +85,6 @@ public class StrictValidationHandlerGetValidationStrictnessTest {
 
         // execute and validate
         UploadValidationStrictness retVal = handler.getUploadValidationStrictnessForStudy(TestConstants.TEST_STUDY);
-        assertEquals(UploadValidationStrictness.WARNING, retVal);
+        assertEquals(retVal, UploadValidationStrictness.WARNING);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/StrictValidationHandlerTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -17,8 +17,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
@@ -38,7 +39,7 @@ public class StrictValidationHandlerTest {
     private UploadValidationContext context;
     private StrictValidationHandler handler;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         handler = new StrictValidationHandler();
 
@@ -122,7 +123,7 @@ public class StrictValidationHandlerTest {
                     fail("Expected exception");
                 } catch (UploadValidationException ex) {
                     for (String oneExpectedError : expectedErrorList) {
-                        assertTrue("Expected error: " + oneExpectedError, ex.getMessage().contains(oneExpectedError));
+                        assertTrue(ex.getMessage().contains(oneExpectedError), "Expected error: " + oneExpectedError);
                     }
                 }
             } else {
@@ -135,15 +136,15 @@ public class StrictValidationHandlerTest {
             // context message list together and make sure our expected strings are in there.
             String concatMessage = Joiner.on('\n').join(context.getMessageList());
             for (String oneExpectedError : expectedErrorList) {
-                assertTrue("Expected error: " + oneExpectedError, concatMessage.contains(oneExpectedError));
+                assertTrue(concatMessage.contains(oneExpectedError), "Expected error: " + oneExpectedError);
             }
 
             if (uploadValidationStrictness == UploadValidationStrictness.REPORT) {
                 // If strictness is REPORT, do the same for record.validationErrors.
                 String recordValidationErrors = record.getValidationErrors();
                 for (String oneExpectedError : expectedErrorList) {
-                    assertTrue("Expected error: " + oneExpectedError, recordValidationErrors.contains(
-                            oneExpectedError));
+                    assertTrue(recordValidationErrors.contains(oneExpectedError),
+                            "Expected error: " + oneExpectedError);
                 }
             }
         }
@@ -241,7 +242,7 @@ public class StrictValidationHandlerTest {
         JsonNode dataNode = context.getHealthDataRecord().getData();
         JsonNode intNode = dataNode.get("canonicalized int");
         assertTrue(intNode.isIntegralNumber());
-        assertEquals(23, intNode.intValue());
+        assertEquals(intNode.intValue(), 23);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/upload/TestingHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/TestingHandlerTest.java
@@ -1,17 +1,18 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
@@ -81,9 +82,9 @@ public class TestingHandlerTest {
         verifyZeroInteractions(mockValidator);
 
         UploadValidationContext testContext = testContextCaptor.getValue();
-        assertEquals(TEST_STUDY_ID, testContext.getStudy().getIdentifier());
-        assertEquals(TEST_UPLOAD_ID, testContext.getUpload().getUploadId());
-        assertEquals(TEST_FILENAME, testContext.getUpload().getFilename());
+        assertEquals(testContext.getStudy().getIdentifier(), TEST_STUDY_ID);
+        assertEquals(testContext.getUpload().getUploadId(), TEST_UPLOAD_ID);
+        assertEquals(testContext.getUpload().getFilename(), TEST_FILENAME);
     }
 
     @Test
@@ -111,14 +112,14 @@ public class TestingHandlerTest {
                 UploadValidationContext.class);
         verify(mockTestHandler).handle(testHandlerArgCaptor.capture());
         UploadValidationContext testHandlerArg = testHandlerArgCaptor.getValue();
-        assertEquals(TEST_STUDY_ID, testHandlerArg.getStudy().getIdentifier());
-        assertEquals(TEST_UPLOAD_ID, testHandlerArg.getUpload().getUploadId());
-        assertEquals(TEST_FILENAME, testHandlerArg.getUpload().getFilename());
+        assertEquals(testHandlerArg.getStudy().getIdentifier(), TEST_STUDY_ID);
+        assertEquals(testHandlerArg.getUpload().getUploadId(), TEST_UPLOAD_ID);
+        assertEquals(testHandlerArg.getUpload().getFilename(), TEST_FILENAME);
 
         ArgumentCaptor<UploadValidationContext> validatorTestContextArgCaptor = ArgumentCaptor.forClass(
                 UploadValidationContext.class);
         verify(mockValidator).validate(same(mockProdContext), validatorTestContextArgCaptor.capture());
-        assertSame(testHandlerArg, validatorTestContextArgCaptor.getValue());
+        assertSame(validatorTestContextArgCaptor.getValue(), testHandlerArg);
     }
 
     @Test
@@ -151,11 +152,11 @@ public class TestingHandlerTest {
                 UploadValidationContext.class);
         verify(mockTestHandler).handle(testHandlerArgCaptor.capture());
         UploadValidationContext testHandlerArg = testHandlerArgCaptor.getValue();
-        assertEquals(TEST_STUDY_ID, testHandlerArg.getStudy().getIdentifier());
-        assertEquals(TEST_UPLOAD_ID, testHandlerArg.getUpload().getUploadId());
-        assertEquals(TEST_FILENAME, testHandlerArg.getUpload().getFilename());
+        assertEquals(testHandlerArg.getStudy().getIdentifier(), TEST_STUDY_ID);
+        assertEquals(testHandlerArg.getUpload().getUploadId(), TEST_UPLOAD_ID);
+        assertEquals(testHandlerArg.getUpload().getFilename(), TEST_FILENAME);
 
-        assertSame(testHandlerArg, validatorTestContextArgCaptor.getValue());
+        assertSame(validatorTestContextArgCaptor.getValue(), testHandlerArg);
     }
 
     private static UploadValidationContext mockContext() {

--- a/src/test/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 
 import java.util.Map;
 import java.util.Set;
@@ -12,10 +12,11 @@ import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -23,7 +24,6 @@ import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TranscribeConsentHandlerTest {
     private static final String TEST_HEALTHCODE = "test-healthcode";
     private static final String TEST_EXTERNAL_ID = "test-external-id";
@@ -34,6 +34,11 @@ public class TranscribeConsentHandlerTest {
     
     @Mock
     private Account mockAccount;
+    
+    @BeforeMethod
+    public void beforeMethod() { 
+        MockitoAnnotations.initMocks(this);
+    }
     
     @Test
     public void test() {
@@ -50,14 +55,14 @@ public class TranscribeConsentHandlerTest {
         HealthDataRecord record = HealthDataRecord.create();
         HealthDataRecord outputRecord = setupContextAndRunHandler(record);
         
-        assertSame(record, outputRecord);
-        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, outputRecord.getUserSharingScope());
-        assertEquals(TEST_EXTERNAL_ID, outputRecord.getUserExternalId());
-        assertEquals(Sets.newHashSet("test-group1","test-group2"), outputRecord.getUserDataGroups());
+        assertSame(outputRecord, record);
+        assertEquals(outputRecord.getUserSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
+        assertEquals(outputRecord.getUserExternalId(), TEST_EXTERNAL_ID);
+        assertEquals(outputRecord.getUserDataGroups(), Sets.newHashSet("test-group1","test-group2"));
         
         Map<String,String> substudyMemberships = outputRecord.getUserSubstudyMemberships();
-        assertEquals("<none>", substudyMemberships.get("subA"));
-        assertEquals("extB", substudyMemberships.get("subB"));
+        assertEquals(substudyMemberships.get("subA"), "<none>");
+        assertEquals(substudyMemberships.get("subB"), "extB");
     }
 
     @Test
@@ -67,8 +72,8 @@ public class TranscribeConsentHandlerTest {
         HealthDataRecord record = HealthDataRecord.create();
         HealthDataRecord outputRecord = setupContextAndRunHandler(record);
 
-        assertSame(record, outputRecord);
-        assertEquals(SharingScope.NO_SHARING, outputRecord.getUserSharingScope());
+        assertSame(outputRecord, record);
+        assertEquals(outputRecord.getUserSharingScope(), SharingScope.NO_SHARING);
         assertNull(outputRecord.getUserExternalId());
         assertNull(outputRecord.getUserDataGroups());
         assertNull(outputRecord.getUserSubstudyMemberships());

--- a/src/test/java/org/sagebionetworks/bridge/upload/UnzipHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UnzipHandlerTest.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -17,8 +17,8 @@ import java.util.function.Function;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.services.UploadArchiveService;
@@ -76,11 +76,11 @@ public class UnzipHandlerTest {
         // execute and validate
         handler.handle(ctx);
         Map<String, File> unzippedFileMap = ctx.getUnzippedDataFileMap();
-        assertEquals(mockUnzippedDataMap.size(), unzippedFileMap.size());
+        assertEquals(unzippedFileMap.size(), mockUnzippedDataMap.size());
         for (String oneUnzippedFileName : mockUnzippedDataMap.keySet()) {
             File unzippedFile = unzippedFileMap.get(oneUnzippedFileName);
             byte[] unzippedFileContent = inMemoryFileHelper.getBytes(unzippedFile);
-            assertArrayEquals(mockUnzippedDataMap.get(oneUnzippedFileName), unzippedFileContent);
+            assertArrayEquals(unzippedFileContent, mockUnzippedDataMap.get(oneUnzippedFileName));
         }
 
         // verify stream passed into mockSvc
@@ -89,6 +89,6 @@ public class UnzipHandlerTest {
 
         InputStream zippedFileInputStream = zippedFileInputStreamCaptor.getValue();
         byte[] zippedFileInputStreamContent = ByteStreams.toByteArray(zippedFileInputStream);
-        assertArrayEquals(ZIPPED_FILE_DUMMY_CONTENT, zippedFileInputStreamContent);
+        assertArrayEquals(zippedFileInputStreamContent, ZIPPED_FILE_DUMMY_CONTENT);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UnzipHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UnzipHandlerTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.upload;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -80,7 +79,7 @@ public class UnzipHandlerTest {
         for (String oneUnzippedFileName : mockUnzippedDataMap.keySet()) {
             File unzippedFile = unzippedFileMap.get(oneUnzippedFileName);
             byte[] unzippedFileContent = inMemoryFileHelper.getBytes(unzippedFile);
-            assertArrayEquals(unzippedFileContent, mockUnzippedDataMap.get(oneUnzippedFileName));
+            assertEquals(unzippedFileContent, mockUnzippedDataMap.get(oneUnzippedFileName));
         }
 
         // verify stream passed into mockSvc
@@ -89,6 +88,6 @@ public class UnzipHandlerTest {
 
         InputStream zippedFileInputStream = zippedFileInputStreamCaptor.getValue();
         byte[] zippedFileInputStreamContent = ByteStreams.toByteArray(zippedFileInputStream);
-        assertArrayEquals(zippedFileInputStreamContent, ZIPPED_FILE_DUMMY_CONTENT);
+        assertEquals(zippedFileInputStreamContent, ZIPPED_FILE_DUMMY_CONTENT);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadArchiveServiceZipTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadArchiveServiceZipTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertArrayEquals;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.Map;
@@ -11,8 +11,9 @@ import java.util.Map;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.services.UploadArchiveService;
@@ -42,7 +43,7 @@ public class UploadArchiveServiceZipTest {
         assertTrue(zippedData.length > 0);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void zipNullInput() {
         uploadArchiveService.zip(null);
     }
@@ -52,21 +53,21 @@ public class UploadArchiveServiceZipTest {
         Map<String, byte[]> result = uploadArchiveService.unzip(zippedData);
 
         // Need to check each entry in the map, since byte[].equals() doesn't do what you expect.
-        assertEquals(UNZIPPED_FILE_MAP.size(), result.size());
+        assertEquals(result.size(), UNZIPPED_FILE_MAP.size());
         for (String oneUnzippedFileName : UNZIPPED_FILE_MAP.keySet()) {
-            assertArrayEquals(UNZIPPED_FILE_MAP.get(oneUnzippedFileName), result.get(oneUnzippedFileName));
+            assertArrayEquals(result.get(oneUnzippedFileName), UNZIPPED_FILE_MAP.get(oneUnzippedFileName));
         }
     }
 
     // There was originally a test here for unzipping garbage data. However, it looks like Java
     // ZipInputStream.getNextEntry() will just return null if the stream contains garbage data.
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void unzipBytesNullInput() {
         uploadArchiveService.unzip(null);
     }
 
-    @Test(expected=BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void testTooManyZipEntries() throws Exception {
         // Set up a test service just for this test. Set the max num to something super small, like 2.
         UploadArchiveService testSvc = new UploadArchiveService();
@@ -77,7 +78,7 @@ public class UploadArchiveServiceZipTest {
         testSvc.unzip(zippedData);
     }
 
-    @Test(expected=BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void testZipEntryTooBig() throws Exception {
         // Set up a test service just for this test. Set the max size to something super small, like 6.
         UploadArchiveService testSvc = new UploadArchiveService();
@@ -88,7 +89,7 @@ public class UploadArchiveServiceZipTest {
         testSvc.unzip(zippedData);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void unzipStreamNullStream() {
         uploadArchiveService.unzip(null,
                 // Use NullOutputStream, since the test won't ever actually create any streams.
@@ -97,7 +98,7 @@ public class UploadArchiveServiceZipTest {
                 (entryName, outputStream) -> {});
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void unzipStreamNullOutputStreamFunction() throws Exception {
         try (ByteArrayInputStream zippedDataInputStream = new ByteArrayInputStream(zippedData)) {
             uploadArchiveService.unzip(zippedDataInputStream,
@@ -107,7 +108,7 @@ public class UploadArchiveServiceZipTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void unzipStreamNullOutputStreamFinalizer() throws Exception {
         try (ByteArrayInputStream zippedDataInputStream = new ByteArrayInputStream(zippedData)) {
             uploadArchiveService.unzip(zippedDataInputStream,

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadArchiveServiceZipTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadArchiveServiceZipTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -55,7 +54,7 @@ public class UploadArchiveServiceZipTest {
         // Need to check each entry in the map, since byte[].equals() doesn't do what you expect.
         assertEquals(result.size(), UNZIPPED_FILE_MAP.size());
         for (String oneUnzippedFileName : UNZIPPED_FILE_MAP.keySet()) {
-            assertArrayEquals(result.get(oneUnzippedFileName), UNZIPPED_FILE_MAP.get(oneUnzippedFileName));
+            assertEquals(result.get(oneUnzippedFileName), UNZIPPED_FILE_MAP.get(oneUnzippedFileName));
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadArtifactsHandlerTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
@@ -22,7 +22,7 @@ public class UploadArtifactsHandlerTest {
     private HealthDataService mockHealthDataService;
     private UploadArtifactsHandler handler;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         // Mock health data service.
         mockHealthDataService = mock(HealthDataService.class);
@@ -56,7 +56,7 @@ public class UploadArtifactsHandlerTest {
         verify(mockHealthDataService).createOrUpdateRecord(createdRecordCaptor.capture());
 
         HealthDataRecord createdRecord = createdRecordCaptor.getValue();
-        assertEquals(42L, createdRecord.getVersion().longValue());
+        assertEquals(createdRecord.getVersion().longValue(), 42L);
     }
 
     private void test() {
@@ -81,11 +81,11 @@ public class UploadArtifactsHandlerTest {
         verify(mockHealthDataService).createOrUpdateRecord(createdRecordCaptor.capture());
 
         HealthDataRecord createdRecord = createdRecordCaptor.getValue();
-        assertEquals(TEST_UPLOAD_ID, createdRecord.getId());
-        assertSame(record, createdRecord);
+        assertEquals(createdRecord.getId(), TEST_UPLOAD_ID);
+        assertSame(createdRecord, record);
 
         // validate record ID in the context
-        assertEquals(TEST_UPLOAD_ID, context.getRecordId());
+        assertEquals(context.getRecordId(), TEST_UPLOAD_ID);
 
         // validate no messages on the context
         assertTrue(context.getMessageList().isEmpty());

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.io.File;
 import java.util.HashMap;
@@ -17,9 +17,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -37,7 +37,7 @@ public class UploadFileHelperFindValueTest {
     private UploadFileHelper uploadFileHelper;
     private ArgumentCaptor<ObjectMetadata> metadataCaptor;
 
-    @Before
+    @BeforeMethod
     public void before() {
         // Spy file helper, so we can check to see how many times we read the disk later. Also make a dummy temp dir,
         // as an in-memory place we can put files into.
@@ -68,13 +68,13 @@ public class UploadFileHelperFindValueTest {
         // Execute
         String expectedAttachmentFilename = UPLOAD_ID + '-' + FIELD_NAME_FILE;
         JsonNode result = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fieldDef, new HashMap<>());
-        assertEquals(expectedAttachmentFilename, result.textValue());
+        assertEquals(result.textValue(), expectedAttachmentFilename);
 
         // Verify uploaded file
         verify(mockS3Helper).writeFileToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(expectedAttachmentFilename),
                 eq(recordJsonFile), metadataCaptor.capture());
         
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class UploadFileHelperFindValueTest {
 
         // Execute
         JsonNode result = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fieldDef, new HashMap<>());
-        assertEquals("dummy content", result.textValue());
+        assertEquals(result.textValue(), "dummy content");
 
         // Verify no uploaded files
         verifyZeroInteractions(mockS3Helper);
@@ -170,13 +170,13 @@ public class UploadFileHelperFindValueTest {
         // Execute
         String expectedAttachmentFilename = UPLOAD_ID + '-' + FIELD_NAME_JSON_KEY;
         JsonNode result = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fieldDef, new HashMap<>());
-        assertEquals(expectedAttachmentFilename, result.textValue());
+        assertEquals(result.textValue(), expectedAttachmentFilename);
 
         // Verify uploaded file
         verify(mockS3Helper).writeBytesToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(expectedAttachmentFilename),
                 eq("\"record-value\"".getBytes(Charsets.UTF_8)), metadataCaptor.capture());
         
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class UploadFileHelperFindValueTest {
 
         // Execute
         JsonNode result = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fieldDef, new HashMap<>());
-        assertEquals("record-value", result.textValue());
+        assertEquals(result.textValue(), "record-value");
 
         // Verify no uploaded files
         verifyZeroInteractions(mockS3Helper);
@@ -216,7 +216,7 @@ public class UploadFileHelperFindValueTest {
 
         // Execute - The file is too large. Skip.
         JsonNode result = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fieldDef, new HashMap<>());
-        assertEquals("Long but not too long", result.textValue());
+        assertEquals(result.textValue(), "Long but not too long");
 
         // Verify no uploaded files
         verifyZeroInteractions(mockS3Helper);
@@ -265,10 +265,10 @@ public class UploadFileHelperFindValueTest {
         Map<String, Map<String, JsonNode>> cache = new HashMap<>();
 
         JsonNode fooResult = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, fooFieldDef, cache);
-        assertEquals("foo-value", fooResult.textValue());
+        assertEquals(fooResult.textValue(), "foo-value");
 
         JsonNode barResult = uploadFileHelper.findValueForField(UPLOAD_ID, fileMap, barFieldDef, cache);
-        assertEquals("bar-value", barResult.textValue());
+        assertEquals(barResult.textValue(), "bar-value");
 
         // Verify no uploaded files
         verifyZeroInteractions(mockS3Helper);

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperUploadJsonAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperUploadJsonAttachmentTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 
@@ -13,9 +13,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Charsets;
-import org.junit.Before;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.s3.S3Helper;
 
@@ -27,7 +27,7 @@ public class UploadFileHelperUploadJsonAttachmentTest {
     private S3Helper mockS3Helper;
     private UploadFileHelper uploadFileHelper;
 
-    @Before
+    @BeforeMethod
     public void before() {
         mockS3Helper = mock(S3Helper.class);
         uploadFileHelper = new UploadFileHelper();
@@ -39,7 +39,7 @@ public class UploadFileHelperUploadJsonAttachmentTest {
         // Normally this will be an array or an object, but for the purpose of this test, use a TextNode.
         JsonNode result = uploadFileHelper.uploadJsonNodeAsAttachment(TextNode.valueOf("dummy content"), UPLOAD_ID,
                 FIELD_NAME);
-        assertEquals(EXPECTED_ATTACHMENT_NAME, result.textValue());
+        assertEquals(result.textValue(), EXPECTED_ATTACHMENT_NAME);
 
         ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
         // Validate uploaded content. The text is quoted because when we serialize a JSON string, it quotes the JSON
@@ -47,10 +47,10 @@ public class UploadFileHelperUploadJsonAttachmentTest {
         verify(mockS3Helper).writeBytesToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(EXPECTED_ATTACHMENT_NAME),
                 eq("\"dummy content\"".getBytes(Charsets.UTF_8)), metadataCaptor.capture());
         
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 
-    @Test(expected = UploadValidationException.class)
+    @Test(expectedExceptions = UploadValidationException.class)
     public void errorCase() throws Exception {
         doThrow(IOException.class).when(mockS3Helper).writeBytesToS3(any(), any(), any(byte[].class), any());
         uploadFileHelper.uploadJsonNodeAsAttachment(TextNode.valueOf("dummy content"), UPLOAD_ID, FIELD_NAME);

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFormatHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFormatHandlerTest.java
@@ -5,8 +5,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
@@ -15,7 +16,7 @@ public class UploadFormatHandlerTest {
     private GenericUploadFormatHandler mockV2GenericHandler;
     private UploadFormatHandler uploadFormatHandler;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         mockV1LegacyHandler = mock(IosSchemaValidationHandler2.class);
         mockV2GenericHandler = mock(GenericUploadFormatHandler.class);

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.InputStream;
@@ -26,11 +26,11 @@ import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.LocalDate;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
@@ -111,7 +111,7 @@ public class UploadHandlersEndToEndTest {
         DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
     }
 
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
         // Reset all member vars, because JUnit doesn't.
         inMemoryFileHelper = new InMemoryFileHelper();
@@ -308,29 +308,29 @@ public class UploadHandlersEndToEndTest {
         //   id - This one is created by the DAO, so it's not present in the passed in record.
         //   synapseExporterStatus - This isn't used in upload validation.
         //   version - That's internal.
-        assertEquals(APP_VERSION, record.getAppVersion());
-        assertEquals(CREATED_ON_MILLIS, record.getCreatedOn().longValue());
-        assertEquals(CREATED_ON_TIME_ZONE, record.getCreatedOnTimeZone());
-        assertEquals(HEALTH_CODE, record.getHealthCode());
-        assertEquals(PHONE_INFO, record.getPhoneInfo());
-        assertEquals(TestConstants.TEST_STUDY_IDENTIFIER, record.getStudyId());
-        assertEquals(MOCK_TODAY, record.getUploadDate());
-        assertEquals(UPLOAD_ID, record.getUploadId());
-        assertEquals(MOCK_NOW_MILLIS, record.getUploadedOn().longValue());
-        assertEquals(SharingScope.SPONSORS_AND_PARTNERS, record.getUserSharingScope());
-        assertEquals(EXTERNAL_ID, record.getUserExternalId());
-        assertEquals(DATA_GROUP_SET, record.getUserDataGroups());
+        assertEquals(record.getAppVersion(), APP_VERSION);
+        assertEquals(record.getCreatedOn().longValue(), CREATED_ON_MILLIS);
+        assertEquals(record.getCreatedOnTimeZone(), CREATED_ON_TIME_ZONE);
+        assertEquals(record.getHealthCode(), HEALTH_CODE);
+        assertEquals(record.getPhoneInfo(), PHONE_INFO);
+        assertEquals(record.getStudyId(), TestConstants.TEST_STUDY_IDENTIFIER);
+        assertEquals(record.getUploadDate(), MOCK_TODAY);
+        assertEquals(record.getUploadId(), UPLOAD_ID);
+        assertEquals(record.getUploadedOn().longValue(), MOCK_NOW_MILLIS);
+        assertEquals(record.getUserSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
+        assertEquals(record.getUserExternalId(), EXTERNAL_ID);
+        assertEquals(record.getUserDataGroups(), DATA_GROUP_SET);
 
         // Metadata needs to exist for backwards compatibility, and it should have appVersion and phoneInfo. Beyond
         // that, it doesn't really matter
         JsonNode metadataNode = record.getMetadata();
-        assertEquals(APP_VERSION, metadataNode.get(UploadUtil.FIELD_APP_VERSION).textValue());
-        assertEquals(PHONE_INFO, metadataNode.get(UploadUtil.FIELD_PHONE_INFO).textValue());
+        assertEquals(metadataNode.get(UploadUtil.FIELD_APP_VERSION).textValue(), APP_VERSION);
+        assertEquals(metadataNode.get(UploadUtil.FIELD_PHONE_INFO).textValue(), PHONE_INFO);
 
         // Validate user metadata.
         JsonNode userMetadataNode = record.getUserMetadata();
-        assertEquals(1, userMetadataNode.size());
-        assertEquals("my-meta-value", userMetadataNode.get("my-meta-key").textValue());
+        assertEquals(userMetadataNode.size(), 1);
+        assertEquals(userMetadataNode.get("my-meta-key").textValue(), "my-meta-value");
     }
 
     private void testSurvey(Map<String, String> fileMap) throws Exception {
@@ -372,23 +372,23 @@ public class UploadHandlersEndToEndTest {
 
         HealthDataRecord record = recordCaptor.getValue();
         validateCommonRecordProps(record);
-        assertEquals(SURVEY_ID, record.getSchemaId());
-        assertEquals(SURVEY_SCHEMA_REV, record.getSchemaRevision());
+        assertEquals(record.getSchemaId(), SURVEY_ID);
+        assertEquals(record.getSchemaRevision(), SURVEY_SCHEMA_REV);
 
         JsonNode dataNode = record.getData();
-        assertEquals(4, dataNode.size());
-        assertEquals("Yes", dataNode.get("AAA").textValue());
+        assertEquals(dataNode.size(), 4);
+        assertEquals(dataNode.get("AAA").textValue(), "Yes");
 
         JsonNode bbbChoiceAnswersNode = dataNode.get("BBB");
-        assertEquals(3, bbbChoiceAnswersNode.size());
-        assertEquals("fencing", bbbChoiceAnswersNode.get(0).textValue());
-        assertEquals("running", bbbChoiceAnswersNode.get(1).textValue());
-        assertEquals("3", bbbChoiceAnswersNode.get(2).textValue());
+        assertEquals(bbbChoiceAnswersNode.size(), 3);
+        assertEquals(bbbChoiceAnswersNode.get(0).textValue(), "fencing");
+        assertEquals(bbbChoiceAnswersNode.get(1).textValue(), "running");
+        assertEquals(bbbChoiceAnswersNode.get(2).textValue(), "3");
 
         JsonNode deliciousNode = dataNode.get("delicious");
-        assertEquals(2, deliciousNode.size());
-        assertEquals("Yes", deliciousNode.get(0).textValue());
-        assertEquals("Maybe", deliciousNode.get(1).textValue());
+        assertEquals(deliciousNode.size(), 2);
+        assertEquals(deliciousNode.get(0).textValue(), "Yes");
+        assertEquals(deliciousNode.get(1).textValue(), "Maybe");
 
         // Answers node has all the same fields as dataNode, except without its own answers field. Note that the
         // answers field doesn't go through canonicalization, since it's treated as an attachment instead of individual
@@ -396,22 +396,22 @@ public class UploadHandlersEndToEndTest {
         String answersAttachmentId = dataNode.get(UploadUtil.FIELD_ANSWERS).textValue();
         byte[] answersUploadedContent = uploadedFileContentMap.get(answersAttachmentId);
         JsonNode answersNode = BridgeObjectMapper.get().readTree(answersUploadedContent);
-        assertEquals(3, answersNode.size());
+        assertEquals(answersNode.size(), 3);
 
         JsonNode aaaChoiceAnswersNode = answersNode.get("AAA");
-        assertEquals(1, aaaChoiceAnswersNode.size());
-        assertEquals("Yes", aaaChoiceAnswersNode.get(0).textValue());
+        assertEquals(aaaChoiceAnswersNode.size(), 1);
+        assertEquals(aaaChoiceAnswersNode.get(0).textValue(), "Yes");
 
         bbbChoiceAnswersNode = answersNode.get("BBB");
-        assertEquals(3, bbbChoiceAnswersNode.size());
-        assertEquals("fencing", bbbChoiceAnswersNode.get(0).textValue());
-        assertEquals("running", bbbChoiceAnswersNode.get(1).textValue());
-        assertEquals(3, bbbChoiceAnswersNode.get(2).intValue());
+        assertEquals(bbbChoiceAnswersNode.size(), 3);
+        assertEquals(bbbChoiceAnswersNode.get(0).textValue(), "fencing");
+        assertEquals(bbbChoiceAnswersNode.get(1).textValue(), "running");
+        assertEquals(bbbChoiceAnswersNode.get(2).intValue(), 3);
 
         deliciousNode = answersNode.get("delicious");
-        assertEquals(2, deliciousNode.size());
-        assertEquals("Yes", deliciousNode.get(0).textValue());
-        assertEquals("Maybe", deliciousNode.get(1).textValue());
+        assertEquals(deliciousNode.size(), 2);
+        assertEquals(deliciousNode.get(0).textValue(), "Yes");
+        assertEquals(deliciousNode.get(1).textValue(), "Maybe");
 
         // We upload the unencrypted zipped file back to S3.
         validateRawDataAttachment();
@@ -585,25 +585,25 @@ public class UploadHandlersEndToEndTest {
 
         HealthDataRecord record = recordCaptor.getValue();
         validateCommonRecordProps(record);
-        assertEquals(SCHEMA_ID, record.getSchemaId());
-        assertEquals(SCHEMA_REV, record.getSchemaRevision());
+        assertEquals(record.getSchemaId(), SCHEMA_ID);
+        assertEquals(record.getSchemaRevision(), SCHEMA_REV);
 
         JsonNode dataNode = record.getData();
-        assertEquals(15, dataNode.size());
+        assertEquals(dataNode.size(), 15);
         assertTrue(dataNode.get("record.json.III").booleanValue());
-        assertEquals("2016-06-03", dataNode.get("record.json.JJJ").textValue());
-        assertEquals("PT1H", dataNode.get("record.json.LLL").textValue());
-        assertEquals(3.14, dataNode.get("record.json.MMM").doubleValue(), /*delta*/ 0.001);
-        assertEquals(2, dataNode.get("record.json.OOO").intValue());
-        assertEquals("1337", dataNode.get("record.json.PPP").textValue());
-        assertEquals("19:21:35.378", dataNode.get("record.json.QQQ").textValue());
-        assertEquals(DateTime.parse("2016-06-03T18:12:34.567+0900"),
-                DateTime.parse(dataNode.get("record.json.arrr").textValue()));
+        assertEquals(dataNode.get("record.json.JJJ").textValue(), "2016-06-03");
+        assertEquals(dataNode.get("record.json.LLL").textValue(), "PT1H");
+        assertEquals(dataNode.get("record.json.MMM").doubleValue(), 3.14, /*delta*/ 0.001);
+        assertEquals(dataNode.get("record.json.OOO").intValue(), 2);
+        assertEquals(dataNode.get("record.json.PPP").textValue(), "1337");
+        assertEquals(dataNode.get("record.json.QQQ").textValue(),"19:21:35.378");
+        assertEquals(DateTime.parse(dataNode.get("record.json.arrr").textValue()),
+                DateTime.parse("2016-06-03T18:12:34.567+0900"));
 
         JsonNode nnnNode = dataNode.get("record.json.NNN");
-        assertEquals(2, nnnNode.size());
-        assertEquals("inline", nnnNode.get(0).textValue());
-        assertEquals("json", nnnNode.get(1).textValue());
+        assertEquals(nnnNode.size(), 2);
+        assertEquals(nnnNode.get(0).textValue(), "inline");
+        assertEquals(nnnNode.get(1).textValue(), "json");
 
         // validate attachment content in S3
         String cccTxtAttachmentId = dataNode.get("CCC.txt").textValue();
@@ -618,19 +618,19 @@ public class UploadHandlersEndToEndTest {
         String eeeJsonAttachmentId = dataNode.get("EEE.json").textValue();
         byte[] eeeJsonUploadedContent = uploadedFileContentMap.get(eeeJsonAttachmentId);
         JsonNode eeeJsonNode = BridgeObjectMapper.get().readTree(eeeJsonUploadedContent);
-        assertEquals(1, eeeJsonNode.size());
-        assertEquals("value", eeeJsonNode.get("key").textValue());
+        assertEquals(eeeJsonNode.size(), 1);
+        assertEquals(eeeJsonNode.get("key").textValue(), "value");
 
         String fffJsonAttachmentId = dataNode.get("FFF.json").textValue();
         byte[] fffJsonUploadedContent = uploadedFileContentMap.get(fffJsonAttachmentId);
         JsonNode fffJsonNode = BridgeObjectMapper.get().readTree(fffJsonUploadedContent);
-        assertEquals(2, fffJsonNode.size());
+        assertEquals(fffJsonNode.size(), 2);
 
-        assertEquals(1, fffJsonNode.get(0).size());
-        assertEquals("Dwayne", fffJsonNode.get(0).get("name").textValue());
+        assertEquals(fffJsonNode.get(0).size(), 1);
+        assertEquals(fffJsonNode.get(0).get("name").textValue(), "Dwayne");
 
-        assertEquals(1, fffJsonNode.get(1).size());
-        assertEquals("Eggplant", fffJsonNode.get(1).get("name").textValue());
+        assertEquals(fffJsonNode.get(1).size(), 1);
+        assertEquals(fffJsonNode.get(1).get("name").textValue(), "Eggplant");
 
         String hhhAttachmentId = dataNode.get("record.json.HHH").textValue();
         
@@ -638,12 +638,12 @@ public class UploadHandlersEndToEndTest {
         verify(mockS3UploadHelper).writeBytesToS3(eq(TestConstants.ATTACHMENT_BUCKET), eq(hhhAttachmentId),
                 attachmentContentCaptor.capture(), metadataCaptor.capture());
         JsonNode hhhNode = BridgeObjectMapper.get().readTree(attachmentContentCaptor.getValue());        
-        assertEquals(3, hhhNode.size());
-        assertEquals("attachment", hhhNode.get(0).textValue());
-        assertEquals("inside", hhhNode.get(1).textValue());
-        assertEquals("file", hhhNode.get(2).textValue());
+        assertEquals(hhhNode.size(), 3);
+        assertEquals(hhhNode.get(0).textValue(), "attachment");
+        assertEquals(hhhNode.get(1).textValue(), "inside");
+        assertEquals(hhhNode.get(2).textValue(), "file");
         
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
 
         // We upload the unencrypted zipped file back to S3.
         validateRawDataAttachment();
@@ -706,7 +706,7 @@ public class UploadHandlersEndToEndTest {
 
     private void validateTextAttachment(String expected, String attachmentId) {
         byte[] uploadedFileContent = uploadedFileContentMap.get(attachmentId);
-        assertEquals(expected, new String(uploadedFileContent, Charsets.UTF_8));
+        assertEquals(new String(uploadedFileContent, Charsets.UTF_8), expected);
     }
 
     private void validateRawDataAttachment() {
@@ -714,7 +714,7 @@ public class UploadHandlersEndToEndTest {
         verify(mockS3UploadHelper).writeFileToS3(eq(TestConstants.ATTACHMENT_BUCKET), eq(expectedRawDataAttachmentId),
                 any(), metadataCaptor.capture());
         byte[] rawDataBytes = uploadedFileContentMap.get(expectedRawDataAttachmentId);
-        assertArrayEquals(zippedFile, rawDataBytes);
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertArrayEquals(rawDataBytes, zippedFile);
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.testng.AssertJUnit.assertArrayEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
@@ -720,7 +719,7 @@ public class UploadHandlersEndToEndTest {
         verify(mockS3UploadHelper).writeFileToS3(eq(TestConstants.ATTACHMENT_BUCKET), eq(expectedRawDataAttachmentId),
                 any(), metadataCaptor.capture());
         byte[] rawDataBytes = uploadedFileContentMap.get(expectedRawDataAttachmentId);
-        assertArrayEquals(rawDataBytes, zippedFile);
+        assertEquals(rawDataBytes, zippedFile);
         assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadRawZipHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadRawZipHandlerTest.java
@@ -1,16 +1,16 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.upload.Upload;
@@ -48,7 +48,7 @@ public class UploadRawZipHandlerTest {
         verify(mockS3Helper).writeFileToS3(eq(UploadRawZipHandler.ATTACHMENT_BUCKET), eq(expectedRawDataAttachmentId),
                 eq(mockDecryptedFile), metadataCaptor.capture());
 
-        assertEquals(expectedRawDataAttachmentId, record.getRawDataAttachmentId());
-        assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadataCaptor.getValue().getSSEAlgorithm());
+        assertEquals(record.getRawDataAttachmentId(), expectedRawDataAttachmentId);
+        assertEquals(metadataCaptor.getValue().getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadUtilTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
@@ -58,8 +58,8 @@ public class UploadUtilTest {
             UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("field").withType(fieldType)
                     .build();
             UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-            assertEquals("bytes for " + fieldType, expectedBytes, fieldSize.getNumBytes());
-            assertEquals("columns for " + fieldType, 1, fieldSize.getNumColumns());
+            assertEquals(fieldSize.getNumBytes(), expectedBytes, "bytes for " + fieldType);
+            assertEquals(fieldSize.getNumColumns(), 1, "columns for " + fieldType);
         }
     }
 
@@ -67,8 +67,8 @@ public class UploadUtilTest {
     public void calculateFieldSizeNullType() {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("field").withType(null).build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(0, fieldSize.getNumBytes());
-        assertEquals(0, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 0);
+        assertEquals(fieldSize.getNumColumns(), 0);
     }
 
     @Test
@@ -80,42 +80,32 @@ public class UploadUtilTest {
             UploadFieldDefinition smallStringField = new UploadFieldDefinition.Builder().withName("small-field")
                     .withType(fieldType).withMaxLength(1).build();
             UploadFieldSize smallFieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(smallStringField));
-            assertEquals("small string field bytes for " + fieldType, 3,
-                    smallFieldSize.getNumBytes());
-            assertEquals("small string field columns for " + fieldType, 1,
-                    smallFieldSize.getNumColumns());
+            assertEquals(smallFieldSize.getNumBytes(), 3, "small string field bytes for " + fieldType);
+            assertEquals(smallFieldSize.getNumColumns(), 1, "small string field columns for " + fieldType);
 
             UploadFieldDefinition mediumStringField = new UploadFieldDefinition.Builder().withName("medium-field")
                     .withType(fieldType).withMaxLength(128).build();
             UploadFieldSize mediumFieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(mediumStringField));
-            assertEquals("medium string field bytes for " + fieldType, 384,
-                    mediumFieldSize.getNumBytes());
-            assertEquals("medium string field columns for " + fieldType, 1,
-                    mediumFieldSize.getNumColumns());
+            assertEquals(mediumFieldSize.getNumBytes(), 384, "medium string field bytes for " + fieldType);
+            assertEquals(mediumFieldSize.getNumColumns(), 1, "medium string field columns for " + fieldType);
 
             UploadFieldDefinition bigStringField = new UploadFieldDefinition.Builder().withName("big-field")
                     .withType(fieldType).withMaxLength(500).build();
             UploadFieldSize bigFieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(bigStringField));
-            assertEquals("big string field bytes for " + fieldType, 1500,
-                    bigFieldSize.getNumBytes());
-            assertEquals("big string field columns for " + fieldType, 1,
-                    bigFieldSize.getNumColumns());
+            assertEquals(bigFieldSize.getNumBytes(), 1500, "big string field bytes for " + fieldType);
+            assertEquals(bigFieldSize.getNumColumns(), 1, "big string field columns for " + fieldType);
 
             UploadFieldDefinition defaultStringField = new UploadFieldDefinition.Builder().withName("default-field")
                     .withType(fieldType).withMaxLength(null).build();
             UploadFieldSize defaultFieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(defaultStringField));
-            assertEquals("default string field bytes for " + fieldType, 300,
-                    defaultFieldSize.getNumBytes());
-            assertEquals("default string field columns for " + fieldType, 1,
-                    defaultFieldSize.getNumColumns());
+            assertEquals(defaultFieldSize.getNumBytes(), 300, "default string field bytes for " + fieldType);
+            assertEquals(defaultFieldSize.getNumColumns(), 1, "default string field columns for " + fieldType);
 
             UploadFieldDefinition unboundedStringField = new UploadFieldDefinition.Builder()
                     .withName("unbounded-field").withType(fieldType).withUnboundedText(true).build();
             UploadFieldSize unboundedFieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(unboundedStringField));
-            assertEquals("unbounded string field bytes for " + fieldType, 3000,
-                    unboundedFieldSize.getNumBytes());
-            assertEquals("unbounded string field columns for " + fieldType, 1,
-                    unboundedFieldSize.getNumColumns());
+            assertEquals(unboundedFieldSize.getNumBytes(), 3000, "unbounded string field bytes for " + fieldType);
+            assertEquals(unboundedFieldSize.getNumColumns(), 1, "unbounded string field columns for " + fieldType);
         }
     }
 
@@ -125,8 +115,8 @@ public class UploadUtilTest {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("field")
                 .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList().build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(0, fieldSize.getNumBytes());
-        assertEquals(0, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 0);
+        assertEquals(fieldSize.getNumColumns(), 0);
     }
 
     @Test
@@ -134,8 +124,8 @@ public class UploadUtilTest {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("field")
                 .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo").build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(5, fieldSize.getNumBytes());
-        assertEquals(1, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 5);
+        assertEquals(fieldSize.getNumColumns(), 1);
     }
 
     @Test
@@ -144,8 +134,8 @@ public class UploadUtilTest {
                 .withType(UploadFieldType.MULTI_CHOICE)
                 .withMultiChoiceAnswerList("foo", "bar", "baz", "qwerty", "asdf").build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(25, fieldSize.getNumBytes());
-        assertEquals(5, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 25);
+        assertEquals(fieldSize.getNumColumns(), 5);
     }
 
     @Test
@@ -154,8 +144,8 @@ public class UploadUtilTest {
                 .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar")
                 .withAllowOtherChoices(true).build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(3010, fieldSize.getNumBytes());
-        assertEquals(3, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 3010);
+        assertEquals(fieldSize.getNumColumns(), 3);
     }
 
     @Test
@@ -163,8 +153,8 @@ public class UploadUtilTest {
         UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("field")
                 .withType(UploadFieldType.TIMESTAMP).build();
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(ImmutableList.of(fieldDef));
-        assertEquals(35, fieldSize.getNumBytes());
-        assertEquals(2, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 35);
+        assertEquals(fieldSize.getNumColumns(), 2);
     }
 
     @Test
@@ -181,8 +171,8 @@ public class UploadUtilTest {
 
         // Execute and validate.
         UploadFieldSize fieldSize = UploadUtil.calculateFieldSize(fieldDefList);
-        assertEquals(3195, fieldSize.getNumBytes());
-        assertEquals(6, fieldSize.getNumColumns());
+        assertEquals(fieldSize.getNumBytes(), 3195);
+        assertEquals(fieldSize.getNumColumns(), 6);
     }
 
     @Test
@@ -342,16 +332,16 @@ public class UploadUtilTest {
             UploadFieldType fieldType = (UploadFieldType) oneTestCase[1];
 
             CanonicalizationResult result = UploadUtil.canonicalize(inputNode, fieldType);
-            assertEquals("Test case: " + inputNodeStr + " as " + fieldType.name(), oneTestCase[2],
-                    result.getCanonicalizedValueNode());
+            assertEquals(result.getCanonicalizedValueNode(), oneTestCase[2],
+                    "Test case: " + inputNodeStr + " as " + fieldType.name());
 
             boolean expectedIsValid = (boolean) oneTestCase[3];
             if (expectedIsValid) {
-                assertTrue("Test case: " + inputNodeStr + " as " + fieldType.name(), result.isValid());
-                assertNull("Test case: " + inputNodeStr + " as " + fieldType.name(), result.getErrorMessage());
+                assertTrue(result.isValid(), "Test case: " + inputNodeStr + " as " + fieldType.name());
+                assertNull(result.getErrorMessage(), "Test case: " + inputNodeStr + " as " + fieldType.name());
             } else {
-                assertFalse("Test case: " + inputNodeStr + " as " + fieldType.name(), result.isValid());
-                assertNotNull("Test case: " + inputNodeStr + " as " + fieldType.name(), result.getErrorMessage());
+                assertFalse(result.isValid(), "Test case: " + inputNodeStr + " as " + fieldType.name());
+                assertNotNull(result.getErrorMessage(), "Test case: " + inputNodeStr + " as " + fieldType.name());
             }
         }
     }
@@ -385,8 +375,8 @@ public class UploadUtilTest {
             String inputNodeStr = BridgeObjectMapper.get().writeValueAsString(inputNode);
 
             JsonNode result = UploadUtil.convertToStringNode(inputNode);
-            assertTrue("Test case: " + inputNodeStr, result.isTextual());
-            assertEquals("Test case: " + inputNodeStr, oneTestCase[1], result.textValue());
+            assertTrue(result.isTextual(), "Test case: " + inputNodeStr);
+            assertEquals(result.textValue(), oneTestCase[1], "Test case: " + inputNodeStr);
         }
 
         // arbitrary JSON object
@@ -398,7 +388,7 @@ public class UploadUtilTest {
             // We don't want to couple to a specific way of JSON formatting. So instead of string checking, convert the
             // string back into JSON and compare JSON directly.
             JsonNode resultNestedJson = BridgeObjectMapper.get().readTree(result.textValue());
-            assertEquals(inputNode, resultNestedJson);
+            assertEquals(resultNestedJson, inputNode);
         }
     }
 
@@ -423,7 +413,7 @@ public class UploadUtilTest {
             String inputNodeStr = BridgeObjectMapper.get().writeValueAsString(inputNode);
 
             String retVal = UploadUtil.getAsString(inputNode);
-            assertEquals("Test case: " + inputNodeStr, oneTestCase[1], retVal);
+            assertEquals(retVal, oneTestCase[1], "Test case: " + inputNodeStr);
         }
 
         // arbitrary JSON object
@@ -434,7 +424,7 @@ public class UploadUtilTest {
             // We don't want to couple to a specific way of JSON formatting. So instead of string checking, convert the
             // string back into JSON and compare JSON directly.
             JsonNode resultNestedJson = BridgeObjectMapper.get().readTree(retVal);
-            assertEquals(inputNode, resultNestedJson);
+            assertEquals(resultNestedJson, inputNode);
         }
     }
 
@@ -461,8 +451,8 @@ public class UploadUtilTest {
         };
 
         for (String oneTestCase : testCases) {
-            assertFalse(oneTestCase + " should be invalid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
-            assertFalse(oneTestCase + " should be invalid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
+            assertFalse(UploadUtil.isValidAnswerChoice(oneTestCase), oneTestCase + " should be invalid answer choice");
+            assertFalse(UploadUtil.isValidSchemaFieldName(oneTestCase), oneTestCase + " should be invalid field name");
         }
     }
 
@@ -477,8 +467,8 @@ public class UploadUtilTest {
         };
 
         for (String oneTestCase : testCases) {
-            assertTrue(oneTestCase + " should be valid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
-            assertFalse(oneTestCase + " should be invalid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
+            assertTrue(UploadUtil.isValidAnswerChoice(oneTestCase), oneTestCase + " should be valid answer choice");
+            assertFalse(UploadUtil.isValidSchemaFieldName(oneTestCase), oneTestCase + " should be invalid field name");
         }
     }
 
@@ -499,8 +489,8 @@ public class UploadUtilTest {
         };
 
         for (String oneTestCase : testCases) {
-            assertTrue(oneTestCase + " should be valid answer choice", UploadUtil.isValidAnswerChoice(oneTestCase));
-            assertTrue(oneTestCase + " should be valid field name", UploadUtil.isValidSchemaFieldName(oneTestCase));
+            assertTrue(UploadUtil.isValidAnswerChoice(oneTestCase), oneTestCase + " should be valid answer choice");
+            assertTrue(UploadUtil.isValidSchemaFieldName(oneTestCase), oneTestCase + " should be valid field name");
         }
     }
 
@@ -561,8 +551,8 @@ public class UploadUtilTest {
         };
 
         for (Object[] oneTestCase : testCases) {
-            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef((UploadFieldDefinition) oneTestCase[0],
-                    (UploadFieldDefinition) oneTestCase[1]));
+            assertEquals(UploadUtil.isCompatibleFieldDef((UploadFieldDefinition) oneTestCase[0],
+                    (UploadFieldDefinition) oneTestCase[1]), oneTestCase[2]);
         }
     }
 
@@ -590,7 +580,7 @@ public class UploadUtilTest {
                 UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                         .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar", "baz")
                         .withAllowOtherChoices(oneTestCase[1]).build();
-                assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+                assertEquals((Boolean)UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), (Boolean)oneTestCase[2]);
             }
 
             // unboundedText
@@ -599,7 +589,7 @@ public class UploadUtilTest {
                         .withType(UploadFieldType.STRING).withUnboundedText(oneTestCase[0]).build();
                 UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                         .withType(UploadFieldType.STRING).withUnboundedText(oneTestCase[1]).build();
-                assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+                assertEquals((Boolean)UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), (Boolean)oneTestCase[3]);
             }
         }
     }
@@ -626,7 +616,7 @@ public class UploadUtilTest {
                     .withType(UploadFieldType.STRING).withMaxLength((Integer) oneTestCase[0]).build();
             UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                     .withType(UploadFieldType.STRING).withMaxLength((Integer) oneTestCase[1]).build();
-            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            assertEquals(UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), oneTestCase[2]);
         }
     }
 
@@ -652,7 +642,7 @@ public class UploadUtilTest {
                     .withType((UploadFieldType) oneTestCase[0]).withMaxLength(null).build();
             UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                     .withType((UploadFieldType) oneTestCase[1]).withMaxLength((Integer) oneTestCase[2]).build();
-            assertEquals(oneTestCase[3], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            assertEquals(UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), oneTestCase[3]);
         }
     }
 
@@ -676,7 +666,7 @@ public class UploadUtilTest {
             UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                     .withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList((List<String>) oneTestCase[1])
                     .build();
-            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            assertEquals(UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), oneTestCase[2]);
         }
     }
 
@@ -696,7 +686,7 @@ public class UploadUtilTest {
                     .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[0]).build();
             UploadFieldDefinition newFieldDef = new UploadFieldDefinition.Builder().withName("field")
                     .withType(UploadFieldType.INT).withRequired((boolean) oneTestCase[1]).build();
-            assertEquals(oneTestCase[2], UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef));
+            assertEquals(UploadUtil.isCompatibleFieldDef(oldFieldDef, newFieldDef), oneTestCase[2]);
         }
     }
 
@@ -729,25 +719,25 @@ public class UploadUtilTest {
     @Test
     public void validCalendarDate() {
         LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25");
-        assertEquals(2015, date.getYear());
-        assertEquals(12, date.getMonthOfYear());
-        assertEquals(25, date.getDayOfMonth());
+        assertEquals(date.getYear(), 2015);
+        assertEquals(date.getMonthOfYear(), 12);
+        assertEquals(date.getDayOfMonth(), 25);
     }
 
     @Test
     public void timestampCalendarDate() {
         LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25T14:33-0800");
-        assertEquals(2015, date.getYear());
-        assertEquals(12, date.getMonthOfYear());
-        assertEquals(25, date.getDayOfMonth());
+        assertEquals(date.getYear(), 2015);
+        assertEquals(date.getMonthOfYear(), 12);
+        assertEquals(date.getDayOfMonth(), 25);
     }
 
     @Test
     public void truncatesIntoValidCalendarDate() {
         LocalDate date = UploadUtil.parseIosCalendarDate("2015-12-25 @ lunchtime");
-        assertEquals(2015, date.getYear());
-        assertEquals(12, date.getMonthOfYear());
-        assertEquals(25, date.getDayOfMonth());
+        assertEquals(date.getYear(), 2015);
+        assertEquals(date.getMonthOfYear(), 12);
+        assertEquals(date.getDayOfMonth(), 25);
     }
 
     @Test
@@ -785,7 +775,7 @@ public class UploadUtilTest {
         String timestampStr = "2015-08-26T23:54:04Z";
         long expectedMillis = DateTime.parse(timestampStr).getMillis();
         DateTime parsedTimestamp = UploadUtil.parseIosTimestamp(timestampStr);
-        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+        assertEquals(parsedTimestamp.getMillis(), expectedMillis);
     }
 
     @Test
@@ -793,14 +783,14 @@ public class UploadUtilTest {
         String timestampStr = "2015-08-26T16:54:04-07:00";
         long expectedMillis = DateTime.parse(timestampStr).getMillis();
         DateTime parsedTimestamp = UploadUtil.parseIosTimestamp(timestampStr);
-        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+        assertEquals(parsedTimestamp.getMillis(), expectedMillis);
     }
 
     @Test
     public void iosTimestamp() {
         long expectedMillis = DateTime.parse("2015-08-26T16:54:04-07:00").getMillis();
         DateTime parsedTimestamp = UploadUtil.parseIosTimestamp("2015-08-26 16:54:04 -0700");
-        assertEquals(expectedMillis, parsedTimestamp.getMillis());
+        assertEquals(parsedTimestamp.getMillis(), expectedMillis);
     }
 
     @Test
@@ -813,8 +803,8 @@ public class UploadUtilTest {
 
         // Execute and validate.
         Map<String, String> outputMap = UploadUtil.sanitizeFieldNames(inputMap);
-        assertEquals(2, outputMap.size());
-        assertEquals("bar", outputMap.get("foo"));
-        assertEquals("sanitize this's value", outputMap.get("sanitize____this"));
+        assertEquals(outputMap.size(), 2);
+        assertEquals(outputMap.get("foo"), "bar");
+        assertEquals(outputMap.get("sanitize____this"), "sanitize this's value");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationContextTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 
 import java.io.File;
 import java.util.Map;
@@ -12,7 +12,8 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -34,7 +35,7 @@ public class UploadValidationContextTest {
         DynamoUpload2 upload = new DynamoUpload2();
         upload.setUploadId(UPLOAD_ID);
         context.setUpload(upload);
-        assertEquals(UPLOAD_ID, context.getUploadId());
+        assertEquals(context.getUploadId(), UPLOAD_ID);
     }
 
     @Test
@@ -67,36 +68,36 @@ public class UploadValidationContextTest {
 
         // copy and validate
         UploadValidationContext copy = original.shallowCopy();
-        assertEquals(HEALTH_CODE, copy.getHealthCode());
-        assertSame(study, copy.getStudy());
-        assertSame(upload, copy.getUpload());
+        assertEquals(copy.getHealthCode(), HEALTH_CODE);
+        assertSame(copy.getStudy(), study);
+        assertSame(copy.getUpload(), upload);
         assertFalse(copy.getSuccess());
-        assertSame(tempDir, copy.getTempDir());
-        assertSame(dataFile, copy.getDataFile());
-        assertSame(decryptedDataFile, copy.getDecryptedDataFile());
-        assertEquals(unzippedDataFileMap, copy.getUnzippedDataFileMap());
-        assertSame(infoJsonNode, copy.getInfoJsonNode());
-        assertSame(record, copy.getHealthDataRecord());
-        assertEquals("test-record", copy.getRecordId());
+        assertSame(copy.getTempDir(), tempDir);
+        assertSame(copy.getDataFile(), dataFile);
+        assertSame(copy.getDecryptedDataFile(), decryptedDataFile);
+        assertEquals(copy.getUnzippedDataFileMap(), unzippedDataFileMap);
+        assertSame(copy.getInfoJsonNode(), infoJsonNode);
+        assertSame(copy.getHealthDataRecord(), record);
+        assertEquals(copy.getRecordId(), "test-record");
 
-        assertEquals(1, copy.getMessageList().size());
-        assertEquals("common message", copy.getMessageList().get(0));
+        assertEquals(copy.getMessageList().size(), 1);
+        assertEquals(copy.getMessageList().get(0), "common message");
 
         // modify original and validate copy unchanged
         original.setHealthCode("new-health-code");
         original.addMessage("original message");
 
-        assertEquals(HEALTH_CODE, copy.getHealthCode());
-        assertEquals(1, copy.getMessageList().size());
-        assertEquals("common message", copy.getMessageList().get(0));
+        assertEquals(copy.getHealthCode(), HEALTH_CODE);
+        assertEquals(copy.getMessageList().size(), 1);
+        assertEquals(copy.getMessageList().get(0), "common message");
 
         // modify copy and validate original unchanged
         copy.setRecordId("new-record-id");
         copy.addMessage("copy message");
 
-        assertEquals("test-record", original.getRecordId());
-        assertEquals(2, original.getMessageList().size());
-        assertEquals("common message", original.getMessageList().get(0));
-        assertEquals("original message", original.getMessageList().get(1));
+        assertEquals(original.getRecordId(), "test-record");
+        assertEquals(original.getMessageList().size(), 2);
+        assertEquals(original.getMessageList().get(0), "common message");
+        assertEquals(original.getMessageList().get(1), "original message");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationTaskFactoryTest.java
@@ -1,13 +1,14 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.file.FileHelper;
@@ -40,13 +41,13 @@ public class UploadValidationTaskFactoryTest {
 
         // execute and validate
         UploadValidationTask task = taskFactory.newTask(study, upload);
-        assertEquals(HEALTH_CODE, task.getContext().getHealthCode());
-        assertSame(study, task.getContext().getStudy());
-        assertSame(upload, task.getContext().getUpload());
+        assertEquals(task.getContext().getHealthCode(), HEALTH_CODE);
+        assertSame(task.getContext().getStudy(), study);
+        assertSame(task.getContext().getUpload(), upload);
 
-        assertSame(fileHelper, task.getFileHelper());
-        assertSame(handlerList, task.getHandlerList());
-        assertSame(dao, task.getUploadDao());
-        assertSame(healthDataService, task.getHealthDataService());
+        assertSame(task.getFileHelper(), fileHelper);
+        assertSame(task.getHandlerList(), handlerList);
+        assertSame(task.getUploadDao(), dao);
+        assertSame(task.getHealthDataService(), healthDataService);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadValidationTaskTest.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.bridge.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.notNull;
@@ -13,6 +10,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.mockito.Mockito.eq;
 
 import javax.annotation.Nonnull;
@@ -24,8 +24,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import org.joda.time.LocalDate;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -73,7 +73,7 @@ public class UploadValidationTaskTest {
     private UploadValidationTask task;
     private Upload upload;
 
-    @Before
+    @BeforeMethod
     public void setup() throws IOException {
         // Mock health data service
         testRecord = makeRecordWithId(RECORD_ID);
@@ -120,10 +120,10 @@ public class UploadValidationTaskTest {
 
         // validate that the handlers ran by checking the messages they wrote
         List<String> messageList = ctx.getMessageList();
-        assertEquals(3, messageList.size());
-        assertEquals("foo was here", messageList.get(0));
-        assertEquals("bar was here", messageList.get(1));
-        assertEquals("kilroy was here", messageList.get(2));
+        assertEquals(messageList.size(), 3);
+        assertEquals(messageList.get(0), "foo was here");
+        assertEquals(messageList.get(1), "bar was here");
+        assertEquals(messageList.get(2), "kilroy was here");
     }
 
     @Test
@@ -164,8 +164,8 @@ public class UploadValidationTaskTest {
         // Validate validation messages. First message is foo handler. Second message is error message. Just check that
         // the second message exists.
         List<String> messageList = ctx.getMessageList();
-        assertEquals(2, messageList.size());
-        assertEquals("foo succeeded", messageList.get(0));
+        assertEquals(messageList.size(), 2);
+        assertEquals(messageList.get(0), "foo succeeded");
         assertFalse(Strings.isNullOrEmpty(messageList.get(1)));
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/util/BridgeCollectorsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/util/BridgeCollectorsTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import org.testng.annotations.Test;
 
 /**
  * Adopted from the OpenGamma library (Apache License v2):
@@ -25,7 +25,7 @@ public class BridgeCollectorsTest {
         List<String> list = Arrays.asList("a", "ab", "b", "bb", "c", "a");
         ImmutableList<String> test = list.stream().filter(s -> s.length() == 1)
                 .collect(BridgeCollectors.toImmutableList());
-        assertEquals(test, ImmutableList.of("a", "b", "c", "a"));
+        assertEquals(ImmutableList.of("a", "b", "c", "a"), test);
         assertTrue(test instanceof ImmutableList);
     }
 
@@ -34,7 +34,7 @@ public class BridgeCollectorsTest {
         List<String> list = Arrays.asList("a", "ab", "b", "bb", "c", "a");
         ImmutableSet<String> test = list.stream().filter(s -> s.length() == 1)
                 .collect(BridgeCollectors.toImmutableSet());
-        assertEquals(test, ImmutableSet.of("a", "b", "c"));
+        assertEquals(ImmutableSet.of("a", "b", "c"), test);
         assertTrue(test instanceof ImmutableSet);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/AccountIdValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AccountIdValidatorTest.java
@@ -2,7 +2,8 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -22,7 +23,7 @@ public class AccountIdValidatorTest {
         Validate.entityThrowingException(AccountIdValidator.getInstance(ChannelType.PHONE), accountId);
     }
     
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void validatorUnsupportedType() {
         AccountId accountId = AccountId.forEmail(TestConstants.TEST_STUDY_IDENTIFIER, "email@email.com");
         Validate.entityThrowingException(AccountIdValidator.getInstance(null), accountId);

--- a/src/test/java/org/sagebionetworks/bridge/validators/AccountSummarySearchValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AccountSummarySearchValidatorTest.java
@@ -5,24 +5,25 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AccountSummarySearchValidatorTest {
 
     private AccountSummarySearchValidator validator;
     
     private AccountSummarySearch.Builder builder;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         validator = new AccountSummarySearchValidator(Sets.newHashSet("group1", "group2"));
         builder = new AccountSummarySearch.Builder();
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ActivityValidatorTest.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
 import org.springframework.validation.Validator;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.schedules.Activity;
 import org.sagebionetworks.bridge.models.schedules.CompoundActivity;

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppConfigElementValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppConfigElementValidatorTest.java
@@ -2,8 +2,9 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
@@ -13,7 +14,7 @@ public class AppConfigElementValidatorTest {
     
     private AppConfigElement element;
     
-    @Before
+    @BeforeMethod
     public void before() {
         element = TestUtils.getAppConfigElement();
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
@@ -12,11 +12,11 @@ import org.joda.time.DateTime;
 
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
@@ -36,7 +36,6 @@ import org.sagebionetworks.bridge.services.UploadSchemaService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AppConfigValidatorTest {
     
     private static final SurveyReference INVALID_SURVEY_REF = new SurveyReference(null, "guid", null);
@@ -63,8 +62,10 @@ public class AppConfigValidatorTest {
     
     private AppConfig appConfig;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         appConfig = AppConfig.create();
         appConfig.setStudyId(TEST_STUDY_IDENTIFIER);
         

--- a/src/test/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dynamodb.DynamoCompoundActivityDefinition;

--- a/src/test/java/org/sagebionetworks/bridge/validators/ConsentSignatureValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ConsentSignatureValidatorTest.java
@@ -1,14 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -20,13 +21,13 @@ public class ConsentSignatureValidatorTest {
     private static final long SIGNED_ON_TIMESTAMP = DateUtils.getCurrentMillisFromEpoch();
     private ConsentSignatureValidator validator;
     
-    @Before
+    @BeforeMethod
     public void before() {
         DateTimeUtils.setCurrentMillisFixed(NOW.getMillis());
         validator = new ConsentSignatureValidator(0);
     }
 
-    @After
+    @AfterMethod
     public void after() {
         DateTimeUtils.setCurrentMillisSystem();
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
@@ -4,12 +4,11 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
@@ -22,7 +21,6 @@ import org.sagebionetworks.bridge.services.SubstudyService;
 
 import com.google.common.collect.ImmutableSet;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ExternalIdValidatorTest {
     
     private ExternalIdValidator validatorV4;
@@ -30,12 +28,14 @@ public class ExternalIdValidatorTest {
     @Mock
     private SubstudyService substudyService;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         validatorV4 = new ExternalIdValidator(substudyService, false);
     }
     
-    @After
+    @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(null);
     }
@@ -143,7 +143,7 @@ public class ExternalIdValidatorTest {
         assertValidatorMessage(validatorV4, id, "substudyId", "is not a valid substudy");
     }
     
-    @Test(expected = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class)
     public void studyIdCannotBeBlank() { 
         ExternalIdentifier.create(new StudyIdentifierImpl("   "), "one-id");
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/HealthDataSubmissionValidatorTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import org.joda.time.DateTime;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;

--- a/src/test/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidatorTest.java
@@ -6,11 +6,11 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.IdentifierUpdate;
@@ -19,7 +19,6 @@ import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.ExternalIdService;
 
-@RunWith(MockitoJUnitRunner.class)
 public class IdentifierUpdateValidatorTest {
 
     private static final String UPDATED_EMAIL = "updated@email.com";
@@ -33,8 +32,10 @@ public class IdentifierUpdateValidatorTest {
     
     private IdentifierUpdateValidator validator;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         study = Study.create();
         study.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         validator = new IdentifierUpdateValidator(study, externalIdService);

--- a/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
@@ -3,7 +3,8 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.IntentToParticipateValidator.INSTANCE;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;

--- a/src/test/java/org/sagebionetworks/bridge/validators/NotificationMessageValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/NotificationMessageValidatorTest.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
@@ -51,7 +51,7 @@ public class NotificationMessageValidatorTest {
             Validate.entityThrowingException(NotificationMessageValidator.INSTANCE, message);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            assertEquals(fieldName+error, e.getErrors().get(fieldName).get(0));
+            assertEquals(e.getErrors().get(fieldName).get(0), fieldName+error);
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/NotificationRegistrationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/NotificationRegistrationValidatorTest.java
@@ -3,8 +3,8 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.NotificationRegistrationValidator.INSTANCE;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.notifications.NotificationProtocol;
@@ -16,7 +16,7 @@ public class NotificationRegistrationValidatorTest {
     
     private NotificationRegistration registration;
     
-    @Before
+    @BeforeMethod
     public void before() {
         registration = TestUtils.getNotificationRegistration();
         registration.setOsName(OS_NAME);

--- a/src/test/java/org/sagebionetworks/bridge/validators/NotificationTopicValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/NotificationTopicValidatorTest.java
@@ -2,9 +2,9 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.validation.Validator;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.notifications.NotificationTopic;
 
@@ -14,7 +14,7 @@ public class NotificationTopicValidatorTest {
     
     private NotificationTopic topic;
     
-    @Before
+    @BeforeMethod
     public void before() {
         topic = NotificationTopic.create();
         topic.setGuid("ABC-DEF");

--- a/src/test/java/org/sagebionetworks/bridge/validators/PasswordResetValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/PasswordResetValidatorTest.java
@@ -1,16 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.function.Consumer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
@@ -18,7 +17,6 @@ import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.StudyService;
 
-@RunWith(MockitoJUnitRunner.class)
 public class PasswordResetValidatorTest {
     
     PasswordResetValidator validator;
@@ -29,8 +27,10 @@ public class PasswordResetValidatorTest {
     @Mock
     Study study;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         doReturn(PasswordPolicy.DEFAULT_PASSWORD_POLICY).when(study).getPasswordPolicy();
         doReturn(study).when(studyService).getStudy("api");
         
@@ -92,7 +92,7 @@ public class PasswordResetValidatorTest {
     private void assertError(InvalidEntityException e, String fieldName, String... messages) {
         for (int i=0; i < messages.length; i++) {
             String message = messages[i];
-            assertEquals(fieldName + " " + message, e.getErrors().get(fieldName).get(i));
+            assertEquals(e.getErrors().get(fieldName).get(i), fieldName + " " + message);
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ReportDataKeyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ReportDataKeyValidatorTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -18,7 +18,7 @@ public class ReportDataKeyValidatorTest {
                 .withIdentifier("foo")
                 .withReportType(ReportType.STUDY).build();
         
-        assertEquals("foo:api", key.getKeyString());
+        assertEquals(key.getKeyString(), "foo:api");
     }
     
     @Test
@@ -29,7 +29,7 @@ public class ReportDataKeyValidatorTest {
                 .withIdentifier("foo")
                 .withReportType(ReportType.PARTICIPANT).build();
 
-        assertEquals("ABC:foo:api", key.getKeyString());
+        assertEquals(key.getKeyString(), "ABC:foo:api");
     }
     
     @Test
@@ -79,7 +79,7 @@ public class ReportDataKeyValidatorTest {
             runnable.run();
         } catch(InvalidEntityException e) {
             String message = e.getErrors().get(fieldName).get(0);
-            assertEquals(fieldName + " " + error, message);
+            assertEquals(message, fieldName + " " + error);
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ReportDataValidatorTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -22,7 +22,7 @@ public class ReportDataValidatorTest {
     
     private ReportDataValidator validator;
     
-    @Before
+    @BeforeMethod
     public void before() { 
         validator = new ReportDataValidator(null);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ScheduleContextValidatorTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;

--- a/src/test/java/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SchedulePlanValidatorTest.java
@@ -1,14 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.validation.Errors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -29,7 +30,7 @@ public class SchedulePlanValidatorTest {
     
     private SchedulePlanValidator validator;
 
-    @Before
+    @BeforeMethod
     public void before() throws Exception {
         validator = new SchedulePlanValidator(TestConstants.USER_DATA_GROUPS, TestConstants.USER_SUBSTUDY_IDS,
                 TASK_IDENTIFIERS);
@@ -107,7 +108,7 @@ public class SchedulePlanValidatorTest {
             Validate.entityThrowingException(validator, plan);
             fail("Should have thrown exception");
         } catch (InvalidEntityException e) {
-            assertEquals(message, e.getErrors().get(fieldName).get(0));
+            assertEquals(e.getErrors().get(fieldName).get(0), message);
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ScheduleValidatorTest.java
@@ -1,15 +1,16 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -25,7 +26,7 @@ public class ScheduleValidatorTest {
     private Schedule schedule;
     ScheduleValidator validator;
     
-    @Before
+    @BeforeMethod
     public void before() {
         schedule = new Schedule();
         validator = new ScheduleValidator(Sets.newHashSet("tapTest"));
@@ -173,7 +174,7 @@ public class ScheduleValidatorTest {
         schedule.setStartsOn(now);
         schedule.setEndsOn(now.plusHours(1));
         
-        assertEquals(ActivityType.TASK, schedule.getActivities().get(0).getActivityType());
+        assertEquals(schedule.getActivities().get(0).getActivityType(), ActivityType.TASK);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/SharedModuleMetadataValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SharedModuleMetadataValidatorTest.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.hibernate.HibernateSharedModuleMetadata;

--- a/src/test/java/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SignInValidatorTest.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.Phone;

--- a/src/test/java/org/sagebionetworks/bridge/validators/SmsMessageValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SmsMessageValidatorTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.sms.SmsMessage;

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyConsentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyConsentValidatorTest.java
@@ -4,21 +4,21 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentForm;
 
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 public class StudyConsentValidatorTest {
 
     private Resource resource;
     
-    @Before
+    @BeforeMethod
     public void before() {
         resource = new AbstractResource() {
             @Override
@@ -32,12 +32,12 @@ public class StudyConsentValidatorTest {
         };
     }
     
-    @After
+    @AfterMethod
     public void after() throws IOException {
         resource.getInputStream().close();
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void detectsInvalidXML() throws Exception {
         StudyConsentValidator validator = new StudyConsentValidator();
         validator.setConsentBodyTemplate(resource);

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertNull;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -9,11 +9,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-@RunWith(MockitoJUnitRunner.class)
 public class StudyParticipantValidatorTest {
     
     private static final Set<String> STUDY_PROFILE_ATTRS = BridgeUtils.commaListToOrderedSet("attr1,attr2");
@@ -50,8 +49,10 @@ public class StudyParticipantValidatorTest {
     
     private Substudy substudy;
     
-    @Before
+    @BeforeMethod
     public void before() {
+        MockitoAnnotations.initMocks(this);
+        
         substudy = Substudy.create();
         
         study = Study.create();
@@ -120,7 +121,7 @@ public class StudyParticipantValidatorTest {
         Validate.entityThrowingException(validator, withEmail("email@email.com"));
     }
     
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validatesIdForExisting() {
         // not new, this should fail, as there's no ID in participant.
         validator = new StudyParticipantValidator(externalIdService, substudyService, study, false); 

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -11,8 +11,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
@@ -44,7 +45,7 @@ public class StudyValidatorTest {
 
     private DynamoStudy study;
     
-    @Before
+    @BeforeMethod
     public void createValidStudy() {
         study = TestUtils.getValidStudy(StudyValidatorTest.class);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
@@ -1,13 +1,13 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -21,7 +21,7 @@ public class SubpopulationValidatorTest {
 
     SubpopulationValidator validator;
     
-    @Before
+    @BeforeMethod
     public void before() {
         validator = new SubpopulationValidator(TestConstants.USER_DATA_GROUPS, TestConstants.USER_SUBSTUDY_IDS);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/SubstudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SubstudyValidatorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.substudies.Substudy;
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SurveyPublishValidatorTest.java
@@ -5,8 +5,9 @@ import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.surveys.MultiValueConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
@@ -23,7 +24,7 @@ public class SurveyPublishValidatorTest {
 
     private SurveyPublishValidator validator;
 
-    @Before
+    @BeforeMethod
     public void before() {
         survey = new TestSurvey(SurveySaveValidatorTest.class, true);
         // because this is set by the service before validation

--- a/src/test/java/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -10,8 +10,8 @@ import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.YearMonth;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
@@ -52,7 +52,7 @@ public class SurveySaveValidatorTest {
 
     private SurveySaveValidator validator;
 
-    @Before
+    @BeforeMethod
     public void before() {
         
         survey = new TestSurvey(SurveySaveValidatorTest.class, true);

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadFieldDefinitionListValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadFieldDefinitionListValidatorTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
@@ -124,10 +124,10 @@ public class UploadFieldDefinitionListValidatorTest {
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "UploadFieldDefinitionList");
         UploadFieldDefinitionListValidator.INSTANCE.validate(fieldDefList, errors, FIELD_LIST_ATTR_NAME);
 
-        assertEquals(hasError, errors.hasErrors());
+        assertEquals(errors.hasErrors(), hasError);
         if (hasError) {
             Map<String, List<String>> errorMap = Validate.convertErrorsToSimpleMap(errors);
-            assertEquals(fieldName + " " + errorMessage, errorMap.get(fieldName).get(0));
+            assertEquals(errorMap.get(fieldName).get(0), fieldName + " " + errorMessage);
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -1,15 +1,14 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -20,6 +19,7 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 import org.springframework.validation.MapBindingResult;
+import org.testng.annotations.Test;
 
 public class UploadSchemaValidatorTest {
     // branch coverage
@@ -123,84 +123,84 @@ public class UploadSchemaValidatorTest {
                 "can't be greater than maxAppVersion");
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNullName() {
         UploadSchema schema = makeValidSchema();
         schema.setName(null);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateEmptyName() {
         UploadSchema schema = makeValidSchema();
         schema.setName("");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateBlankName() {
         UploadSchema schema = makeValidSchema();
         schema.setName("   ");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNegativeRev() {
         UploadSchema schema = makeValidSchema();
         schema.setRevision(-1);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateZeroRev() {
         UploadSchema schema = makeValidSchema();
         schema.setRevision(0);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNullSchemaId() {
         UploadSchema schema = makeValidSchema();
         schema.setSchemaId(null);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateEmptySchemaId() {
         UploadSchema schema = makeValidSchema();
         schema.setSchemaId("");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateBlankSchemaId() {
         UploadSchema schema = makeValidSchema();
         schema.setSchemaId("   ");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNullSchemaType() {
         UploadSchema schema = makeValidSchema();
         schema.setSchemaType(null);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNullStudyId() {
         UploadSchema schema = makeValidSchema();
         schema.setStudyId(null);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateEmptyStudyId() {
         UploadSchema schema = makeValidSchema();
         schema.setStudyId("");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
-    @Test(expected = InvalidEntityException.class)
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void validateBlankStudyId() {
         UploadSchema schema = makeValidSchema();
         schema.setStudyId("   ");

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.HttpStatus;
-import org.junit.Test;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.springframework.validation.Validator;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -25,7 +25,7 @@ public class UploadValidatorTest {
         BridgeObjectMapper mapper = new BridgeObjectMapper();
         
         JsonNode node = mapper.valueToTree(new UploadRequest());
-        assertEquals("Type is UploadRequest", "UploadRequest", node.get("type").asText());
+        assertEquals("UploadRequest", node.get("type").asText(), "Type is UploadRequest");
     }
 
     @Test
@@ -54,7 +54,7 @@ public class UploadValidatorTest {
             
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
-            assertEquals("Name missing", HttpStatus.SC_BAD_REQUEST, e.getStatusCode());
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Name missing");
         }
 
         try {
@@ -66,7 +66,7 @@ public class UploadValidatorTest {
             
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
-            assertEquals("Content type missing", HttpStatus.SC_BAD_REQUEST, e.getStatusCode());
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content type missing");
         }
 
         try {
@@ -78,7 +78,7 @@ public class UploadValidatorTest {
             
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
-            assertEquals("Content length missing", HttpStatus.SC_BAD_REQUEST, e.getStatusCode());
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length missing");
         }
 
         try {
@@ -91,7 +91,7 @@ public class UploadValidatorTest {
             
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
-            assertEquals("Content length > 10 MB", HttpStatus.SC_BAD_REQUEST, e.getStatusCode());
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length > 10 MB");
         }
 
         try {
@@ -104,7 +104,7 @@ public class UploadValidatorTest {
             
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
-            assertEquals("MD5 not base64 encoded", HttpStatus.SC_BAD_REQUEST, e.getStatusCode());
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 not base64 encoded");
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/VerificationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/VerificationValidatorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.accounts.Verification;
 


### PR DESCRIPTION
Changes so BridgeServerLogic can be copied into BridgeServer2.

* Switches from JUnit to TestNG;
* Changed the related import statements in each file;
* Renamed annotations: `@Before` --> `@BeforeMethod` and `@After` --> `@AfterMethod`
* `@Test(expected = Exception.class)` --> `@Test(**expectedExceptions** = Exception.class)`
* Removed `@RunWith(MockitoJUnitRunner.class)` and replaced it with `MockitoAnnotations.initMocks(this)` in the `@BeforeMethod` annotated method
* switched the order of all `assertEquals`, `assertSame`, `assertNotEquals`, `assertNotSame` calls. This is many many changes, however, the tests still work if these were not swapped, or were incorrect to start with (and so now are swapped and still incorrect), so this was low risk and never failed any tests.

In addition, two tests needed further changes to pass, I think possibly because mocks are not recreated as part of each test method run, but I'm not sure:

`CacheAdminServiceTest, line 327`: this test relied on the order of properties being the same in both iterators, which was not true after refactoring. Converted property names into sets and compared those;

`ReferenceResolverTest`: order or test execution mattered because there are two maps that serve as caches, and their state was not being fully reset between test methods. Clearing the maps after each test fixed this.

