### PR TITLE
01 Converting Play-based unit tests (ReferenceResolverTest, DynamoAppConfigDaoTest, DynamoCompoundActivityDefinitionDaoTest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeServerLogic</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 
     <properties>
         <aws.version>1.11.198</aws.version>

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 
 public class TestConstants {
     
+    public static final String HEALTH_CODE = "oneHealthCode";
     public static final String ENCRYPTED_HEALTH_CODE = "TFMkaVFKPD48WissX0bgcD3esBMEshxb3MVgKxHnkXLSEPN4FQMKc01tDbBAVcXx94kMX6ckXVYUZ8wx4iICl08uE+oQr9gorE1hlgAyLAM=";
     public static final String UNENCRYPTED_HEALTH_CODE = "5a2192ee-f55d-4d01-a385-2d19f15a0880";
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
@@ -28,7 +28,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -53,7 +52,6 @@ public class DynamoActivityEventDaoTest extends Mockito {
             .withHealthCode(HEALTH_CODE).withObjectType(ACTIVITY).withObjectId("AAA-BBB-CCC").withEventType(FINISHED)
             .withTimestamp(TIMESTAMP).build();
     
-    @Spy
     @InjectMocks
     DynamoActivityEventDao dao;
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
@@ -1,0 +1,183 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ACTIVITY;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.QUESTION;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.SURVEY;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventType.ANSWERED;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventType.FINISHED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DynamoActivityEventDaoTest extends Mockito {
+    
+    // timestamp is in milliseconds since the epoch, so use UTC here
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    
+    private static final DynamoActivityEvent ENROLLMENT_EVENT = new DynamoActivityEvent.Builder()
+            .withHealthCode(HEALTH_CODE).withObjectType(ENROLLMENT).withTimestamp(TIMESTAMP).build();
+
+    private static final DynamoActivityEvent SURVEY_FINISHED_EVENT = new DynamoActivityEvent.Builder()
+            .withHealthCode(HEALTH_CODE).withObjectType(SURVEY).withEventType(FINISHED).withTimestamp(TIMESTAMP)
+            .withObjectId("AAA-BBB-CCC").build();
+
+    private static final DynamoActivityEvent QUESTION_ANSWERED_EVENT = new DynamoActivityEvent.Builder()
+            .withHealthCode(HEALTH_CODE).withObjectType(QUESTION).withObjectId("DDD-EEE-FFF").withEventType(ANSWERED)
+            .withAnswerValue("anAnswer").withTimestamp(TIMESTAMP).build();
+
+    private static final DynamoActivityEvent ACTIVITY_FINISHED_EVENT = new DynamoActivityEvent.Builder()
+            .withHealthCode(HEALTH_CODE).withObjectType(ACTIVITY).withObjectId("AAA-BBB-CCC").withEventType(FINISHED)
+            .withTimestamp(TIMESTAMP).build();
+    
+    @Spy
+    @InjectMocks
+    DynamoActivityEventDao dao;
+    
+    @Mock
+    DynamoDBMapper mockMapper;
+    
+    @Mock
+    PaginatedQueryList<DynamoActivityEvent> queryResults;
+    
+    @Captor
+    ArgumentCaptor<DynamoActivityEvent> eventCaptor;
+    
+    @Captor
+    ArgumentCaptor<DynamoDBQueryExpression<DynamoActivityEvent>> queryCaptor;
+    
+    @Captor
+    ArgumentCaptor<List<DynamoActivityEvent>> listCaptor;
+    
+    @BeforeMethod
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void publishEventIsNew() {
+        boolean result = dao.publishEvent(SURVEY_FINISHED_EVENT);
+        assertTrue(result);
+        
+        verify(mockMapper).load(eventCaptor.capture());
+        DynamoActivityEvent loadKey = eventCaptor.getValue();
+        assertEquals(loadKey.getHealthCode(), HEALTH_CODE);
+        assertEquals(loadKey.getEventId(), "survey:AAA-BBB-CCC:finished");
+        
+        verify(mockMapper).save(eventCaptor.capture());
+        assertSame(eventCaptor.getValue(), SURVEY_FINISHED_EVENT);
+    }
+    
+    @Test
+    public void publishEventIsMutableAndLater() {
+        DynamoActivityEvent earlierEvent = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
+                .withObjectType(SURVEY).withEventType(FINISHED).withTimestamp(TIMESTAMP.minusHours(1))
+                .withObjectId("AAA-BBB-CCC").build();
+        when(mockMapper.load(any())).thenReturn(earlierEvent);
+        
+        boolean result = dao.publishEvent(SURVEY_FINISHED_EVENT);
+        assertTrue(result);
+        
+        verify(mockMapper).save(eventCaptor.capture());
+        assertSame(eventCaptor.getValue(), SURVEY_FINISHED_EVENT);
+    }
+    
+    @Test
+    public void publishEventIsImmutableFails() {
+        when(mockMapper.load(any())).thenReturn(ENROLLMENT_EVENT);
+        
+        DynamoActivityEvent laterEvent = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
+                .withObjectType(ENROLLMENT).withTimestamp(TIMESTAMP.plusHours(1)).build();
+        
+        boolean result = dao.publishEvent(laterEvent);
+        assertFalse(result);
+        
+        verify(mockMapper, never()).save(any());
+    }
+    
+    @Test
+    public void publishEventIsEarlierFails() {
+        DynamoActivityEvent laterEvent = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
+                .withObjectType(SURVEY).withEventType(FINISHED).withTimestamp(TIMESTAMP.plusHours(1))
+                .withObjectId("AAA-BBB-CCC").build();
+        when(mockMapper.load(any())).thenReturn(laterEvent);
+        
+        boolean result = dao.publishEvent(SURVEY_FINISHED_EVENT);
+        assertFalse(result);
+        
+        verify(mockMapper, never()).save(any());
+    }
+
+    @Test
+    public void getActivityEventMap() {
+        List<DynamoActivityEvent> savedEvents = ImmutableList.of(ENROLLMENT_EVENT, SURVEY_FINISHED_EVENT,
+                QUESTION_ANSWERED_EVENT, ACTIVITY_FINISHED_EVENT);
+        when(queryResults.iterator()).thenReturn(savedEvents.iterator());
+        when(mockMapper.query(eq(DynamoActivityEvent.class), any())).thenReturn(queryResults);
+        
+        Map<String, DateTime> results = dao.getActivityEventMap(HEALTH_CODE);
+        
+        assertEquals(results.size(), 4);
+        assertEquals(results.get("enrollment"), TIMESTAMP);
+        assertEquals(results.get("survey:AAA-BBB-CCC:finished"), TIMESTAMP);
+        assertEquals(results.get("question:DDD-EEE-FFF:answered=anAnswer"), TIMESTAMP);
+        assertEquals(results.get("activity:AAA-BBB-CCC:finished"), TIMESTAMP);
+        
+        verify(mockMapper).query(any(), queryCaptor.capture());
+        
+        DynamoDBQueryExpression<DynamoActivityEvent> query = queryCaptor.getValue();
+        assertEquals(query.getHashKeyValues().getHealthCode(), HEALTH_CODE);
+    }
+    
+    @Test
+    public void getActivityEventMapNoEvents() {
+        List<DynamoActivityEvent> savedEvents = ImmutableList.of();
+        when(queryResults.iterator()).thenReturn(savedEvents.iterator());
+        when(mockMapper.query(eq(DynamoActivityEvent.class), any())).thenReturn(queryResults);
+        
+        Map<String, DateTime> results = dao.getActivityEventMap(HEALTH_CODE);
+        assertTrue(results.isEmpty());
+        
+        verify(mockMapper).query(any(), queryCaptor.capture());
+        
+        DynamoDBQueryExpression<DynamoActivityEvent> query = queryCaptor.getValue();
+        assertEquals(query.getHashKeyValues().getHealthCode(), HEALTH_CODE);
+    }
+    
+    @Test
+    public void deleteActivityEvents() {
+        List<DynamoActivityEvent> savedEvents = ImmutableList.of(ENROLLMENT_EVENT, SURVEY_FINISHED_EVENT,
+                QUESTION_ANSWERED_EVENT, ACTIVITY_FINISHED_EVENT);
+        when(queryResults.toArray()).thenReturn(savedEvents.toArray());
+        when(mockMapper.query(eq(DynamoActivityEvent.class), any())).thenReturn(queryResults);
+        
+        dao.deleteActivityEvents(HEALTH_CODE);
+        
+        verify(mockMapper).batchDelete(listCaptor.capture());
+        List<DynamoActivityEvent> eventsToDelete = listCaptor.getValue();
+        assertEquals(eventsToDelete, savedEvents);
+    }    
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
@@ -15,8 +15,6 @@ import java.util.List;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.google.common.collect.ImmutableList;
 
@@ -26,16 +24,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.appconfig.AppConfig;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 
 public class DynamoAppConfigDaoTest extends Mockito {
 
@@ -68,7 +63,6 @@ public class DynamoAppConfigDaoTest extends Mockito {
     ArgumentCaptor<AppConfig> configCaptor;
     
     @InjectMocks
-    @Spy
     DynamoAppConfigDao dao;
 
     @BeforeMethod

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigDaoTest.java
@@ -1,0 +1,313 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static com.amazonaws.services.dynamodbv2.model.ComparisonOperator.NE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.CriteriaDao;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.Criteria;
+import org.sagebionetworks.bridge.models.appconfig.AppConfig;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+
+public class DynamoAppConfigDaoTest extends Mockito {
+
+    private static final String GUID = "oneGuid";
+    
+    private static final DynamoAppConfig KEY = new DynamoAppConfig();
+    static {
+        KEY.setStudyId(TEST_STUDY_IDENTIFIER);
+        KEY.setGuid(GUID);
+    }
+    
+    private static final String CRITERIA_KEY = "appconfig:" + GUID;
+    
+    @Mock
+    DynamoDBMapper mockMapper;
+    
+    @Mock
+    CriteriaDao mockCriteriaDao;
+    
+    @Mock
+    PaginatedQueryList<DynamoAppConfig> mockResults;
+    
+    @Captor
+    ArgumentCaptor<DynamoDBQueryExpression<DynamoAppConfig>> queryCaptor;
+    
+    @Captor
+    ArgumentCaptor<Criteria> criteriaCaptor;
+    
+    @Captor
+    ArgumentCaptor<AppConfig> configCaptor;
+    
+    @InjectMocks
+    @Spy
+    DynamoAppConfigDao dao;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void getAppConfigsIncludeDeleted() {
+        List<DynamoAppConfig> configs = ImmutableList.of(new DynamoAppConfig(), new DynamoAppConfig());
+        when(mockResults.size()).thenReturn(configs.size());
+        when(mockResults.iterator()).thenReturn(configs.iterator());
+        when(mockMapper.query(eq(DynamoAppConfig.class), any())).thenReturn(mockResults);
+        
+        List<AppConfig> results = dao.getAppConfigs(TEST_STUDY, true);
+        assertEquals(results.size(), 2);
+        
+        verify(mockMapper).query(eq(DynamoAppConfig.class), queryCaptor.capture());
+        
+        DynamoDBQueryExpression<DynamoAppConfig> query = queryCaptor.getValue();
+        assertEquals(query.getHashKeyValues().getStudyId(), TEST_STUDY_IDENTIFIER);
+        // Regardless of the state of the deleted flag
+        assertNull(query.getQueryFilter());
+    }
+    
+    @Test
+    public void getAppConfigsExcludeDeleted() {
+        List<DynamoAppConfig> configs = ImmutableList.of(new DynamoAppConfig(), new DynamoAppConfig());
+        when(mockResults.size()).thenReturn(configs.size());
+        when(mockResults.iterator()).thenReturn(configs.iterator());
+        when(mockMapper.query(eq(DynamoAppConfig.class), any())).thenReturn(mockResults);
+        
+        List<AppConfig> results = dao.getAppConfigs(TEST_STUDY, false);
+        assertEquals(results.size(), 2);
+        
+        verify(mockMapper).query(eq(DynamoAppConfig.class), queryCaptor.capture());
+        
+        DynamoDBQueryExpression<DynamoAppConfig> query = queryCaptor.getValue();
+        assertEquals(query.getHashKeyValues().getStudyId(), TEST_STUDY_IDENTIFIER);
+        
+        // where the deleted flag is not set to 1 (deleted)
+        Condition condition = query.getQueryFilter().get("deleted");
+        assertEquals(condition.getComparisonOperator(), NE.name());
+        assertEquals(condition.getAttributeValueList().get(0).getN(), "1");
+    }
+    
+    @Test
+    public void getAppConfig() {
+        DynamoAppConfig config = new DynamoAppConfig();
+        config.setGuid(GUID);
+        when(mockMapper.load(KEY)).thenReturn(config);
+        
+        Criteria criteria = new DynamoCriteria();
+        when(mockCriteriaDao.getCriteria(CRITERIA_KEY)).thenReturn(criteria);
+        
+        AppConfig result = dao.getAppConfig(TEST_STUDY, GUID);
+        
+        assertSame(result, config);
+        assertSame(result.getCriteria(), criteria);
+    }
+    
+    @Test
+    public void getAppConfigWithNoCriteria() {
+        DynamoAppConfig config = new DynamoAppConfig();
+        config.setGuid(GUID);
+        when(mockMapper.load(KEY)).thenReturn(config);
+        
+        AppConfig result = dao.getAppConfig(TEST_STUDY, GUID);
+        assertNotNull(result.getCriteria());
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getAppConfigNotFound() {
+        dao.getAppConfig(TEST_STUDY, GUID);
+    }
+    
+    @Test
+    public void createAppConfig() {
+        AppConfig config = AppConfig.create();
+        config.setDeleted(true); // verify this cannot be created true
+        config.setGuid(GUID); // set in AppConfigService
+        Criteria criteria = Criteria.create();
+        config.setCriteria(criteria);
+        
+        AppConfig result = dao.createAppConfig(config);
+        assertSame(result, config);
+        assertFalse(result.isDeleted());
+        assertEquals(criteria.getKey(), CRITERIA_KEY);
+        
+        verify(mockMapper).save(config);
+        verify(mockCriteriaDao).createOrUpdateCriteria(criteria);
+    }
+    
+    @Test
+    public void updateAppConfig() {
+        DynamoCriteria criteria = new DynamoCriteria();
+        criteria.setLanguage("fr");
+        
+        AppConfig config = AppConfig.create();
+        config.setStudyId(TEST_STUDY_IDENTIFIER);
+        config.setGuid(GUID);
+        config.setCriteria(criteria);
+        
+        DynamoAppConfig saved = new DynamoAppConfig();
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        // whether there is a criteria object or not is not relevant, it will
+        // always be replaced by the submitted criteria. The code currently loads
+        // it but it doesn't need to.
+        
+        AppConfig result = dao.updateAppConfig(config);
+        assertSame(result, config);
+        
+        verify(mockCriteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
+        verify(mockMapper).save(config);
+        
+        assertFalse(result.isDeleted());
+        assertEquals(criteriaCaptor.getValue().getKey(), CRITERIA_KEY);
+        assertEquals(criteriaCaptor.getValue().getLanguage(), "fr"); // it is the object we submitted
+    }
+
+    @Test
+    public void updateAppConfigDeletes() {
+        DynamoCriteria criteria = new DynamoCriteria();
+        criteria.setLanguage("fr");
+        
+        AppConfig config = AppConfig.create();
+        config.setStudyId(TEST_STUDY_IDENTIFIER);
+        config.setGuid(GUID);
+        config.setDeleted(true); // can be deleted as part of an update
+        config.setCriteria(criteria);
+        
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setDeleted(false);
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        AppConfig result = dao.updateAppConfig(config);
+        assertSame(result, config);
+        
+        verify(mockCriteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
+        verify(mockMapper).save(config);
+        
+        assertTrue(result.isDeleted());
+        assertEquals(criteriaCaptor.getValue().getKey(), CRITERIA_KEY);
+        assertEquals(criteriaCaptor.getValue().getLanguage(), "fr"); // it is the object we submitted
+    }
+    
+    @Test
+    public void updateAppConfigUndeletes() {
+        DynamoCriteria criteria = new DynamoCriteria();
+        criteria.setLanguage("fr");
+        
+        AppConfig config = AppConfig.create();
+        config.setStudyId(TEST_STUDY_IDENTIFIER);
+        config.setGuid(GUID);
+        config.setDeleted(false); // can be undeleted as part of an update
+        config.setCriteria(criteria);
+        
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setDeleted(true);
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        AppConfig result = dao.updateAppConfig(config);
+        assertSame(result, config);
+        
+        verify(mockCriteriaDao).createOrUpdateCriteria(criteriaCaptor.capture());
+        verify(mockMapper).save(config);
+        
+        assertFalse(result.isDeleted());
+        assertEquals(criteriaCaptor.getValue().getKey(), CRITERIA_KEY);
+        assertEquals(criteriaCaptor.getValue().getLanguage(), "fr"); // it is the object we submitted
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void updateAppConfigLogicallyDeleted() {
+        AppConfig config = AppConfig.create();
+        config.setStudyId(TEST_STUDY_IDENTIFIER);
+        config.setGuid(GUID);
+        config.setDeleted(true);
+        config.setCriteria(Criteria.create());
+        
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setDeleted(true);
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        dao.updateAppConfig(config);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void updateAppConfigNotFound() {
+        AppConfig config = AppConfig.create();
+        config.setStudyId(TEST_STUDY_IDENTIFIER);
+        config.setGuid(GUID);
+        
+        dao.updateAppConfig(config);
+    }
+    
+    @Test
+    public void deleteAppConfig() {
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setStudyId(TEST_STUDY_IDENTIFIER);
+        saved.setGuid(GUID);
+        saved.setCriteria(Criteria.create());
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        dao.deleteAppConfig(TEST_STUDY, GUID);
+        
+        verify(mockMapper).save(configCaptor.capture());
+        assertTrue(configCaptor.getValue().isDeleted());
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteAppConfigNotFound() {
+        dao.deleteAppConfig(TEST_STUDY, GUID);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteAppConfigAlreadyDeleted() {
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setDeleted(true);
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        dao.deleteAppConfig(TEST_STUDY, GUID);
+    }
+    
+    @Test
+    public void deleteAppConfigPermanently() {
+        DynamoAppConfig saved = new DynamoAppConfig();
+        saved.setGuid(GUID);
+        when(mockMapper.load(KEY)).thenReturn(saved);
+        
+        dao.deleteAppConfigPermanently(TEST_STUDY, GUID);
+        
+        verify(mockMapper).delete(saved);
+        verify(mockCriteriaDao).deleteCriteria(CRITERIA_KEY);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteAppConfigPermanentlyNotFound() {
+        dao.deleteAppConfigPermanently(TEST_STUDY, GUID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
@@ -21,7 +21,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -61,7 +60,6 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
     @Captor
     ArgumentCaptor<DynamoDBQueryExpression<DynamoCompoundActivityDefinition>> queryCaptor;
     
-    @Spy
     @InjectMocks
     DynamoCompoundActivityDefinitionDao dao;
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
@@ -1,0 +1,196 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.schedules.CompoundActivityDefinition;
+
+public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
+
+    static String TASK_ID = "oneTaskId";
+    
+    static DynamoCompoundActivityDefinition KEYS = new DynamoCompoundActivityDefinition();
+    static {
+        KEYS.setStudyId(TEST_STUDY_IDENTIFIER);
+        KEYS.setTaskId(TASK_ID);
+    }
+    
+    static DynamoCompoundActivityDefinition COMPOUND_ACTIVITY_DEF = new DynamoCompoundActivityDefinition();
+    static {
+        COMPOUND_ACTIVITY_DEF.setStudyId(TEST_STUDY_IDENTIFIER);
+        COMPOUND_ACTIVITY_DEF.setTaskId(TASK_ID);
+    }
+    
+    @Mock
+    DynamoDBMapper mockMapper;
+    
+    @Mock
+    PaginatedQueryList<DynamoCompoundActivityDefinition> mockQueryList;
+    
+    @Mock
+    List<DynamoDBMapper.FailedBatch> mockFailedBatchList; 
+    
+    @Captor
+    ArgumentCaptor<DynamoCompoundActivityDefinition> defCaptor;
+    
+    @Captor
+    ArgumentCaptor<DynamoDBQueryExpression<DynamoCompoundActivityDefinition>> queryCaptor;
+    
+    @Spy
+    @InjectMocks
+    DynamoCompoundActivityDefinitionDao dao;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void createCompoundActivityDefinition() {
+        DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
+        def.setStudyId(TEST_STUDY_IDENTIFIER);
+        def.setTaskId(TASK_ID);
+        def.setVersion(1L);
+        
+        CompoundActivityDefinition result = dao.createCompoundActivityDefinition(def);
+        assertSame(result, def);
+        
+        verify(mockMapper).save(defCaptor.capture());
+        assertNull(defCaptor.getValue().getVersion());
+    }
+    
+    @Test(expectedExceptions = ConcurrentModificationException.class)
+    public void createCompoundActivityDefinitionConditionalCheckFailedException() {
+        doThrow(new ConditionalCheckFailedException("")).when(mockMapper).save(any());
+        dao.createCompoundActivityDefinition(COMPOUND_ACTIVITY_DEF);
+    }
+
+    @Test
+    public void deleteCompoundActivityDefinition() {
+        when(mockMapper.load(any())).thenReturn(COMPOUND_ACTIVITY_DEF);
+        
+        dao.deleteCompoundActivityDefinition(TEST_STUDY, TASK_ID);
+        
+        verify(mockMapper).delete(COMPOUND_ACTIVITY_DEF);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteCompoundActivityDefinitionEntityNotFoundException() {
+        when(mockMapper.load(any())).thenReturn(COMPOUND_ACTIVITY_DEF);
+        doThrow(new ConditionalCheckFailedException("")).when(mockMapper).delete(any());
+        
+        dao.deleteCompoundActivityDefinition(TEST_STUDY, TASK_ID);
+    }
+
+    @Test
+    public void deleteAllCompoundActivityDefinitionsInStudy() {
+        when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class),
+                queryCaptor.capture())).thenReturn(mockQueryList);
+        
+        dao.deleteAllCompoundActivityDefinitionsInStudy(TEST_STUDY);
+        
+        verify(mockMapper).batchDelete(mockQueryList);
+    }
+
+    @Test(expectedExceptions = BridgeServiceException.class)
+    public void deleteAllCompoundActivityDefinitionsInStudyWithErrors() {
+        when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class),
+                queryCaptor.capture())).thenReturn(mockQueryList);
+        
+        DynamoDBMapper.FailedBatch failure1 = new DynamoDBMapper.FailedBatch();
+        failure1.setException(new IllegalArgumentException("First errror message"));
+        failure1.setUnprocessedItems(ImmutableMap.of());
+        
+        DynamoDBMapper.FailedBatch failure2 = new DynamoDBMapper.FailedBatch();
+        failure2.setException(new UnsupportedOperationException("Second errror message"));
+        failure2.setUnprocessedItems(ImmutableMap.of());
+        
+        when(mockFailedBatchList.iterator()).thenReturn(ImmutableList.of(failure1, failure2).iterator());
+        when(mockMapper.batchDelete(mockQueryList)).thenReturn(mockFailedBatchList);
+        
+        dao.deleteAllCompoundActivityDefinitionsInStudy(TEST_STUDY);
+        
+        verify(mockMapper).batchDelete(mockQueryList);
+    }
+    
+    @Test
+    public void getAllCompoundActivityDefinitionsInStudy() {
+        List<DynamoCompoundActivityDefinition> defList = ImmutableList.of(
+                new DynamoCompoundActivityDefinition(),
+                new DynamoCompoundActivityDefinition());
+        when(mockQueryList.toArray()).thenReturn(defList.toArray());
+        when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class), any())).thenReturn(mockQueryList);
+        
+        List<CompoundActivityDefinition> results = dao.getAllCompoundActivityDefinitionsInStudy(TEST_STUDY);
+        assertEquals(results.size(), 2);
+        
+        verify(mockMapper).query(any(), queryCaptor.capture());
+        assertEquals(queryCaptor.getValue().getHashKeyValues().getStudyId(), TEST_STUDY_IDENTIFIER);
+    }
+
+    @Test
+    public void getCompoundActivityDefinition() {
+        when(mockMapper.load(any())).thenReturn(COMPOUND_ACTIVITY_DEF);
+        
+        CompoundActivityDefinition result = dao.getCompoundActivityDefinition(TEST_STUDY, TASK_ID);
+        assertSame(result, COMPOUND_ACTIVITY_DEF);
+        
+        verify(mockMapper).load(defCaptor.capture());
+        CompoundActivityDefinition def = defCaptor.getValue();
+        assertEquals(def.getStudyId(), TEST_STUDY_IDENTIFIER);
+        assertEquals(def.getTaskId(), TASK_ID);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getCompoundActivityDefinitionEntityNotFoundException() {
+        dao.getCompoundActivityDefinition(TEST_STUDY, TASK_ID);
+    }
+    
+    @Test
+    public void updateCompoundActivityDefinition() {
+        when(mockMapper.load(any())).thenReturn(COMPOUND_ACTIVITY_DEF);
+        
+        CompoundActivityDefinition result = dao.updateCompoundActivityDefinition(COMPOUND_ACTIVITY_DEF);
+        assertSame(result, COMPOUND_ACTIVITY_DEF);
+        
+        verify(mockMapper).save(COMPOUND_ACTIVITY_DEF);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void updateCompoundActivityDefinitionEntityNotFoundException() {
+        dao.updateCompoundActivityDefinition(COMPOUND_ACTIVITY_DEF);
+    }
+    
+    @Test(expectedExceptions = ConcurrentModificationException.class)
+    public void updateCompoundActivityDefinitionConcurrentModificationException() {
+        when(mockMapper.load(any())).thenReturn(COMPOUND_ACTIVITY_DEF);
+        doThrow(new ConditionalCheckFailedException("")).when(mockMapper).save(COMPOUND_ACTIVITY_DEF);
+        
+        dao.updateCompoundActivityDefinition(COMPOUND_ACTIVITY_DEF);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ReferenceResolverTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -14,7 +13,6 @@ import java.util.HashMap;
 
 import org.joda.time.DateTime;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.testng.annotations.AfterMethod;


### PR DESCRIPTION
SFAICT, none of these have a non-play unit tests, all have to be implemented from scratch. I verified coverage both with coverage tools and looking at existing tests for potentially missed tests cases.